### PR TITLE
fix nav menu 'truncation' issue

### DIFF
--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -107,7 +107,7 @@ img {
 header {
   width:270px;
   float:left;
-  position:fixed;
+  //position:fixed;
   -webkit-font-smoothing:subpixel-antialiased;
 }
 


### PR DESCRIPTION
the navigation menu appears truncated if the browser window height
is not large enough. this is in part due to the
header { position: fixed; }
attribute in the style sheet. However, currently i've not yet found a
way to let the nav have its own scroll bar. Hence a solution is to
comment the header{ position: fixed; } attribute

comment the stylesheet define:
in _sass/jekyll-theme-minimal.scss
header { // position: fixed; }