### PR TITLE
docs: cover bill williams and backtesting criteria drift

### DIFF
--- a/Backtesting.md
+++ b/Backtesting.md
@@ -51,18 +51,26 @@ AnalysisCriterion net = new NetReturnCriterion();
 AnalysisCriterion buyHold = new VersusEnterAndHoldCriterion(new NetReturnCriterion());
 AnalysisCriterion romad = new ReturnOverMaxDrawdownCriterion();
 AnalysisCriterion sharpe = new SharpeRatioCriterion();
+AnalysisCriterion sortino = new SortinoRatioCriterion(0.05, SamplingFrequency.DAILY, Annualization.ANNUALIZED, ZoneOffset.UTC);
 AnalysisCriterion drawdownRisk = new MonteCarloMaximumDrawdownCriterion();
 AnalysisCriterion commissions = new CommissionsImpactPercentageCriterion();
 AnalysisCriterion totalFees = new TotalFeesCriterion();
+AnalysisCriterion avgDurationSeconds = new PositionDurationCriterion(Statistics.MEAN);
+AnalysisCriterion rMultiple = new RMultipleCriterion(new StopLossPositionRiskModel(5));
 
 System.out.println("Net return: " + net.calculate(series, record));
 System.out.println("Vs buy & hold: " + buyHold.calculate(series, record));
 System.out.println("Return / Max DD: " + romad.calculate(series, record));
 System.out.println("Sharpe ratio: " + sharpe.calculate(series, record));
+System.out.println("Sortino ratio: " + sortino.calculate(series, record));
 System.out.println("Drawdown risk p95: " + drawdownRisk.calculate(series, record));
 System.out.println("Commission drag: " + commissions.calculate(series, record));
 System.out.println("Total fees: " + totalFees.calculate(series, record));
