### PR TITLE
docs: refresh ta4j wiki drift coverage

### DIFF
--- a/Backtesting.md
+++ b/Backtesting.md
@@ -27,13 +27,13 @@ List<TradingStatement> ranked = result.getTopStrategies(
         new NetReturnCriterion());
 ```
 
-*What this does:* the first block runs a single strategy through the traditional `BarSeriesManager`. The second block spins up `BacktestExecutor`, runs a batch of strategies while collecting runtime telemetry, and then ranks the resulting `TradingStatement`s by ROMAD and net return. For a full working sample see [`ta4jexamples.backtesting.TopStrategiesExampleBacktest`](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/TopStrategiesExampleBacktest.java).
+*What this does:* the first block runs a single strategy through the traditional `BarSeriesManager`. The second block spins up `BacktestExecutor`, runs a batch of strategies while collecting runtime telemetry, and then ranks the resulting `TradingStatement`s by ROMAD and net return. For a maintained batch-ranking example, see [`ta4jexamples.backtesting.BacktestPerformanceTuningHarness`](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java).
 
 ## Get useful results
 
 - `TradingRecord` – chronological trades with entry/exit prices, costs, exposure, and net/gross PnL. Pass it into any criterion or build a `BaseTradingStatement`.
-- `BacktestExecutionResult` – wraps a `TradingRecord` plus execution metrics (runtime, bars processed, memory estimates). Great for profiling slow strategies.
-- `BacktestRuntimeReport` – aggregated stats from a `BacktestExecutor` run, used by the progress listener hook.
+- `BacktestExecutionResult` – wraps the evaluated `TradingStatement` list plus a `BacktestRuntimeReport`; use it to keep both ranking data and runtime context together.
+- `BacktestRuntimeReport` – aggregated timing stats from a `BacktestExecutor` run (overall/min/max/average/median and per-strategy runtimes).
 
 ## Backtesting VWAP, support/resistance, and Wyckoff stacks
 
@@ -77,8 +77,8 @@ Ta4j includes dozens of criteria organized by package:
 - `criteria.pnl.*` – differentiate net vs. gross results.
 - `criteria.drawdown.*` – absolute, relative, duration, Monte Carlo.
 - `criteria.commissions.*` – total fees across positions.
-- `criteria.costs.*` – commissions and holding costs.
-- `criteria.position.*` – streaks, max profit/loss per position, time in market, `PositionDurationCriterion` (mean/median/p95 style summaries), open-position cost basis and unrealized PnL when using `LiveTradingRecord`.
+- `criteria.risk.*` – risk-model-based evaluation such as `RMultipleCriterion`.
+- `org.ta4j.core.criteria` (top-level package) – ratio/return criteria, `PositionDurationCriterion`, open-position cost basis and unrealized PnL criteria, plus position streak/count criteria.
 
 Mix and match to build your own evaluation stack.
 
@@ -102,7 +102,7 @@ List<TradingStatement> topFive = batch.getTopStrategies(5, romad, net);
 
 ## Visualize your backtests
 
-After you have a `TradingRecord`, you can render candlesticks, trades, and indicator overlays using the `ChartMaker` helper that lives in the `ta4j-examples` module.
+After you have a `TradingRecord`, you can render candlesticks, trades, and indicator overlays using `ChartWorkflow` + `ChartBuilder` from `ta4j-examples`.
 
 ### Using the Fluent Builder API (Recommended)
 
@@ -110,38 +110,28 @@ The builder API provides a clean, composable way to create and display charts:
 
 ```java
 TradingRecord record = manager.run(strategy);
-ChartMaker chartMaker = new ChartMaker("target/charts");
+ChartWorkflow chartWorkflow = new ChartWorkflow("target/charts");
 
 ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
 SMAIndicator sma = new SMAIndicator(closePrice, 50);
 EMAIndicator ema = new EMAIndicator(closePrice, 200);
 
-chartMaker.builder()
-    .withTradingRecord(series, strategy.getName(), record)
-    .addIndicators(sma, ema)
-    .withAnalysisCriterion(series, record, new MaximumDrawdownCriterion())
-    .build()
-    .display()
-    .save("my-strategy");
+ChartPlan plan = chartWorkflow.builder()
+    .withSeries(series)
+    .withTradingRecordOverlay(record)
+    .withIndicatorOverlay(sma)
+    .withIndicatorOverlay(ema)
+    .toPlan();
+
+chartWorkflow.display(plan);
+chartWorkflow.save(plan, "my-strategy");
 ```
 
 See the [Charting](Charting.md) guide for comprehensive documentation and more examples.
 
-### Legacy API
+### Convenience workflow methods
 
-The original methods remain available for backward compatibility:
-
-```java
-ChartMaker charts = new ChartMaker("target/charts");
-charts.displayTradingRecordChart(
-        series,
-        strategy.getName(),
-        record,
-        new SMAIndicator(new ClosePriceIndicator(series), 50),
-        new EMAIndicator(new ClosePriceIndicator(series), 200));
-```
-
-Saved images are JPEGs (see `FileSystemChartStorage`), so the directory you pass to the constructor ends up with files like `mySeries_2023-01-01_to_2024-05-01_timestamp.jpg`. `ChartMaker` composes JFreeChart visualizations through pluggable display and storage backends, so you can pop up Swing windows, stream bytes, or save those JPEGs after each backtest. Explore [`ta4jexamples.charting.ChartMaker`](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/charting/ChartMaker.java) and the [`ta4jexamples.strategies.NetMomentumStrategy`](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/NetMomentumStrategy.java) sample, which loads data, runs a strategy, and drops charts into `ta4j-examples/log/charts`.
+If you prefer less builder wiring, `ChartWorkflow` also exposes convenience methods like `createTradingRecordChart(...)`, `display(...)`, and `save(...)`. Saved images are JPEGs (see `FileSystemChartStorage`) with generated names derived from series metadata. For a full end-to-end strategy + chart flow, see [`ta4jexamples.strategies.NetMomentumStrategy`](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/NetMomentumStrategy.java).
 
 ## Backtesting with LiveTradingRecord
 
@@ -153,7 +143,7 @@ When you need cost basis, unrealized PnL, or a position book in your backtest (e
 - **Insufficient warm-up** – Set `strategy.setUnstableBars(n)` to skip the early `n` indices when indicators have not stabilized yet (`Indicator.isStable()` helps confirm).
 - **Moving series** – When using `setMaximumBarCount`, do not reference indexes older than `series.getBeginIndex()`. Criteria referencing evicted bars will return `NaN`.
 - **Ratio criteria edge cases** – `SortinoRatioCriterion` returns `NaN` when downside deviation is zero. Guard `NaN` values before `chooseBest(...)` or top-K ranking.
-- **Transaction costs** – Always configure `TransactionCostModel` / `HoldingCostModel` on `BarSeriesManager` or pass explicit cost models to `BacktestExecutor`.
+- **Transaction costs** – Always configure explicit `CostModel` implementations (for example `LinearTransactionCostModel`, `LinearBorrowingCostModel`) on `BarSeriesManager` or `BacktestExecutor`.
 
 ## Walk-forward optimization
 

--- a/Bar-series-and-bars.md
+++ b/Bar-series-and-bars.md
@@ -36,7 +36,7 @@ Options to consider:
 
 - **Builders** – `TimeBarBuilder`, `TickBarBuilder`, `VolumeBarBuilder`, and the new `AmountBarBuilder` aggregate trades into bars by elapsed time, tick count, volume, or quote currency size respectively.
 - **Begin vs. end timestamps** – Since 0.18 you can build bars anchored on begin time (`timePeriod` + `beginTime`) or end time. Use whichever matches your data source.
-- **Split series** – `series.getSubSeries(start, end)` and `series.split(...)` are handy for walk-forward tests or training/testing splits.
+- **Split series** – `series.getSubSeries(start, end)` is the standard way to create train/test or walk-forward slices.
 - **Data Sources** – The `ta4j-examples` module includes ready-made data sources for loading historical data from APIs (Yahoo Finance, Coinbase) and files (CSV, JSON). See [Data Sources](Data-Sources.md) for comprehensive documentation.
 
 ## Working with live data
@@ -63,8 +63,8 @@ As intrabar updates stream in:
 
 ```java
 liveSeries.addPrice(100.9);          // updates close + high/low if needed
