### PR TITLE
Javadoc link update to 0.17

### DIFF
--- a/Backtesting.md
+++ b/Backtesting.md
@@ -43,7 +43,7 @@ BarSeriesManager seriesManager = new BarSeriesManager(series);
 Strategy bestStrategy = criterion.chooseBest(seriesManager, Arrays.asList(strategy1, strategy2));
 ```
 
-Ta4j comes with several analysis criteria which are all listed [in the Javadoc](https://oss.sonatype.org/service/local/repositories/releases/archive/org/ta4j/ta4j-core/0.15/ta4j-core-0.15-javadoc.jar/!/org/ta4j/core/criteria/package-summary.html).
+Ta4j comes with several analysis criteria which are all listed [in the Javadoc](https://oss.sonatype.org/service/local/repositories/releases/archive/org/ta4j/ta4j-core/0.17/ta4j-core-0.17-javadoc.jar/!/org/ta4j/core/criteria/package-summary.html).
 ### Walk-forward optimization
 
 Ta4j allows you to perform a well-known *Walk-forward* optimization. An example can be found [here](Usage-examples.md).

--- a/Maven-notes.md
+++ b/Maven-notes.md
@@ -62,7 +62,7 @@ mvn clean deploy
 
     mvn release:perform -Psonatype-oss-release
     ```
-6. Update Wiki with CHANGELOG.md and new Javadoc
+6. Update Wiki with CHANGELOG.md and new Javadoc links (_layouts/default.html, Backtesting.md, Technical-indicators.md)
 7. Update CHANGELOG.md and README.md on develop branch
 
 ### Internal notes

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -7,7 +7,7 @@ About technical indicators:
   * [Wikipedia's article on Technical indicators](http://en.wikipedia.org/wiki/Technical_indicator)
   * [Investopedia's definition](http://www.investopedia.com/terms/t/technicalindicator.asp)
 
-In ta4j, all technical indicators implement the `Indicator` interface. So a list of all the indicators provided can be found [in the Javadoc](https://oss.sonatype.org/service/local/repositories/releases/archive/org/ta4j/ta4j-core/0.11/ta4j-core-0.11-javadoc.jar/!/index.html).
+In ta4j, all technical indicators implement the `Indicator` interface. So a list of all the indicators provided can be found [in the Javadoc](https://oss.sonatype.org/service/local/repositories/releases/archive/org/ta4j/ta4j-core/0.17/ta4j-core-0.17-javadoc.jar/!/index.html).
 
 Ta4j list of [Moving average indicators](Moving-Average-Indicators.html)
 


### PR DESCRIPTION
Updates wiki javadoc links to current version.
Adds list of link locations to maven notes to include future updates in release process.