+System.out.println("Average position duration (sec): " + avgDurationSeconds.calculate(series, record));
+System.out.println("Average R-multiple: " + rMultiple.calculate(series, record));
 ```
+
+`SortinoRatioCriterion` is usually preferable when downside volatility matters more than upside volatility. `RMultipleCriterion` averages only closed positions with valid positive risk values from the configured risk model.
 
 Ta4j includes dozens of criteria organized by package:
 
@@ -70,7 +78,7 @@ Ta4j includes dozens of criteria organized by package:
 - `criteria.drawdown.*` – absolute, relative, duration, Monte Carlo.
 - `criteria.commissions.*` – total fees across positions.
 - `criteria.costs.*` – commissions and holding costs.
-- `criteria.position.*` – streaks, max profit/loss per position, time in market, open-position cost basis and unrealized PnL when using `LiveTradingRecord`.
+- `criteria.position.*` – streaks, max profit/loss per position, time in market, `PositionDurationCriterion` (mean/median/p95 style summaries), open-position cost basis and unrealized PnL when using `LiveTradingRecord`.
 
 Mix and match to build your own evaluation stack.
 
@@ -137,13 +145,14 @@ Saved images are JPEGs (see `FileSystemChartStorage`), so the directory you pass
 
 ## Backtesting with LiveTradingRecord
 
-When you need cost basis, unrealized PnL, or a position book in your backtest (e.g. to align with live reconciliation), run your strategy in a loop and feed a `LiveTradingRecord` instead of using `BarSeriesManager.run(strategy)` (which returns a `BaseTradingRecord`). At each bar, call `strategy.shouldEnter(index, record)` / `shouldExit(index, record)` and then `record.enter(index, price, amount)` or `record.exit(index, price, amount)`. You can then use `OpenPositionCostBasisCriterion`, `OpenPositionUnrealizedProfitCriterion`, and `record.getOpenPositions()` / `getNetOpenPosition()` for analysis. For a full walkthrough of partial fills and criteria, see [Live Trading – LiveTradingRecord walkthrough](Live-trading.md#walkthrough-livetradingrecord-with-partial-fills-and-cost-basis).
+When you need cost basis, unrealized PnL, or a position book in your backtest (e.g. to align with live reconciliation), run your strategy in a loop and feed a `LiveTradingRecord` instead of using `BarSeriesManager.run(strategy)` (which returns a `BaseTradingRecord`). At each bar, call `strategy.shouldEnter(index, record)` / `shouldExit(index, record)` and then `record.enter(index, price, amount)` or `record.exit(index, price, amount)`. You can then use `OpenPositionCostBasisCriterion`, `OpenPositionUnrealizedProfitCriterion`, and `record.getOpenPositions()` / `getNetOpenPosition()` for analysis. To enforce minimum hold time before exits, use `OpenedPositionMinimumBarCountRule(n)` for a fixed minimum or `OpenPositionDurationRule(indicator, minBars)` for dynamic thresholds. For a full walkthrough of partial fills and criteria, see [Live Trading – LiveTradingRecord walkthrough](Live-trading.md#walkthrough-livetradingrecord-with-partial-fills-and-cost-basis).
 
 ## Avoid common pitfalls
 
 - **Look-ahead bias** – Ensure your indicator windows do not peek at future bars. Ta4j indicators automatically cap their lookbacks, but custom logic must do the same.
 - **Insufficient warm-up** – Set `strategy.setUnstableBars(n)` to skip the early `n` indices when indicators have not stabilized yet (`Indicator.isStable()` helps confirm).
 - **Moving series** – When using `setMaximumBarCount`, do not reference indexes older than `series.getBeginIndex()`. Criteria referencing evicted bars will return `NaN`.
+- **Ratio criteria edge cases** – `SortinoRatioCriterion` returns `NaN` when downside deviation is zero. Guard `NaN` values before `chooseBest(...)` or top-K ranking.
 - **Transaction costs** – Always configure `TransactionCostModel` / `HoldingCostModel` on `BarSeriesManager` or pass explicit cost models to `BacktestExecutor`.
 
 ## Walk-forward optimization

--- a/Bill-Williams-Indicators.md
+++ b/Bill-Williams-Indicators.md
@@ -2,12 +2,38 @@
 
 ta4j 0.22.3 adds a complete Bill Williams indicator stack so you can model trend context, breakout structure, and participation in one workflow.
 
+## What this suite is (ta4j view)
+
+In ta4j, the Bill Williams stack is implemented as composable indicators that plug directly into the standard `Indicator` + `Rule` + `Strategy` pipeline:
+
+- trend context from `AlligatorIndicator`
+- structure confirmation from `FractalHighIndicator` / `FractalLowIndicator`
+- participation/expansion context from `GatorOscillatorIndicator` and `MarketFacilitationIndexIndicator`
+
+This matters in ta4j because each component can be backtested, combined with non-Bill-Williams indicators, and ranked with the same criteria stack used elsewhere in the library.
+
 ## Included indicators
 
 - `AlligatorIndicator` – displaced SMMAs on median price (`jaw`, `teeth`, `lips`)
 - `FractalHighIndicator` / `FractalLowIndicator` – confirmed fractal pivots (default `2/2` windows)
 - `GatorOscillatorIndicator` – histogram spread between alligator lines
 - `MarketFacilitationIndexIndicator` – Bill Williams MFI (`(high - low) / volume`)
+
+## Why and when this is useful
+
+Use this suite when your ta4j strategy needs all three at once:
+
+1. trend regime (sleeping vs trending),
+2. explicit structure events (confirmed fractal breakouts),
+3. participation filter (range expansion per volume).
+
+Typical ta4j use cases:
+
+- swing/trend-following systems that need structure-aware entries,
+- breakout systems that want confirmation on fully formed bars,
+- hybrid systems where Bill Williams signals gate another indicator family (for example MACD-V or VWAP rules).
+
+Avoid relying on it alone in very low-volume instruments or ultra-short bar horizons where `(high - low) / volume` becomes unstable/noisy.
 
 ## Canonical defaults
 
@@ -24,6 +50,8 @@ Fractal defaults use `2` preceding + `2` following bars.
 Fractal indicators confirm on the current bar. When a fractal is confirmed at index `i`, the pivot is earlier. Use `getConfirmedFractalIndex(i)` to retrieve the pivot index explicitly.
 
 This avoids accidental look-ahead bias when building entry/exit rules.
+
+In ta4j terms: `FractalHighIndicator` and `FractalLowIndicator` are `Indicator<Boolean>` implementations, so they are event/confirmation signals, not direct price levels.
 
 ## Example workflow
 
@@ -42,6 +70,28 @@ GatorOscillatorIndicator gatorLower = GatorOscillatorIndicator.lower(series);
 MarketFacilitationIndexIndicator bwMfi = new MarketFacilitationIndexIndicator(series);
 ```
 
+## Strategy wiring pattern in ta4j
+
+```java
+Num zero = series.numFactory().zero();
+
+Rule trendUp = new OverIndicatorRule(lips, teeth)
+        .and(new OverIndicatorRule(teeth, jaw));
+Rule confirmedFractalBreakout = new BooleanIndicatorRule(fractalHigh);
+Rule participation = new OverIndicatorRule(gatorUpper, zero)
+        .and(new OverIndicatorRule(bwMfi, zero));
+
+Rule entryRule = trendUp.and(confirmedFractalBreakout).and(participation);
+```
+
+Why this pattern works in ta4j:
+
+- `BooleanIndicatorRule` consumes fractal confirmation events directly.
+- `OverIndicatorRule` keeps numeric comparisons explicit and testable.
+- `Num` values come from the series factory, keeping numeric type consistency.
+
+For realistic backtests, set unstable bars high enough to cover all dependency warm-up periods (Alligator displacement + fractal windows + any added filters).
+
 Typical interpretation:
 
 1. Use alligator line ordering (`lips > teeth > jaw` or inverse) for trend context.
@@ -51,5 +101,7 @@ Typical interpretation:
 ## Practical notes
 
 - `MarketFacilitationIndexIndicator` is not the same indicator as `MoneyFlowIndexIndicator`.