-liveSeries.addTrade(liveSeries.numFactory().numOf(100),
-        liveSeries.numFactory().numOf(2)); // updates volume + close
+liveSeries.addTrade(liveSeries.numFactory().numOf(2),
+        liveSeries.numFactory().numOf(100)); // volume first, then price
 liveSeries.addBar(updatedBar, true); // replace the last bar entirely
 ```
 
@@ -94,6 +94,9 @@ ConcurrentBarSeries concurrentSeries = new ConcurrentBarSeriesBuilder()
 The recommended approach for real-time data feeds is to use `ingestTrade()` methods, which let the configured `BarBuilder` handle bar rollovers automatically:
 
 ```java
+// Configure the trade builder before ingestion (required)
+concurrentSeries.tradeBarBuilder().timePeriod(Duration.ofMinutes(1));
+
 // Simple trade ingestion (no side/liquidity data)
 concurrentSeries.ingestTrade(
     Instant.now(),

--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -75,6 +75,13 @@ The Elliott Wave indicators in ta4j are built on several key principles:
 5. **Degree-Aware**: The system supports multiple wave degrees, allowing analysis across different timeframes.
 6. **Resilient to Edge Cases**: Indicators gracefully handle insufficient data, returning `NaN` values rather than throwing exceptions.
 
+### Internal Implementation Boundary
+
+Some Elliott package classes are internal implementation details (for example, scenario-rule/scoring internals used to build ranked alternatives).
+
+- These internals are intentionally not surfaced in general wiki pages.
+- This dedicated Elliott page is the right place to discuss Elliott internals when needed.
+
 ### Component Hierarchy
 
 The Elliott Wave system in ta4j follows a layered architecture:
@@ -648,9 +655,6 @@ if (scenario.expectsCompletion()) {
     System.out.println("Wave structure approaching completion");
 }
 ```
-<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
-read_file
-
 ### Scenario Types
 
 The `ScenarioType` enum classifies the pattern structure:

--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -131,6 +131,12 @@ ElliottSwingIndicator (alternating swings)
 - You want to track multiple wave counts simultaneously
 - You need explicit invalidation price levels for stop placement
 
+### Recent changes relevant to this guide (last ~120 days)
+
+- Commit `d6cb699f` expanded Elliott swing utility coverage and strengthened metadata/comparator usage.
+- Commit `bebb758e` added the analyzer/facade trend-bias pipeline (`ElliottTrendBias`, `ElliottTrendBiasIndicator`, analyzer trend-bias output) and expanded pluggable confidence/swing infrastructure.
+- Confidence scoring now applies softer scoring outside preferred extension ranges (rather than hard pass/fail), so marginally overextended wave-3/wave-5 structures are penalized instead of treated as binary invalid.
+
 ---
 
 ## Core Components
@@ -823,6 +829,9 @@ The `ElliottConfidenceScorer` evaluates each scenario against five weighted fact
 | Alternation Quality | 15% | Degree of pattern/depth alternation between waves 2 and 4 |
 | Channel Adherence | 15% | Whether price stays within projected channel boundaries |
 | Structure Completeness | 15% | How many expected waves are confirmed |
+
+Implementation note:
+- The default scoring is continuous, not binary. In particular, extension ratios are down-weighted when they drift outside preferred wave-3/wave-5 zones, which improves ranking separation between "acceptable" and "best-fit" scenarios.
 
 ### The ElliottConfidence Record
 

--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -138,11 +138,11 @@ ElliottSwingIndicator (alternating swings)
 - You want to track multiple wave counts simultaneously
 - You need explicit invalidation price levels for stop placement
 
-### Recent changes relevant to this guide (last ~120 days)
+### Change tracking relevant to this guide
 
-- Commit `d6cb699f` expanded Elliott swing utility coverage and strengthened metadata/comparator usage.
-- Commit `bebb758e` added the analyzer/facade trend-bias pipeline (`ElliottTrendBias`, `ElliottTrendBiasIndicator`, analyzer trend-bias output) and expanded pluggable confidence/swing infrastructure.
-- Confidence scoring now applies softer scoring outside preferred extension ranges (rather than hard pass/fail), so marginally overextended wave-3/wave-5 structures are penalized instead of treated as binary invalid.
+- This guide covers the stable Elliott API surface used in the `0.22.x` line (`ElliottTrendBias`, `ElliottTrendBiasIndicator`, scenario sets, analyzer/facade workflows, and confidence scoring behavior).
+- Confidence scoring applies softer penalties outside preferred extension ranges (rather than hard pass/fail), so marginally overextended wave-3/wave-5 structures are down-weighted instead of treated as binary invalid.
+- For release-by-release history, see [Release Notes](Release-notes.md).
 
 ---
 

--- a/Home.md
+++ b/Home.md
@@ -18,6 +18,7 @@ Your one-stop guide for building technical-analysis-driven trading systems in Ja
 - **Bill Williams toolkit** – Added `AlligatorIndicator`, `FractalHighIndicator` / `FractalLowIndicator`, `GatorOscillatorIndicator`, and `MarketFacilitationIndexIndicator` with a dedicated [Bill Williams Indicators](Bill-Williams-Indicators.md) guide.
 - **MACD-V momentum-state APIs** – Added momentum-state classification (`MACDVMomentumStateIndicator`, `MACDVMomentumProfile`) and rule integration helpers.
 - **New risk/quality criteria** – Added metrics like `SortinoRatioCriterion`, `PositionDurationCriterion`, and `RMultipleCriterion` for tighter backtest analysis.
+- **Threshold-aware rule composition** – Added coverage for `RiskRewardRatioRule`, `OverOrEqualIndicatorRule`, `UnderOrEqualIndicatorRule`, and `OrWithThresholdRule` in [Trading Strategies](Trading-strategies.md) and [Stop Loss & Stop Gain Rules](Stop-Loss-and-Stop-Gain-Rules.md).
 
 - **Unified return representation system** – Consistent formatting across all return-based criteria (multiplicative, decimal, percentage, logarithmic) via `ReturnRepresentation` and `ReturnRepresentationPolicy`
 - **New oscillators** – `TrueStrengthIndexIndicator`, `SchaffTrendCycleIndicator`, and `ConnorsRSIIndicator` expand oscillator coverage

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -22,6 +22,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 12. [Renko](#12-renko)
 13. [Analysis (PnL, returns, cash flow)](#13-analysis-pnl-returns-cash-flow)
 14. [Charting (ta4j-examples)](#14-charting-ta4j-examples)
+15. [Supporting public types (facades, enums, records)](#15-supporting-public-types-facades-enums-records)
 
 ---
 
@@ -132,6 +133,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.donchian` | **DonchianChannelUpperIndicator** | Highest high over the period. |
 | `org.ta4j.core.indicators.donchian` | **DonchianChannelLowerIndicator** | Lowest low over the period. |
 | `org.ta4j.core.indicators.donchian` | **DonchianChannelMiddleIndicator** | Midpoint of Donchian channel. |
+| `org.ta4j.core.indicators.donchian` | **DonchianChannelFacade** | Fluent builder that exposes cached numeric Donchian lower/upper/middle channels from one constructor call. |
 | `org.ta4j.core.indicators` | **ChandelierExitLongIndicator** | Chandelier Exit (long): highest high minus ATR-based offset. |
 | `org.ta4j.core.indicators` | **ChandelierExitShortIndicator** | Chandelier Exit (short): lowest low plus ATR-based offset. |
 | `org.ta4j.core.indicators` | **ChopIndicator** | Choppiness Index (0–100); measures trend vs range. |
@@ -506,9 +508,51 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 ---
 
+## 15. Supporting public types (facades, enums, records)
+
+These types live in `org.ta4j.core.indicators` and its subpackages and are part of the public indicator API surface, even though they are not all `*Indicator` classes.
+
+| FQN | Class | Description (from codebase) |
+|-----|-------|-----------------------------|
+| `org.ta4j.core.indicators` | **PriceChannel** | Interface for channel-like outputs (upper/lower/median), used by channel indicators. |
+| `org.ta4j.core.indicators.aroon` | **AroonFacade** | Convenience wrapper exposing Aroon Up/Down/Oscillator values from a common setup. |
+| `org.ta4j.core.indicators.bollinger` | **BollingerBandFacade** | Convenience wrapper exposing middle/upper/lower Bollinger values together. |
+| `org.ta4j.core.indicators.donchian` | **DonchianChannelFacade** | Convenience wrapper exposing Donchian channel components from one entry point. |
+| `org.ta4j.core.indicators.keltner` | **KeltnerChannelFacade** | Convenience wrapper exposing Keltner channel components from one entry point. |
+| `org.ta4j.core.indicators.macd` | **MACDHistogramMode** | Enum controlling histogram calculation mode for MACD-V helper APIs. |
+| `org.ta4j.core.indicators.macd` | **MACDLineValues** | Record containing MACD, signal, and histogram line values as one object. |
+| `org.ta4j.core.indicators.macd` | **MACDVMomentumProfile** | Record encapsulating configurable MACD-V momentum state thresholds. |
+| `org.ta4j.core.indicators.macd` | **MACDVMomentumState** | Enum for MACD-V momentum regimes used by momentum-state indicators/rules. |
+| `org.ta4j.core.indicators.pivotpoints` | **PivotLevel** | Enum for pivot-derived levels (pivot/support/resistance variants). |
+| `org.ta4j.core.indicators.pivotpoints` | **TimeLevel** | Enum describing pivot timeframe granularity (for example day/week/month). |
+| `org.ta4j.core.indicators.elliott` | **ElliottAnalysisResult** | Record returned by `ElliottWaveAnalyzer` with scenarios, confidence, and diagnostics. |
+| `org.ta4j.core.indicators.elliott` | **ElliottChannel** | Record representing Elliott channel boundaries (`PriceChannel` implementation). |
+| `org.ta4j.core.indicators.elliott` | **ElliottConfidence** | Record capturing aggregate and component confidence values for Elliott analysis. |
+| `org.ta4j.core.indicators.elliott` | **ElliottDegree** | Enum for Elliott wave degrees (multi-timeframe wave scale). |
+| `org.ta4j.core.indicators.elliott` | **ElliottFibonacciValidator** | Validator for Elliott Fibonacci relationship checks across swings/waves. |
+| `org.ta4j.core.indicators.elliott` | **ElliottPhase** | Enum representing Elliott phase classification (impulse/corrective states). |
+| `org.ta4j.core.indicators.elliott` | **ElliottRatio** | Record representing a computed Elliott ratio and its ratio type. |
+| `org.ta4j.core.indicators.elliott` | **ElliottScenario** | Record describing one candidate Elliott scenario and associated metadata. |
+| `org.ta4j.core.indicators.elliott` | **ElliottSwing** | Record describing a swing segment used by Elliott scenario generation/scoring. |
+| `org.ta4j.core.indicators.elliott` | **ElliottSwingCompressor** | Utility that compresses/noise-filters Elliott swing sequences. |
+| `org.ta4j.core.indicators.elliott` | **ElliottTrendBias** | Record representing bullish/bearish/neutral Elliott trend-bias weighting. |
+| `org.ta4j.core.indicators.elliott` | **ScenarioType** | Enum for supported Elliott scenario families (used in pattern selection/scoring). |
+| `org.ta4j.core.indicators.elliott.confidence` | **ConfidenceFactorCategory** | Enum categorizing confidence factors in Elliott confidence scoring. |
+| `org.ta4j.core.indicators.elliott.confidence` | **ConfidenceFactorResult** | Record containing one factor's raw score, weighted score, and diagnostics. |
+| `org.ta4j.core.indicators.elliott.confidence` | **ElliottConfidenceContext** | Record containing context input used by Elliott confidence factors/models. |
+| `org.ta4j.core.indicators.wyckoff` | **WyckoffCycleAnalysisResult** | Record containing cycle-analysis outcomes and supporting notes. |
+| `org.ta4j.core.indicators.wyckoff` | **WyckoffCycleType** | Enum representing inferred Wyckoff cycle type. |
+| `org.ta4j.core.indicators.wyckoff` | **WyckoffEvent** | Record describing a detected Wyckoff event and its properties. |
+| `org.ta4j.core.indicators.wyckoff` | **WyckoffPhase** | Record representing inferred Wyckoff phase classification with confidence. |
+| `org.ta4j.core.indicators.wyckoff` | **WyckoffPhaseType** | Enum for Wyckoff phase labels. |
+| `org.ta4j.core.indicators.zigzag` | **ZigZagTrend** | Enum representing ZigZag directional state. |
+
+---
+
 ## Summary
 
-- **ta4j-core** provides 200+ indicators across helpers, averages, volatility, momentum, trend, volume, candles, pivots, swing, Elliott, statistics, renko, and analysis.  
+- **ta4j-core** currently provides 247 indicator classes across helpers, averages, volatility, momentum, trend, volume, candles, pivots, swing, Elliott, statistics, renko, and analysis.
+- The inventory also tracks supporting public types (facades, enums, records, interfaces) in indicator packages that are required for complete API coverage.
 - **ta4j-examples** adds charting-oriented indicators (labels, channel boundary).  
 - All entries above use the **fully qualified name** and **class name** and a **short description as in the ta4j codebase**.  
 - Each category includes a **short usage** block (what it is, theory, when to use, when not to use) and **room for expansion** (use cases, example code).  

--- a/Moving-Average-Indicators.md
+++ b/Moving-Average-Indicators.md
@@ -38,7 +38,7 @@ Moving averages are versatile tools used in a variety of ways:
 
 ## Moving Averages in TA4J
 
-Package: `org.ta4j.core.indicators.averages` (ta4j `0.22.4-SNAPSHOT`).
+Package: `org.ta4j.core.indicators.averages` (ta4j `0.22.3`).
 
 | Abbreviation | Full Name                                     | Indicator Name             | Moving Average Type            |
 |--------------|-----------------------------------------------|----------------------------|--------------------------------|
@@ -68,7 +68,7 @@ Package: `org.ta4j.core.indicators.averages` (ta4j `0.22.4-SNAPSHOT`).
 
 Notes:
 - `AbstractEMAIndicator` is an internal base class used by EMA-family implementations, not a standalone trading indicator.
-- In the last ~120 days no new moving-average indicator classes were added in this package; warmup/unstable behavior was updated in ta4j commit `d0ef59e7` ("Update Indicator Unstable Counts").
+- As of ta4j `0.22.3` (commit `d0ef59e7`), no new moving-average indicator classes were added in this package; warmup/unstable behavior was updated in that release line.
 
 
 ## Classification of Moving Averages

--- a/Moving-Average-Indicators.md
+++ b/Moving-Average-Indicators.md
@@ -38,6 +38,8 @@ Moving averages are versatile tools used in a variety of ways:
 
 ## Moving Averages in TA4J
 
+Package: `org.ta4j.core.indicators.averages` (ta4j `0.22.4-SNAPSHOT`).
+
 | Abbreviation | Full Name                                     | Indicator Name             | Moving Average Type            |
 |--------------|-----------------------------------------------|----------------------------|--------------------------------|
 | ATMA         | Asymmetric Triangular Moving Average          | ATMAIndicator              | Specialized Moving Average     |
@@ -51,7 +53,7 @@ Moving averages are versatile tools used in a variety of ways:
 | KiJunV2      | Kihon Moving Average                          | KiJunV2Indicator           | Specialized Moving Average     |
 | LSMA         | Least Squares Moving Average                  | LSMAIndicator              | Polynomial-Based Moving Average|
 | LWMA         | Linear Weighted Moving Average                | LWMAIndicator              | Weighted Moving Average        |
-| MCGinley     | McGinley Moving Average                       | MCGinleyMAIndicator        | Adaptive Moving Average        |
+| McGinley     | McGinley Moving Average                       | MCGinleyMAIndicator        | Adaptive Moving Average        |
 | MMA          | Modified Moving Average                       | MMAIndicator               | Exponential Moving Average     |
 | SMA          | Simple Moving Average                         | SMAIndicator               | Simple Moving Average          |
 | SGMA         | Savitzky-Golay Moving Average                 | SGMAIndicator              | Polynomial-Based Moving Average|
@@ -60,9 +62,13 @@ Moving averages are versatile tools used in a variety of ways:
 | TMA          | Triangular Moving Average                     | TMAIndicator               | Simple Moving Average          |
 | VIDYA        | Chandes Variable Index Dynamic Moving Average | VIDYAIndicator             | Adaptive Moving Average        |
 | VWMA         | Volume Weighted Moving Average                | VWMAIndicator              | Weighted Moving Average        |
-| WilderMA     | Wilders Moving Average                        | WildersMAIndicator         | Smoothed Moving Average        |
+| WildersMA    | Wilders Moving Average                        | WildersMAIndicator         | Smoothed Moving Average        |
 | WMA          | Weighted Moving Average                       | WMAIndicator               | Weighted Moving Average        |
 | ZLEMA        | Zero Lag Exponential Moving Average           | ZLEMAIndicator             | Exponential Moving Average     |
+
+Notes:
+- `AbstractEMAIndicator` is an internal base class used by EMA-family implementations, not a standalone trading indicator.
+- In the last ~120 days no new moving-average indicator classes were added in this package; warmup/unstable behavior was updated in ta4j commit `d0ef59e7` ("Update Indicator Unstable Counts").
 
 
 ## Classification of Moving Averages

--- a/Moving-Average-Indicators.md
+++ b/Moving-Average-Indicators.md
@@ -114,7 +114,7 @@ Notes:
 - These averages reduce short-term fluctuations to produce a smoother trendline.
 - **Indicators**:
   - SMMA (Smoothed Moving Average)
-  - WilderMA (Wilder’s Moving Average)
+  - WildersMA (Wilder’s Moving Average)
 
 ---
 

--- a/Num.md
+++ b/Num.md
@@ -99,6 +99,8 @@ The `ta4j-examples` module includes a benchmark (`DecimalNumPrecisionPerformance
 
 To measure precision impact on your specific use case, run the benchmark:
 
+Run this command from the ta4j repository root so the `ta4j-examples` module is resolvable. The benchmark entrypoint is `ta4jexamples.num.DecimalNumPrecisionPerformanceTest`.
+
 ```bash
 mvn -pl ta4j-examples -Dexec.mainClass=ta4jexamples.num.DecimalNumPrecisionPerformanceTest exec:java
 ```

--- a/Num.md
+++ b/Num.md
@@ -14,7 +14,7 @@ Take a look at the [usage examples](Usage-examples.md) to see `Num` and `BaseBar
 Every calculation faces the precision vs. speed trade-off:
 
 - **DecimalNum** stores values as `BigDecimal` with a **default precision of 16 digits** and **default rounding mode of HALF_UP** (changed from 32 digits in 0.19 for better performance). You can configure the default precision/rounding globally via `DecimalNum.configureDefaultPrecision(int)` or `DecimalNum.configureDefaultMathContext(MathContext)`, or request a factory with a specific precision/rounding mode (`DecimalNumFactory.getInstance(new MathContext(34, RoundingMode.HALF_EVEN))`). Higher precision reduces rounding error but increases CPU cost, GC pressure, and memory footprint because BigDecimal allocates new objects for every arithmetic call.
-- **DoubleNum** uses binary floating point. It’s fast and allocation-free but inherits IEEE-754 quirks. For example:
+- **DoubleNum** uses binary floating point. It’s fast but inherits IEEE-754 quirks. For example:
 
   ```java
   System.out.println(1.0 - 9 * 0.1); // prints 0.09999999999999998
@@ -99,9 +99,8 @@ The `ta4j-examples` module includes a benchmark (`DecimalNumPrecisionPerformance
 
 To measure precision impact on your specific use case, run the benchmark:
 
-```java
-// Run the precision performance benchmark
-ta4jexamples.num.DecimalNumPrecisionPerformanceTest.main(new String[0]);
+```bash
+mvn -pl ta4j-examples -Dexec.mainClass=ta4jexamples.num.DecimalNumPrecisionPerformanceTest exec:java
 ```
 
 The benchmark outputs CSV data showing:
@@ -145,6 +144,18 @@ series.addBar(bar);
 ```
 
 **Important:** A `BarSeries` has a fixed numeric backend. Mixing different `Num` types on the same series (e.g., creating a `DoubleNum` literal and feeding it into a `DecimalNum` series) will throw or produce undefined behavior—always go through `numFactory()`.
+
+For null/NaN guards in custom code, use the static helpers on `Num`:
+
+```java
+if (Num.isValid(value)) {
+    // safe to consume value
+}
+
+if (Num.isNaNOrNull(value)) {
+    // skip or fallback
+}
+```
 
 ## Implementing your own Num
 If you need a custom numeric type (decimal128, fixed-point integers, GPU-backed tensors, etc.), implement the `Num` interface plus a matching `NumFactory`. As long as the factory can produce `zero()`, `one()`, and `numOf(...)`, the rest of ta4j will treat it like any other `Num`.

--- a/Stop-Loss-and-Stop-Gain-Rules.md
+++ b/Stop-Loss-and-Stop-Gain-Rules.md
@@ -19,6 +19,8 @@ Use this page as the operational guide for:
 
 These use percentage distance from entry (or favorable move for trailing variants).
 
+Percent inputs are percentage points (for example, `3` means `3%`, not `0.03`).
+
 Best when:
 
 - You want simple, interpretable risk limits.
@@ -50,6 +52,8 @@ Best when:
 - `AverageTrueRangeTrailingStopGainRule`
 
 These use a dynamic threshold based on volatility indicators (typically ATR multiplied by a coefficient).
+
+From 0.22.3, ATR-based rules also support constructors that accept a custom `ATRIndicator` directly, so you can share precomputed ATR pipelines instead of rebuilding ATR inside each rule.
 
 Best when:
 
@@ -88,6 +92,7 @@ Notes:
 
 - Keep one hard fail-safe stop even when using adaptive stops.
 - Avoid stacking many correlated stop rules unless each has a distinct purpose.
+- `TrailingStopGainRule` and `AverageTrueRangeTrailingStopGainRule` are two-stage: they activate only after reaching the initial gain threshold, then trigger on retracement from the favorable extreme.
 
 ## Using stop-price models for risk analytics
 
@@ -159,6 +164,32 @@ Practical tuning workflow:
 2. Validate on multiple volatility regimes.
 3. Compare with realistic fees/slippage.
 4. Stress test gap days and high-spread windows.
+
+## Complementary risk gating rules (0.22.2+)
+
+Use these with stop rules when you need stronger entry/exit constraints:
+
+- `RiskRewardRatioRule`
+  - Checks whether your current `price/stop/target` tuple satisfies a minimum reward-to-risk threshold.
+  - Useful before entering trades that rely on dynamic stop/target indicators.
+- `OverOrEqualIndicatorRule`
+  - Same semantics as `OverIndicatorRule`, but inclusive (`>=`) for threshold boundaries.
+  - Useful for exact trigger levels (for example, "allow signal when RSI is exactly 50").
+- `UnderOrEqualIndicatorRule`
+  - Same semantics as `UnderIndicatorRule`, but inclusive (`<=`) for threshold boundaries.
+  - Useful for exact lower bounds (for example, "allow exit when RSI is exactly 30").
+- `OrWithThresholdRule`
+  - OR composition evaluated over a rolling threshold window (current bar included).
+  - Useful when either of two confirmation signals can fire within the last `N` bars.
+
+```java
+Rule rrGate = new RiskRewardRatioRule(close, stopPrice, targetPrice, true, 2.0);
+Rule inclusiveState = new OverOrEqualIndicatorRule(rsi, 50);
+Rule inclusiveOversold = new UnderOrEqualIndicatorRule(rsi, 30);
+Rule delayedConfirm = new OrWithThresholdRule(macdCrossUp, breakoutRule, 3);
+
+Rule entryRule = rrGate.and(inclusiveState).and(inclusiveOversold.negation()).and(delayedConfirm);
+```
 
 ## Common mistakes
 

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -1,6 +1,6 @@
 # Technical Indicators
 
-Technical indicators (a.k.a. *technicals*) transform price/volume data into structured signals that power rules and strategies. ta4j ships with 130+ indicators covering every major category plus building blocks for your own creations.
+Technical indicators (a.k.a. *technicals*) transform price/volume data into structured signals that power rules and strategies. ta4j currently ships with 247 indicator classes under `org.ta4j.core.indicators`, covering every major category plus building blocks for your own creations.
 
 **Exhaustive list:** For a full inventory of all indicators in ta4j-core and ta4j-examples (fully qualified names, class names, short descriptions, and usage notes), see [Indicators Inventory](Indicators-Inventory.md).
 
@@ -31,7 +31,7 @@ Indicator<Num> trendBias = BinaryOperationIndicator.division(fast, slow);
 Indicator<Num> blendedMomentum = BinaryOperationIndicator.add(macdv.getMacd(), netMomentum);
 ```
 
-- `BinaryOperationIndicator` / `UnaryOperationIndicator` replace the older `TransformIndicator`/`CombineIndicator` classes (removed in 0.19, enhanced in 0.21.0).
+- `BinaryOperationIndicator` / `UnaryOperationIndicator` are the preferred numeric composition APIs for new code; `CombineIndicator` remains available in `org.ta4j.core.indicators.helpers`.
 - Output indicators can feed directly into rules (`new OverIndicatorRule(trendBias, numOf(1.0))`) or become inputs to other indicators.
 
 ## Market structure workflow (VWAP + S/R + Wyckoff)
@@ -45,6 +45,8 @@ ta4j now includes a complete workflow for value, location, and phase analysis:
 Use the dedicated guide for implementation templates and tuning advice:
 
 - [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md)
+
+For Donchian channels, `DonchianChannelFacade` provides fluent `lower()/upper()/middle()` numeric indicators from one constructor call; see [Indicators Inventory](Indicators-Inventory.md) for class-level details.
 
 ## Bill Williams workflow (0.22.3)
 
@@ -93,8 +95,6 @@ Sub-class `CachedIndicator<Num>` or compose existing indicators with operations.
 - When working with unconventional chart types (Renko, Heikin Ashi), prefer the dedicated builders/indicators shipped in 0.18/0.19/0.21.0—they keep the math consistent across strategies.
 - Combine price- and volume-driven indicators to reduce false positives (e.g., `new AndIndicatorRule(new OverIndicatorRule(macdv, zero), new OverIndicatorRule(vwma, close))`).
 - Document indicator usage inside strategies so others know the intent—especially if the indicator is non-standard or parameter-sensitive.
-Technicals also need to be backtested on historic data to see how effective they would have been to predict future prices. [Some examples](Usage-examples.html) are available in this sense.
-
 ### Visualizing indicators
 
 You can visualize indicators on charts using the [ChartBuilder API](Charting.md). Indicators can be displayed as overlays on price charts or as separate sub-charts:

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -1,6 +1,6 @@
 # Technical Indicators
 
-Technical indicators (a.k.a. *technicals*) transform price/volume data into structured signals that power rules and strategies. ta4j currently ships with 247 indicator classes under `org.ta4j.core.indicators`, covering every major category plus building blocks for your own creations.
+Technical indicators (a.k.a. *technicals*) transform price/volume data into structured signals that power rules and strategies. ta4j currently ships with hundreds of indicator classes under `org.ta4j.core.indicators`, covering every major category plus building blocks for your own creations.
 
 **Exhaustive list:** For a full inventory of all indicators in ta4j-core and ta4j-examples (fully qualified names, class names, short descriptions, and usage notes), see [Indicators Inventory](Indicators-Inventory.md).
 

--- a/Trading-strategies.md
+++ b/Trading-strategies.md
@@ -26,6 +26,7 @@ Key points:
 
 - `Rule#isSatisfied(int index)` is stateless. Pass the `TradingRecord` when the rule depends on open positions or previous signals.
 - Composition is fluent (`and`, `or`, `xor`, `negation`), making it easy to express “enter when fast SMA crosses slow SMA **and** RSI recovers above 40.”
+- For windowed boolean composition across the last `N` bars, use `AndWithThresholdRule` / `OrWithThresholdRule` (introduced in 0.22.2). These are explicit rule classes rather than overloads on `and(...)` / `or(...)`.
 - Since 0.19 you can use `VoteRule` to require agreement between multiple rules (e.g., "at least 3 out of 5 oscillators must agree"). In 0.21.0, return representation is unified across all criteria for consistent formatting.
 - `InSlopeRule` is satisfied when the slope of one indicator is within a boundary of another (e.g. for trend strength or momentum alignment).
 
@@ -34,13 +35,18 @@ Key points:
 ```java
 Rule trendFilter = new OverIndicatorRule(sma200, sma400);
 Rule momentumKick = new CrossedUpIndicatorRule(macd, signalLine);
-Rule renkoBreak = new RenkoUpIndicator(series, brickSize);
+Rule renkoBreak = new BooleanIndicatorRule(new RenkoUpIndicator(closePrice, brickSize, 2));
 
-Indicator<Num> netMomentum = new NetMomentumIndicator(series);
+RSIIndicator rsi = new RSIIndicator(closePrice, 14);
+Indicator<Num> netMomentum = NetMomentumIndicator.forRsi(rsi, 20);
 Rule entryRule = new VoteRule(2, trendFilter, momentumKick, renkoBreak)
         .and(new OverIndicatorRule(netMomentum, series.numFactory().zero()));
 
-Rule exitRule = new CrossedDownIndicatorRule(macd, signalLine)
+Rule timedMomentumExit = new OrWithThresholdRule(
+        new CrossedDownIndicatorRule(macd, signalLine),
+        new InSlopeRule(netMomentum, 3, series.numFactory().numOf("-10")),
+        3);
+Rule exitRule = timedMomentumExit
         .or(new StopLossRule(closePrice, numOf(3)))
         .or(new StopGainRule(closePrice, numOf(5)));
 ```
@@ -56,6 +62,23 @@ The **exit** rule triggers if MACD crosses below its signal line, price falls 3%
 For the full stop toolkit (fixed %, fixed amount, trailing, volatility, ATR) and live-trading usage guidance, see [Stop Loss & Stop Gain Rules](Stop-Loss-and-Stop-Gain-Rules.md).
 
 Use numeric indicator helpers like `BinaryOperationIndicator` and `UnaryOperationIndicator` when you need on-the-fly math (ratios, differences, powers) without writing custom indicator classes—each helper still benefits from caching.
+
+## Risk-reward and threshold-aware composition (0.22.2+)
+
+For setups where timing and trade quality are both important, combine the newer threshold-aware rules with stop/target models:
+
+```java
+Rule minRewardToRisk = new RiskRewardRatioRule(closePrice, stopIndicator, targetIndicator, true, 2.0);
+Rule stateGate = new OverOrEqualIndicatorRule(rsi, 50);
+Rule notOverSold = new UnderOrEqualIndicatorRule(rsi, 30).negation();
+Rule signalWindow = new OrWithThresholdRule(macdCrossUp, breakoutRule, 3);
+
+Rule entryRule = minRewardToRisk.and(stateGate).and(notOverSold).and(signalWindow);
+```
+
+- `RiskRewardRatioRule`: rejects bars where stop/target geometry is not attractive enough.
+- `OverOrEqualIndicatorRule` / `UnderOrEqualIndicatorRule`: include boundary values (`>=` / `<=`) instead of strict comparisons.
+- `OrWithThresholdRule`: lets either condition satisfy within a recent bar window, reducing missed entries from one-bar misalignment.
 
 ## MACD-V momentum-state filters (0.22.3)
 
@@ -89,7 +112,7 @@ BarSeriesManager manager = new BarSeriesManager(series);
 TradingRecord record = manager.run(strategy);
 ```
 
-`BarSeriesManager` wires your entry/exit rules to simulated orders, applies the configured cost/execution models, and returns a `TradingRecord` containing every trade so you can plug it into analysis criteria or ChartMaker visualizations.
+`BarSeriesManager` wires your entry/exit rules to simulated orders, applies the configured cost/execution models, and returns a `TradingRecord` containing every trade so you can plug it into analysis criteria or the charting workflow documented in [Backtesting](Backtesting.md#visualize-your-backtests).
 
 The same strategy class can be used in [backtests](Backtesting.md) and [live trading](Live-trading.md) contexts.
 
@@ -99,20 +122,45 @@ For reusable presets, implement `NamedStrategy`. The new registry system keeps c
 
 ```java
 public final class SmaCrossNamedStrategy extends NamedStrategy {
-    @Override
-    protected Strategy build(BarSeries series) {
+    static {
+        registerImplementation(SmaCrossNamedStrategy.class);
+    }
+
+    public SmaCrossNamedStrategy(BarSeries series, int fastPeriod, int slowPeriod) {
+        super(
+            NamedStrategy.buildLabel(SmaCrossNamedStrategy.class,
+                    String.valueOf(fastPeriod), String.valueOf(slowPeriod)),
+            entryRule(series, fastPeriod, slowPeriod),
+            exitRule(series, fastPeriod, slowPeriod));
+    }
+
+    public SmaCrossNamedStrategy(BarSeries series, String... params) {
+        this(series, Integer.parseInt(params[0]), Integer.parseInt(params[1]));
+    }
+
+    private static Rule entryRule(BarSeries series, int fastPeriod, int slowPeriod) {
         ClosePriceIndicator close = new ClosePriceIndicator(series);
-        SMAIndicator fast = new SMAIndicator(close, parameters().getInt("fastPeriod"));
-        SMAIndicator slow = new SMAIndicator(close, parameters().getInt("slowPeriod"));
-        return new BaseStrategy(entryRule(fast, slow), exitRule(fast, slow));
+        return new CrossedUpIndicatorRule(
+                new SMAIndicator(close, fastPeriod),
+                new SMAIndicator(close, slowPeriod));
+    }
+
+    private static Rule exitRule(BarSeries series, int fastPeriod, int slowPeriod) {
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        return new CrossedDownIndicatorRule(
+                new SMAIndicator(close, fastPeriod),
+                new SMAIndicator(close, slowPeriod));
     }
 }
 
-NamedStrategy.initializeRegistry(SmaCrossNamedStrategy.class.getPackageName());
-Strategy preset = NamedStrategy.lookup("SmaCrossNamedStrategy_fast14_slow50").instantiate(series);
+NamedStrategy.initializeRegistry("com.example.strategies");
+List<Strategy> presets = NamedStrategy.buildAllStrategyPermutations(
+        series,
+        List.of(new String[] { "14", "50" }, new String[] { "20", "100" }),
+        SmaCrossNamedStrategy::new);
 ```
 
-In practice the registry maps friendly identifiers (like `fast14_slow50`) back to indicator wiring, so front-ends, parameter sweeps, or config files can request a preset without touching the Java source.
+In practice the registry maps compact labels (for example `SmaCrossNamedStrategy_14_50`) back to indicator wiring during serialization/deserialization, while permutation builders let you generate parameter grids without touching strategy logic.
 
 This is ideal for:
 
@@ -135,7 +183,7 @@ That JSON payload captures the full rule graph, making it safe to persist strate
 
 ## Execution context tips
 
-- **Backtesting** – Inject custom `TransactionCostModel`, `HoldingCostModel`, or `TradeExecutionModel` into `BarSeriesManager` to simulate slippage and commissions accurately.
+- **Backtesting** – Inject custom `CostModel` implementations (for example `LinearTransactionCostModel`, `LinearBorrowingCostModel`) or a custom `TradeExecutionModel` into `BarSeriesManager` to simulate slippage and commissions accurately.
 - **Live trading** – Feed real-time bars into a moving `BarSeries`, call `strategy.shouldEnter(index, record)` / `shouldExit(...)`, then execute trades through your broker (see [Live Trading](Live-trading.md)).
 - **Diagnostics** – Mirror the approach in `ta4jexamples.logging.StrategyExecutionLogging` to trace which rule triggered each trade.
 
@@ -144,5 +192,5 @@ That JSON payload captures the full rule graph, making it safe to persist strate
 - Normalize indicator scales when combining oscillators with price-based rules.
 - Use `strategy.setUnstableBars(...)` (optional now that indicators track `getCountOfUnstableBars()`) and/or `Indicator.isStable()` to avoid acting before indicators warm up.
 - Encapsulate repeated rule snippets into helper methods or custom `Rule` implementations—readability matters when strategies grow complex.
-- Keep entry/exit rules symmetric when building short strategies, or wrap separate long/short strategies via `CombinedBuySellStrategy`.
+- Keep entry/exit rules symmetric when building short strategies; for short-only operation, construct your strategy with starting type `TradeType.SELL`.
 - When mixing timeframes or data sources, align them into the same `BarSeries` (or into multiple series managed by your own coordinator) to avoid implicit look-ahead.

--- a/Trading-strategies.md
+++ b/Trading-strategies.md
@@ -56,8 +56,9 @@ This configuration fires an **entry** when at least two of the following hold on
 2. MACD crosses above its signal line (momentum confirmation), or
 3. The Renko brick detector sees an upside breakout.
 
-On top of that vote, the Net Momentum indicator must be above zero so entries only happen when breadth is positive.  
-The **exit** rule triggers if MACD crosses below its signal line, price falls 3% from the entry (`StopLossRule`), or price rallies 5% (`StopGainRule`).
+On top of that vote, the Net Momentum indicator must be above zero so entries only happen when breadth is positive.
+The **exit** side first evaluates `timedMomentumExit`, an `OrWithThresholdRule` over a 3-bar window: it triggers when either MACD crosses below its signal line or the Net Momentum slope rule (`InSlopeRule(netMomentum, 3, -10)`) is satisfied within that same 3-bar window.
+That combined rule is then OR'd with `StopLossRule(closePrice, numOf(3))` and `StopGainRule(closePrice, numOf(5))` as hard risk/profit boundaries.
 
 For the full stop toolkit (fixed %, fixed amount, trailing, volatility, ATR) and live-trading usage guidance, see [Stop Loss & Stop Gain Rules](Stop-Loss-and-Stop-Gain-Rules.md).
 

--- a/Usage-examples.md
+++ b/Usage-examples.md
@@ -10,8 +10,8 @@ The [`ta4j-examples`](https://github.com/ta4j/ta4j/tree/master/ta4j-examples/src
 ## Bar series & `Num`
 
 - **[BuildBarSeries](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java)** – demonstrates bar builders, sub-series, and moving windows.
-- **[CsvBarsDataSource](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/CsvBarsDataSource.java)** / **[BitstampCsvTradesDataSource](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/BitstampCsvTradesDataSource.java)** – ingest historical OHLCV data.
-- **[AdaptiveJsonBarsSerializer](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/AdaptiveJsonBarsSerializer.java)** – parse Coinbase/Binance OHLC JSON payloads (introduced in 0.19).
+- **[CsvFileBarSeriesDataSource](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/CsvFileBarSeriesDataSource.java)** / **[BitStampCsvTradesFileBarSeriesDataSource](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/BitStampCsvTradesFileBarSeriesDataSource.java)** – ingest historical OHLCV or trade-level CSV data.
+- **[JsonFileBarSeriesDataSource](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/JsonFileBarSeriesDataSource.java)** – parse Coinbase/Binance OHLC JSON payloads via the adaptive type adapter.
 - **[CompareNumTypes](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java)** – compare `DecimalNum` vs `DoubleNum` implementations
 - **[DecimalNumPrecisionPerformanceTest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/num/DecimalNumPrecisionPerformanceTest.java)** – benchmark precision vs. performance trade-offs for `DecimalNum` (see [Num](Num.md#performance-characteristics) for details)
 
@@ -57,13 +57,16 @@ Strategy examples that use charting:
 - **[RSI2Strategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java)**
 - **[NetMomentumStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/NetMomentumStrategy.java)**
 - **[ADXStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java)**
+- **[MACDVMomentumStateStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/MACDVMomentumStateStrategy.java)**
 
 ## Strategy patterns
 
 - **[CCICorrectionStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java)**, **[MovingMomentumStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java)**, **[RSI2Strategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java)** – foundational strategies referenced throughout [Trading Strategies](Trading-strategies.md).
 - **[ADXStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java)** and **[GlobalExtremaStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java)** – trend following setups with multiple indicators.
 - **[DayOfWeekStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/DayOfWeekStrategy.java)** – combines calendar rules with indicator signals.
+- **[HourOfDayStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/HourOfDayStrategy.java)** / **[MinuteOfHourStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/MinuteOfHourStrategy.java)** – intraday calendar-time strategies using hour/minute rules.
 - **[NetMomentumStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/NetMomentumStrategy.java)** – showcases the Net Momentum indicator (introduced in 0.19).
+- **[MACDVMomentumStateStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/MACDVMomentumStateStrategy.java)** – demonstrates volatility-normalized MACD-V momentum states with chart overlays (added in 2026).
 - **[UnstableIndicatorStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/UnstableIndicatorStrategy.java)** – demonstrates how to handle indicators that require long warm-up periods.
 - **[WalkForward](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java)** – complete walk-forward optimization loop.
 
@@ -71,8 +74,8 @@ Strategy examples that use charting:
 
 - **[SimpleMovingAverageBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java)** / **[SimpleMovingAverageRangeBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageRangeBacktest.java)** – baseline moving-average crossover tests.
 - **[MovingAverageCrossOverRangeBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/MovingAverageCrossOverRangeBacktest.java)** – parameter sweeps over SMA periods.
-- **[MultiStrategyBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/MultiStrategyBacktest.java)** – evaluate several strategies across the same dataset.
-- **[TopStrategiesExample](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtest/TopStrategiesExample.java)** – uses the `BacktestExecutor` (introduced in 0.19) to keep a rolling leaderboard of strategies.
+- **[CoinbaseBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/CoinbaseBacktest.java)** / **[YahooFinanceBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/YahooFinanceBacktest.java)** – backtest strategies using live HTTP data-source adapters.
+- **[BacktestPerformanceTuningHarness](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java)** – tune strategy-count/bar-count/heap settings for large backtest runs.
 - **[CashFlowToChart](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java)** and **[BuyAndSellSignalsToChart](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java)** – visualize equity curves and trade signals.
 - **[TradeCost](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/TradeCost.java)** – study how transaction/holding costs impact returns.
 - **[StrategyExecutionLogging](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/logging/StrategyExecutionLogging.java)** – trace rule evaluations line-by-line.
@@ -92,6 +95,7 @@ Strategy examples that use charting:
 ## Bots & live trading
 
 - **[TradingBotOnMovingBarSeries](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingBarSeries.java)** – continuously updates a moving bar series and reacts to strategy signals.
+- **[WyckoffCycleIndicatorSuiteDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/wyckoff/WyckoffCycleIndicatorSuiteDemo.java)** – one-shot and streaming Wyckoff cycle analysis demo (added in 2026).
 - **ConcurrentBarSeries for live trading**: Since 0.22.2, use `ConcurrentBarSeries` for thread-safe bar ingestion in multi-threaded live trading scenarios. See [Live Trading](Live-trading.md) and [Bar Series & Bars](Bar-series-and-bars.md#concurrent-bar-series-for-multi-threaded-scenarios) for comprehensive documentation and examples.
 - **LiveTradingRecord (partial fills, cost basis, position book)**: For bots that receive partial fills or need per-lot cost basis and unrealized PnL, use `LiveTradingRecord` with `recordFill(ExecutionFill)` or `enter`/`exit`. See the [Live Trading – LiveTradingRecord walkthrough](Live-trading.md#walkthrough-livetradingrecord-with-partial-fills-and-cost-basis) for a step-by-step code guide and criteria (`OpenPositionCostBasisCriterion`, `OpenPositionUnrealizedProfitCriterion`).
 

--- a/Usage-examples.md
+++ b/Usage-examples.md
@@ -66,7 +66,7 @@ Strategy examples that use charting:
 - **[DayOfWeekStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/DayOfWeekStrategy.java)** – combines calendar rules with indicator signals.
 - **[HourOfDayStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/HourOfDayStrategy.java)** / **[MinuteOfHourStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/MinuteOfHourStrategy.java)** – intraday calendar-time strategies using hour/minute rules.
 - **[NetMomentumStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/NetMomentumStrategy.java)** – showcases the Net Momentum indicator (introduced in 0.19).
-- **[MACDVMomentumStateStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/MACDVMomentumStateStrategy.java)** – demonstrates volatility-normalized MACD-V momentum states with chart overlays (added in 2026).
+- **[MACDVMomentumStateStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/MACDVMomentumStateStrategy.java)** – demonstrates volatility-normalized MACD-V momentum states with chart overlays (0.22.x+).
 - **[UnstableIndicatorStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/UnstableIndicatorStrategy.java)** – demonstrates how to handle indicators that require long warm-up periods.
 - **[WalkForward](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java)** – complete walk-forward optimization loop.
 
@@ -95,7 +95,7 @@ Strategy examples that use charting:
 ## Bots & live trading
 
 - **[TradingBotOnMovingBarSeries](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingBarSeries.java)** – continuously updates a moving bar series and reacts to strategy signals.
-- **[WyckoffCycleIndicatorSuiteDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/wyckoff/WyckoffCycleIndicatorSuiteDemo.java)** – one-shot and streaming Wyckoff cycle analysis demo (added in 2026).
+- **[WyckoffCycleIndicatorSuiteDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/wyckoff/WyckoffCycleIndicatorSuiteDemo.java)** – one-shot and streaming Wyckoff cycle analysis demo (0.22.x+).
 - **ConcurrentBarSeries for live trading**: Since 0.22.2, use `ConcurrentBarSeries` for thread-safe bar ingestion in multi-threaded live trading scenarios. See [Live Trading](Live-trading.md) and [Bar Series & Bars](Bar-series-and-bars.md#concurrent-bar-series-for-multi-threaded-scenarios) for comprehensive documentation and examples.
 - **LiveTradingRecord (partial fills, cost basis, position book)**: For bots that receive partial fills or need per-lot cost basis and unrealized PnL, use `LiveTradingRecord` with `recordFill(ExecutionFill)` or `enter`/`exit`. See the [Live Trading – LiveTradingRecord walkthrough](Live-trading.md#walkthrough-livetradingrecord-with-partial-fills-and-cost-basis) for a step-by-step code guide and criteria (`OpenPositionCostBasisCriterion`, `OpenPositionUnrealizedProfitCriterion`).
 

--- a/VWAP-Support-Resistance-and-Wyckoff.md
+++ b/VWAP-Support-Resistance-and-Wyckoff.md
@@ -81,17 +81,23 @@ WyckoffPhaseIndicator wyckoff = WyckoffPhaseIndicator.builder(series)
         .withVolumeThresholds(num.numOf("1.6"), num.numOf("0.7"))
         .build();
 
-// Optional: facade API for cycle + phase access
+// Optional high-level alternative: use the facade when you want cycle + phase context
+// and trading-range helpers from one entrypoint.
 WyckoffCycleFacade wyckoffFacade = WyckoffCycleFacade.builder(series)
         .withSwingConfiguration(2, 2, 1)
         .withVolumeWindows(5, 20)
         .withTolerances(num.numOf("0.02"), num.numOf("0.05"))
         .withVolumeThresholds(num.numOf("1.6"), num.numOf("0.7"))
         .build();
+
+// Facade helpers
+WyckoffPhase facadePhase = wyckoffFacade.phase(series.getEndIndex());
+Num rangeLow = wyckoffFacade.tradingRangeLow(series.getEndIndex());
+Num rangeHigh = wyckoffFacade.tradingRangeHigh(series.getEndIndex());
 ```
 
-Recent code drift note (last ~120 days):
-- ta4j commit `39194498` introduced/expanded this stack materially (VWAP derivatives, support/resistance families, and Wyckoff cycle facade/analysis). The map above reflects the current class surface in `org.ta4j.core.indicators.volume`, `supportresistance`, and `wyckoff`.
+Recent code drift note:
+- In ta4j `0.22.3` (commit `39194498`), this stack was expanded materially (VWAP derivatives, support/resistance families, and Wyckoff cycle facade/analysis). The map above reflects the current class surface in `org.ta4j.core.indicators.volume`, `supportresistance`, and `wyckoff`.
 
 ## Backtesting how-to
 
@@ -114,17 +120,21 @@ strategy.setUnstableBars(unstableBars);
 ```java
 int i = series.getEndIndex();
 Num price = close.getValue(i);
-WyckoffPhase phase = wyckoff.getValue(i);
+WyckoffPhase phase = wyckoff.getValue(i);           // low-level indicator path
+WyckoffPhase cyclePhase = wyckoffFacade.phase(i);   // high-level facade path
+Num cycleRangeLow = wyckoffFacade.tradingRangeLow(i);
 
 boolean inAccumulationAdvance = phase.cycleType() == WyckoffCycleType.ACCUMULATION
         && (phase.phaseType() == WyckoffPhaseType.PHASE_D || phase.phaseType() == WyckoffPhaseType.PHASE_E)
         && phase.confidence() >= 0.75;
+boolean cycleAgrees = cyclePhase.cycleType() == WyckoffCycleType.ACCUMULATION;
 
 boolean aboveValue = price.isGreaterThan(vwap.getValue(i));
 boolean notOverextended = zScore.getValue(i).isLessThan(num.numOf("2.0"));
 boolean nearSupport = price.minus(support.getValue(i)).abs().isLessThanOrEqual(num.numOf("0.5"));
+boolean nearCycleRangeLow = price.minus(cycleRangeLow).abs().isLessThanOrEqual(num.numOf("0.5"));
 
-if (inAccumulationAdvance && aboveValue && notOverextended && nearSupport) {
+if (inAccumulationAdvance && cycleAgrees && aboveValue && notOverextended && nearSupport && nearCycleRangeLow) {
     // candidate long condition
 }
 ```

--- a/VWAP-Support-Resistance-and-Wyckoff.md
+++ b/VWAP-Support-Resistance-and-Wyckoff.md
@@ -35,11 +35,15 @@ Combined, they answer:
   weighted price clustering in a rolling lookback.
 - `BounceCountSupportIndicator` / `BounceCountResistanceIndicator`:
   bounce-frequency-driven zones.
+- `TrendLineSupportIndicator` / `TrendLineResistanceIndicator`:
+  linear regression trendline support/resistance over rolling windows.
 
 ### Wyckoff family
 
 - `WyckoffPhaseIndicator`: phase inference engine (cycle + phase + confidence + latest event index).
 - `WyckoffPhase`: record with cycle type, phase type, confidence, and latest event index.
+- `WyckoffCycleFacade`: unified entry point wrapping phase indicator plus cycle-level helpers.
+- `WyckoffCycleAnalysis` / `WyckoffCycleAnalysisResult`: multi-degree cycle analysis utilities.
 - `WyckoffEventDetector`, `WyckoffStructureTracker`, `WyckoffVolumeProfile`:
   internal components used by the phase indicator.
 
@@ -65,6 +69,8 @@ PriceClusterSupportIndicator support = new PriceClusterSupportIndicator(close, v
         num.numOf("0.25"), num.numOf("0.5"));
 PriceClusterResistanceIndicator resistance = new PriceClusterResistanceIndicator(close, volume, 150,
         num.numOf("0.25"), num.numOf("0.5"));
+TrendLineSupportIndicator trendSupport = new TrendLineSupportIndicator(series, 2, 80);
+TrendLineResistanceIndicator trendResistance = new TrendLineResistanceIndicator(series, 2, 80);
 VolumeProfileKDEIndicator profile = new VolumeProfileKDEIndicator(close, volume, 150, num.numOf("0.5"));
 
 // 3) Phase context (Wyckoff)
@@ -74,7 +80,18 @@ WyckoffPhaseIndicator wyckoff = WyckoffPhaseIndicator.builder(series)
         .withTolerances(num.numOf("0.02"), num.numOf("0.05"))
         .withVolumeThresholds(num.numOf("1.6"), num.numOf("0.7"))
         .build();
+
+// Optional: facade API for cycle + phase access
+WyckoffCycleFacade wyckoffFacade = WyckoffCycleFacade.builder(series)
+        .withSwingConfiguration(2, 2, 1)
+        .withVolumeWindows(5, 20)
+        .withTolerances(num.numOf("0.02"), num.numOf("0.05"))
+        .withVolumeThresholds(num.numOf("1.6"), num.numOf("0.7"))
+        .build();
 ```
+
+Recent code drift note (last ~120 days):
+- ta4j commit `39194498` introduced/expanded this stack materially (VWAP derivatives, support/resistance families, and Wyckoff cycle facade/analysis). The map above reflects the current class surface in `org.ta4j.core.indicators.volume`, `supportresistance`, and `wyckoff`.
 
 ## Backtesting how-to
 


### PR DESCRIPTION
## Summary
- refresh wiki pages that drifted from ta4j core/examples APIs and recent history
- expand new-feature coverage for threshold-aware rules and supporting indicator API types
- update usage examples and inventory/documentation links to current classes

## Validation
- 
- internal markdown link check on all changed pages
- placeholder scan for TODO/TBD/FIXME in changed pages

@coderabbitai full review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New charting workflow with plan-based display/save; enriched backtest result & runtime reporting; many new indicators, facades and analysis results (Donchian, Elliott, Wyckoff, trendline S/R, VWAP variants); intraday strategies and data-source formats; threshold-aware/risk-gating rule types and two-stage trailing stop gain.

* **Documentation**
  * Expanded indicator inventory (≈247 entries), updated backtesting, examples, usage guides, and tuning/best-practice notes across the docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->