+- `AlligatorIndicator` displacement is implemented without look-ahead (value at `i` reads smoothed value at `i - shift`).
+- `GatorOscillatorIndicator.upper(...)` and `.lower(...)` provide the two histogram branches separately.
 - For reproducible backtests, combine this toolkit with unstable-bar handling in [Backtesting](Backtesting.md).
 - For broader market-structure context (VWAP + support/resistance + Wyckoff), see [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md).

--- a/Bill-Williams-Indicators.md
+++ b/Bill-Williams-Indicators.md
@@ -1,0 +1,55 @@
+# Bill Williams Indicators
+
+ta4j 0.22.3 adds a complete Bill Williams indicator stack so you can model trend context, breakout structure, and participation in one workflow.
+
+## Included indicators
+
+- `AlligatorIndicator` – displaced SMMAs on median price (`jaw`, `teeth`, `lips`)
+- `FractalHighIndicator` / `FractalLowIndicator` – confirmed fractal pivots (default `2/2` windows)
+- `GatorOscillatorIndicator` – histogram spread between alligator lines
+- `MarketFacilitationIndexIndicator` – Bill Williams MFI (`(high - low) / volume`)
+
+## Canonical defaults
+
+Alligator canonical settings in ta4j follow Bill Williams defaults:
+
+- jaw: `SMMA(13)` shifted by `8`
+- teeth: `SMMA(8)` shifted by `5`
+- lips: `SMMA(5)` shifted by `3`
+
+Fractal defaults use `2` preceding + `2` following bars.
+
+## Look-ahead safety
+
+Fractal indicators confirm on the current bar. When a fractal is confirmed at index `i`, the pivot is earlier. Use `getConfirmedFractalIndex(i)` to retrieve the pivot index explicitly.
+
+This avoids accidental look-ahead bias when building entry/exit rules.
+
+## Example workflow
+
+```java
+BarSeries series = ...;
+
+AlligatorIndicator jaw = AlligatorIndicator.jaw(series);
+AlligatorIndicator teeth = AlligatorIndicator.teeth(series);
+AlligatorIndicator lips = AlligatorIndicator.lips(series);
+
+FractalHighIndicator fractalHigh = new FractalHighIndicator(series);
+FractalLowIndicator fractalLow = new FractalLowIndicator(series);
+
+GatorOscillatorIndicator gatorUpper = GatorOscillatorIndicator.upper(series);
+GatorOscillatorIndicator gatorLower = GatorOscillatorIndicator.lower(series);
+MarketFacilitationIndexIndicator bwMfi = new MarketFacilitationIndexIndicator(series);
+```
+
+Typical interpretation:
+
+1. Use alligator line ordering (`lips > teeth > jaw` or inverse) for trend context.
+2. Use confirmed fractals for structure breakouts and invalidation levels.
+3. Use gator and BW MFI to filter weak setups with low participation.
+
+## Practical notes
+
+- `MarketFacilitationIndexIndicator` is not the same indicator as `MoneyFlowIndexIndicator`.
+- For reproducible backtests, combine this toolkit with unstable-bar handling in [Backtesting](Backtesting.md).
+- For broader market-structure context (VWAP + support/resistance + Wyckoff), see [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md).

--- a/Getting-started.md
+++ b/Getting-started.md
@@ -93,6 +93,8 @@ MACDVIndicator macdv = new MACDVIndicator(series, 12, 26, 9); // uses volume wei
 
 Indicators are cached automatically. If you mutate the most recent bar (typical in live trading), ta4j recalculates the final value on demand.
 
+If you specifically want the volatility-normalized MACD-V formulation (`(EMAfast - EMAslow) / ATR * scale`, often called Spiroglou-style), use `VolatilityNormalizedMACDIndicator` instead of `MACDVIndicator`.
+
 ### 3. Compose rules and a strategy
 
 ```java

--- a/Home.md
+++ b/Home.md
@@ -13,6 +13,12 @@ Your one-stop guide for building technical-analysis-driven trading systems in Ja
 
 ## What's New in 0.21.0
 
+### Latest highlights (0.22.3)
+
+- **Bill Williams toolkit** – Added `AlligatorIndicator`, `FractalHighIndicator` / `FractalLowIndicator`, `GatorOscillatorIndicator`, and `MarketFacilitationIndexIndicator` with a dedicated [Bill Williams Indicators](Bill-Williams-Indicators.md) guide.
+- **MACD-V momentum-state APIs** – Added momentum-state classification (`MACDVMomentumStateIndicator`, `MACDVMomentumProfile`) and rule integration helpers.
+- **New risk/quality criteria** – Added metrics like `SortinoRatioCriterion`, `PositionDurationCriterion`, and `RMultipleCriterion` for tighter backtest analysis.
+
 - **Unified return representation system** – Consistent formatting across all return-based criteria (multiplicative, decimal, percentage, logarithmic) via `ReturnRepresentation` and `ReturnRepresentationPolicy`
 - **New oscillators** – `TrueStrengthIndexIndicator`, `SchaffTrendCycleIndicator`, and `ConnorsRSIIndicator` expand oscillator coverage
 - **Helper indicators** – `PercentRankIndicator`, `DifferenceIndicator`, and `StreakIndicator` for advanced indicator composition

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -29,6 +29,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
+| `org.ta4j.core` | **Indicator** | Core ta4j indicator interface; typed value provider over bar indexes. |
 | `org.ta4j.core.indicators.helpers` | **ClosePriceIndicator** | Returns the close price of a bar. |
 | `org.ta4j.core.indicators.helpers` | **OpenPriceIndicator** | Returns the open price of a bar. |
 | `org.ta4j.core.indicators.helpers` | **HighPriceIndicator** | Returns the high price of a bar. |
@@ -55,6 +56,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.helpers` | **FixedBooleanIndicator** | Fixed boolean value. |
 | `org.ta4j.core.indicators.helpers` | **FixedIndicator** | Wraps a single value as an indicator over the series length. |
 | `org.ta4j.core.indicators.helpers` | **BooleanTransformIndicator** | Converts a numeric indicator to boolean via a threshold or condition. |
+| `org.ta4j.core.indicators.helpers` | **BandIndicator** | Generic upper/lower band around a middle indicator value. |
 | `org.ta4j.core.indicators.helpers` | **CrossIndicator** | Detects crosses between two indicators (e.g. cross up/down). |
 | `org.ta4j.core.indicators.helpers` | **ConvergenceDivergenceIndicator** | Convergence/divergence between two indicators. |
 | `org.ta4j.core.indicators.helpers` | **CloseLocationValueIndicator** | CLV: where close sits in the bar range (-1 to 1). |
@@ -155,7 +157,9 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators` | **StochasticOscillatorKIndicator** | Stochastic %K. |
 | `org.ta4j.core.indicators` | **StochasticOscillatorDIndicator** | Stochastic %D (smoothed %K). |
 | `org.ta4j.core.indicators` | **MACDIndicator** | MACD (APO): short EMA − long EMA. |
-| `org.ta4j.core.indicators` | **MACDVIndicator** | ta4j variant: MACD EMA spread with volume/ATR-weighted EMA inputs (not ATR division). |
+| `org.ta4j.core.indicators` | **MACDVIndicator** | Deprecated compatibility shim for `org.ta4j.core.indicators.macd.MACDVIndicator`. |
+| `org.ta4j.core.indicators.macd` | **MACDVIndicator** | MACD-V using volume/ATR-weighted EMA inputs (ATR used in weighting term, not direct division). |
+| `org.ta4j.core.indicators.macd` | **MACDVMomentumStateIndicator** | Classifies MACD-V values into momentum states via configurable thresholds. |
 | `org.ta4j.core.indicators.macd` | **VolatilityNormalizedMACDIndicator** | Volatility-normalized MACD-V (`(EMAfast - EMAslow) / ATR * scale`), often called Spiroglou-style. |
 | `org.ta4j.core.indicators` | **PPOIndicator** | Percentage Price Oscillator (MACD as % of longer EMA). |
 | `org.ta4j.core.indicators` | **ROCIndicator** | Rate of change (price change over period). |
@@ -240,6 +244,11 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.volume` | **MoneyFlowIndexIndicator** | MFI: volume-weighted RSI-style oscillator. |
 | `org.ta4j.core.indicators` | **MarketFacilitationIndexIndicator** | Bill Williams MFI: `(high - low) / volume` (not Money Flow Index). |
 | `org.ta4j.core.indicators.volume` | **VWAPIndicator** | Volume-weighted average price (from open). |
+| `org.ta4j.core.indicators.volume` | **AnchoredVWAPIndicator** | Anchored VWAP from a configurable start index/time anchor. |
+| `org.ta4j.core.indicators.volume` | **VWAPBandIndicator** | VWAP ± multiplier × VWAP standard deviation bands. |
+| `org.ta4j.core.indicators.volume` | **VWAPDeviationIndicator** | Absolute price deviation from VWAP (premium/discount vs value). |
+| `org.ta4j.core.indicators.volume` | **VWAPStandardDeviationIndicator** | Volume-weighted standard deviation used by VWAP-derived bands/z-scores. |
+| `org.ta4j.core.indicators.volume` | **VWAPZScoreIndicator** | Z-score of price relative to VWAP and VWAP standard deviation. |
 | `org.ta4j.core.indicators.volume` | **MVWAPIndicator** | Moving VWAP (VWAP over a rolling window). |
 | `org.ta4j.core.indicators.volume` | **NVIIndicator** | Negative Volume Index. |
 | `org.ta4j.core.indicators.volume` | **PVIIndicator** | Positive Volume Index. |
@@ -279,7 +288,9 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.candles` | **MorningStarIndicator** | Morning star (three-candle reversal). |
 | `org.ta4j.core.indicators.candles` | **EveningStarIndicator** | Evening star. |
 | `org.ta4j.core.indicators.candles` | **DarkCloudIndicator** | Dark cloud cover. |
+| `org.ta4j.core.indicators.candles` | **DarkCloudCoverIndicator** | Dark cloud cover candlestick pattern indicator. |
 | `org.ta4j.core.indicators.candles` | **PiercingIndicator** | Piercing line. |
+| `org.ta4j.core.indicators.candles` | **PiercingLineIndicator** | Piercing line candlestick pattern indicator. |
 | `org.ta4j.core.indicators.candles` | **BullishKickerIndicator** | Bullish kicker (gap + opposite body). |
 | `org.ta4j.core.indicators.candles` | **BearishKickerIndicator** | Bearish kicker. |
 | `org.ta4j.core.indicators.candles` | **ThreeWhiteSoldiersIndicator** | Three white soldiers. |
@@ -302,6 +313,12 @@ For an overview of indicator categories and composition patterns, see [Technical
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.supportresistance` | **TrendLineSupportIndicator** | Support level from trend line (e.g. swing lows). |
 | `org.ta4j.core.indicators.supportresistance` | **TrendLineResistanceIndicator** | Resistance level from trend line. |
+| `org.ta4j.core.indicators.supportresistance` | **BounceCountSupportIndicator** | Support estimate from clustered bounce frequency below/around price levels. |
+| `org.ta4j.core.indicators.supportresistance` | **BounceCountResistanceIndicator** | Resistance estimate from clustered bounce frequency above/around price levels. |
+| `org.ta4j.core.indicators.supportresistance` | **PriceClusterSupportIndicator** | Support levels from close-price clustering with configurable tolerance. |
+| `org.ta4j.core.indicators.supportresistance` | **PriceClusterResistanceIndicator** | Resistance levels from close-price clustering with configurable tolerance. |
+| `org.ta4j.core.indicators.supportresistance` | **VolumeProfileKDEIndicator** | Smoothed volume-at-price profile using kernel density estimation. |
+| `org.ta4j.core.indicators.wyckoff` | **WyckoffPhaseIndicator** | Inferred Wyckoff phase classification from structural/volume context. |
 | `org.ta4j.core.indicators.pivotpoints` | **PivotPointIndicator** | Standard pivot point (and optionally R1/R2/S1/S2). |
 | `org.ta4j.core.indicators.pivotpoints` | **DeMarkPivotPointIndicator** | DeMark pivot points. |
 | `org.ta4j.core.indicators.pivotpoints` | **StandardReversalIndicator** | Reversal level from standard pivots. |
@@ -323,8 +340,6 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
-| `org.ta4j.core.indicators` | **RecentSwingHighIndicator** | Price of the most recent confirmed swing high. |
-| `org.ta4j.core.indicators` | **RecentSwingLowIndicator** | Price of the most recent confirmed swing low. |
 | `org.ta4j.core.indicators` | **RecentSwingIndicator** | Generic recent swing (e.g. value at last swing). |
 | `org.ta4j.core.indicators` | **FractalHighIndicator** | Bill Williams fractal high confirmation indicator (no look-ahead). |
 | `org.ta4j.core.indicators` | **FractalLowIndicator** | Bill Williams fractal low confirmation indicator (no look-ahead). |
@@ -421,6 +436,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.statistics` | **SimpleLinearRegressionIndicator** | Moving simple linear regression (slope/intercept). |
 | `org.ta4j.core.indicators.statistics` | **StandardErrorIndicator** | Standard error of regression (or estimate). |
 | `org.ta4j.core.indicators.statistics` | **SigmaIndicator** | Z-score (value in standard deviations from mean). |
+| `org.ta4j.core.indicators.statistics` | **ZScoreIndicator** | Z-score indicator. |
 | `org.ta4j.core.indicators.statistics` | **PeriodicalGrowthRateIndicator** | Period-over-period growth rate (e.g. annualized). |
 | `org.ta4j.core.indicators.numeric` | **BinaryOperationIndicator** | Binary operation (add, subtract, multiply, divide, min, max) on two indicators. |
 | `org.ta4j.core.indicators.numeric` | **UnaryOperationIndicator** | Unary operation (negate, abs, log, etc.) on one indicator. |
@@ -477,6 +493,8 @@ For an overview of indicator categories and composition patterns, see [Technical
 |-----|-------|-----------------------------|
 | `ta4jexamples.charting.annotation` | **BarSeriesLabelIndicator** | Sparse bar-index labels for chart annotations; getValue returns label Y (e.g. price) at labeled indices and NaN elsewhere; labels() for text. |
 | `ta4jexamples.charting` | **ChannelBoundaryIndicator** | Wraps a channel (e.g. PriceChannel); extracts upper, lower, or median boundary for chart overlay; forwards Num when source is already Num. |
+| `ta4jexamples.charting` | **AnalysisCriterionIndicator** | Visualizes an `AnalysisCriterion` as an indicator for chart overlays. |
+| `ta4jexamples.indicators` | **CandlestickChartWithChopIndicator** | Example candlestick chart workflow with a Chop indicator overlay. |
 
 **Short usage**  
 - **What it is:** Charting helpers: annotation labels and channel-boundary extraction for display.  

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -155,8 +155,8 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators` | **StochasticOscillatorKIndicator** | Stochastic %K. |
 | `org.ta4j.core.indicators` | **StochasticOscillatorDIndicator** | Stochastic %D (smoothed %K). |
 | `org.ta4j.core.indicators` | **MACDIndicator** | MACD (APO): short EMA − long EMA. |
-| `org.ta4j.core.indicators` | **MACDVIndicator** | MACD with volume weighting. |
-| `org.ta4j.core.indicators.macd` | **VolatilityNormalizedMACDIndicator** | MACD-V formulation using volatility normalization. |
+| `org.ta4j.core.indicators` | **MACDVIndicator** | ta4j variant: MACD EMA spread with volume/ATR-weighted EMA inputs (not ATR division). |
+| `org.ta4j.core.indicators.macd` | **VolatilityNormalizedMACDIndicator** | Volatility-normalized MACD-V (`(EMAfast - EMAslow) / ATR * scale`), often called Spiroglou-style. |
 | `org.ta4j.core.indicators` | **PPOIndicator** | Percentage Price Oscillator (MACD as % of longer EMA). |
 | `org.ta4j.core.indicators` | **ROCIndicator** | Rate of change (price change over period). |
 | `org.ta4j.core.indicators` | **CMOIndicator** | Chande Momentum Oscillator. |

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -156,6 +156,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators` | **StochasticOscillatorDIndicator** | Stochastic %D (smoothed %K). |
 | `org.ta4j.core.indicators` | **MACDIndicator** | MACD (APO): short EMA − long EMA. |
 | `org.ta4j.core.indicators` | **MACDVIndicator** | MACD with volume weighting. |
+| `org.ta4j.core.indicators.macd` | **VolatilityNormalizedMACDIndicator** | MACD-V formulation using volatility normalization. |
 | `org.ta4j.core.indicators` | **PPOIndicator** | Percentage Price Oscillator (MACD as % of longer EMA). |
 | `org.ta4j.core.indicators` | **ROCIndicator** | Rate of change (price change over period). |
 | `org.ta4j.core.indicators` | **CMOIndicator** | Chande Momentum Oscillator. |
@@ -164,8 +165,10 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators` | **CCIIndicator** | Commodity Channel Index. |
 | `org.ta4j.core.indicators` | **KRIIndicator** | Klinger Volume Oscillator (simplified or full). |
 | `org.ta4j.core.indicators` | **AwesomeOscillatorIndicator** | Awesome Oscillator (median price, 5 vs 34 period). |
+| `org.ta4j.core.indicators` | **GatorOscillatorIndicator** | Bill Williams gator oscillator derived from alligator line spreads. |
 | `org.ta4j.core.indicators` | **AccelerationDecelerationIndicator** | AC: acceleration/deceleration of momentum. |
 | `org.ta4j.core.indicators` | **TrueStrengthIndexIndicator** | TSI: double-smoothed momentum. |
+| `org.ta4j.core.indicators` | **UltimateOscillatorIndicator** | Multi-window oscillator combining short/mid/long buying pressure. |
 | `org.ta4j.core.indicators` | **SchaffTrendCycleIndicator** | Schaff Trend Cycle; MACD + stochastic-style normalization. |
 | `org.ta4j.core.indicators` | **ConnorsRSIIndicator** | Connors RSI (streak + RSI components). |
 | `org.ta4j.core.indicators` | **FisherIndicator** | Fisher transform (normalizes price to Gaussian-like). |
@@ -203,6 +206,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.aroon` | **AroonUpIndicator** | Aroon Up (periods since highest high). |
 | `org.ta4j.core.indicators.aroon` | **AroonDownIndicator** | Aroon Down (periods since lowest low). |
 | `org.ta4j.core.indicators.aroon` | **AroonOscillatorIndicator** | Aroon Up − Aroon Down. |
+| `org.ta4j.core.indicators` | **AlligatorIndicator** | Bill Williams alligator line (jaw/teeth/lips displaced SMMAs). |
 | `org.ta4j.core.indicators.ichimoku` | **IchimokuTenkanSenIndicator** | Tenkan-sen (conversion line). |
 | `org.ta4j.core.indicators.ichimoku` | **IchimokuKijunSenIndicator** | Kijun-sen (base line). |
 | `org.ta4j.core.indicators.ichimoku` | **IchimokuSenkouSpanAIndicator** | Senkou Span A (leading span A). |
@@ -214,6 +218,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.supertrend` | **SuperTrendLowerBandIndicator** | SuperTrend lower band. |
 | `org.ta4j.core.indicators.trend` | **UpTrendIndicator** | Boolean: price in uptrend (e.g. above MA). |
 | `org.ta4j.core.indicators.trend` | **DownTrendIndicator** | Boolean: price in downtrend. |
+| `org.ta4j.core.indicators` | **VortexIndicator** | Vortex (+VI, −VI, and oscillator) trend-strength/direction indicator. |
 
 **Short usage**  
 - **What it is:** ADX/DI measure trend strength and direction; Aroon and Ichimoku add structure; SuperTrend gives a single trend line.  
@@ -233,6 +238,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.volume` | **ChaikinMoneyFlowIndicator** | CMF: volume-weighted money flow over period. |
 | `org.ta4j.core.indicators.volume` | **ChaikinOscillatorIndicator** | Chaikin Oscillator (A/D short − long EMA). |
 | `org.ta4j.core.indicators.volume` | **MoneyFlowIndexIndicator** | MFI: volume-weighted RSI-style oscillator. |
+| `org.ta4j.core.indicators` | **MarketFacilitationIndexIndicator** | Bill Williams MFI: `(high - low) / volume` (not Money Flow Index). |
 | `org.ta4j.core.indicators.volume` | **VWAPIndicator** | Volume-weighted average price (from open). |
 | `org.ta4j.core.indicators.volume` | **MVWAPIndicator** | Moving VWAP (VWAP over a rolling window). |
 | `org.ta4j.core.indicators.volume` | **NVIIndicator** | Negative Volume Index. |
@@ -320,6 +326,8 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators` | **RecentSwingHighIndicator** | Price of the most recent confirmed swing high. |
 | `org.ta4j.core.indicators` | **RecentSwingLowIndicator** | Price of the most recent confirmed swing low. |
 | `org.ta4j.core.indicators` | **RecentSwingIndicator** | Generic recent swing (e.g. value at last swing). |
+| `org.ta4j.core.indicators` | **FractalHighIndicator** | Bill Williams fractal high confirmation indicator (no look-ahead). |
+| `org.ta4j.core.indicators` | **FractalLowIndicator** | Bill Williams fractal low confirmation indicator (no look-ahead). |
 | `org.ta4j.core.indicators` | **RecentFractalSwingHighIndicator** | Most recent fractal swing high (Bill Williams style). |
 | `org.ta4j.core.indicators` | **RecentFractalSwingLowIndicator** | Most recent fractal swing low. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagPivotHighIndicator** | True at ZigZag pivot high bars. |

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -7,10 +7,11 @@ Technical indicators (a.k.a. *technicals*) transform price/volume data into stru
 | Category | Highlights | Docs |
 | --- | --- | --- |
 | Trend / Moving Averages | SMA, EMA, HMA, VIDYA, Jurik, Displaced variants, SuperTrend, Renko helpers. | [Moving Average Indicators](Moving-Average-Indicators.md) |
-| Momentum & Oscillators | RSI family, NetMomentum (new), MACD/MACDV, KST, Stochastics, Calm (CMO), ROC. | This page |
+| Momentum & Oscillators | RSI family, NetMomentum (new), MACD/MACDV, MACD-V momentum states, KST, Stochastics, CMO, ROC. | This page |
 | Volatility & Bands | ATR, Donchian, Bollinger, Keltner, Average True Range trailing stops. | [Bar Series & Bars](Bar-series-and-bars.md) (for ATR-based stops) |
 | Volume & Breadth | OBV, VWAP/VWMA, Accumulation/Distribution, Chaikin, Volume spikes. | Indicators package |
 | Market Structure (VWAP/SR/Wyckoff) | Anchored VWAP, VWAP bands/z-score, price clusters, bounce counts, KDE volume profile, Wyckoff phase detection. | [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md) |
+| Bill Williams Toolkit | Alligator (jaw/teeth/lips), FractalHigh/Low, Gator Oscillator, Market Facilitation Index. | [Bill Williams Indicators](Bill-Williams-Indicators.md) |
 | Candle/Pattern | Hammer, Shooting Star, Three White Soldiers, DownTrend/UpTrend. | `indicators.candles` |
 | Price Transformations | RenkoUp/Down/X (0.19), Heikin Ashi builders, `BinaryOperationIndicator`/`UnaryOperationIndicator` transforms. | `indicators.renko` |
 | Oscillators | TrueStrengthIndex, SchaffTrendCycle, ConnorsRSI (0.21.0), RSI family, MACD/MACDV, KST, Stochastics, CMO, ROC. | This page |
@@ -44,6 +45,24 @@ ta4j now includes a complete workflow for value, location, and phase analysis:
 Use the dedicated guide for implementation templates and tuning advice:
 
 - [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md)
+
+## Bill Williams workflow (0.22.3)
+
+ta4j 0.22.3 added a complete Bill Williams toolkit:
+
+- Trend context: `AlligatorIndicator` (jaw/teeth/lips with canonical 13/8, 8/5, 5/3 settings)
+- Breakout structure: `FractalHighIndicator`, `FractalLowIndicator` (`2/2` windows by default)
+- Momentum/participation confirmation: `GatorOscillatorIndicator`, `MarketFacilitationIndexIndicator`
+
+Fractal indicators confirm on the current bar; use `getConfirmedFractalIndex(...)` to reference the pivot bar without introducing look-ahead bias.
+
+## MACD-V momentum-state workflow (0.22.3)
+
+Prefer `org.ta4j.core.indicators.macd.MACDVIndicator` for new code. The legacy `org.ta4j.core.indicators.MACDVIndicator` is deprecated and scheduled for removal in 0.24.0.
+
+- Use `getSignalLine(...)`, `getHistogram(...)`, and `getLineValues(...)` to expose all MACD-V lines.
+- Classify MACD-V regime with `MACDVMomentumStateIndicator` and `MACDVMomentumProfile` (default thresholds: `+50/+150/-50/-150`).
+- Attach state-aware rules with `inMomentumState(...)` or `MomentumStateRule`.
 
 ## Backtesting indicators
 

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -60,6 +60,9 @@ Fractal indicators confirm on the current bar; use `getConfirmedFractalIndex(...
 
 Prefer `org.ta4j.core.indicators.macd.MACDVIndicator` for new code. The legacy `org.ta4j.core.indicators.MACDVIndicator` is deprecated and scheduled for removal in 0.24.0.
 
+- `MACDVIndicator` in ta4j is the volume/ATR-weighted EMA-spread variant (ATR is used inside the weighting term).
+- `VolatilityNormalizedMACDIndicator` is the volatility-normalized form (EMA spread divided by ATR and scaled), often referred to as the Spiroglou-style MACD-V formulation.
+- They are related but not interchangeable; thresholds and interpretation can differ materially between the two.
 - Use `getSignalLine(...)`, `getHistogram(...)`, and `getLineValues(...)` to expose all MACD-V lines.
 - Classify MACD-V regime with `MACDVMomentumStateIndicator` and `MACDVMomentumProfile` (default thresholds: `+50/+150/-50/-150`).
 - Attach state-aware rules with `inMomentumState(...)` or `MomentumStateRule`.

--- a/Trading-strategies.md
+++ b/Trading-strategies.md
@@ -57,6 +57,24 @@ For the full stop toolkit (fixed %, fixed amount, trailing, volatility, ATR) and
 
 Use numeric indicator helpers like `BinaryOperationIndicator` and `UnaryOperationIndicator` when you need on-the-fly math (ratios, differences, powers) without writing custom indicator classes—each helper still benefits from caching.
 
+## MACD-V momentum-state filters (0.22.3)
+
+`org.ta4j.core.indicators.macd.MACDVIndicator` now ships with momentum-state helpers you can wire directly into rules.
+
+```java
+MACDVIndicator macdv = new MACDVIndicator(series, 12, 26, 9);
+MACDVMomentumStateIndicator state = new MACDVMomentumStateIndicator(
+        macdv,
+        MACDVMomentumProfile.defaultProfile()); // +50/+150/-50/-150
+
+Rule bullishState = new MomentumStateRule(state, MACDVMomentumState.RALLYING_OR_RETRACING)
+        .or(new MomentumStateRule(state, MACDVMomentumState.HIGH_RISK));
+Rule macdCrossUp = macdv.crossedUpSignal();
+Rule entryRule = macdCrossUp.and(bullishState);
+```
+
+This pattern keeps entries aligned with MACD-V regime and avoids triggering signal-line crosses during weak/ranging states.
+
 ## Build a strategy
 
 ```java

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -11,6 +11,7 @@
 - [Technical Indicators](Technical-indicators.md)
 - [Indicators Inventory](Indicators-Inventory.md)
 - [Moving Average Indicators](Moving-Average-Indicators.md)
+- [Bill Williams Indicators](Bill-Williams-Indicators.md)
 - [Trendlines & Swing Points](Trendlines-and-Swing-Points.md)
 - [Elliott Wave Indicators](Elliott-Wave-Indicators.md)
 - [VWAP, S/R & Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md)


### PR DESCRIPTION
## Summary
- add a new Bill Williams indicators page and wire it into wiki navigation
- document 0.22.3 indicator drift in Technical Indicators and Indicators Inventory
- extend Backtesting guidance with Sortino, PositionDuration, R-multiple, and position-duration exit rules

## Validation
- git diff --check
- internal markdown link existence check on changed files

coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bill Williams toolkit indicators (Alligator, Fractals, Gator Oscillator, Market Facilitation Index)
  * MACD-V momentum-state APIs and strategy filters
  * New analysis criteria (SortinoRatio, PositionDuration, RMultiple)
  * VolatilityNormalizedMACD, UltimateOscillator, and VortexIndicator

* **Documentation**
  * Bill Williams Indicators guide with practical examples
  * MACD-V momentum-state trading strategy documentation
  * Enhanced backtesting and live-trading guidance
  * Updated indicators inventory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->