### PR TITLE
docs: refresh ta4j wiki drift coverage

### DIFF
--- a/Backtesting.md
+++ b/Backtesting.md
@@ -14,6 +14,13 @@ BarSeriesManager manager = new BarSeriesManager(series);
 TradingRecord record = manager.run(strategy);
 ```
 
+For short-first strategies, set `TradeType.SELL` on the strategy and `run(strategy)` will honor it:
+
+```java
+Strategy shortFirst = new BaseStrategy("short-first", entryRule, exitRule, Trade.TradeType.SELL);
+TradingRecord shortRecord = manager.run(shortFirst); // uses strategy.getStartingType()
+```
+
 ```java
 BacktestExecutor executor = new BacktestExecutor(series);
 BacktestExecutionResult result = executor.executeWithRuntimeReport(
@@ -32,8 +39,10 @@ List<TradingStatement> ranked = result.getTopStrategies(
 ## Get useful results
 
 - `TradingRecord` – chronological trades with entry/exit prices, costs, exposure, and net/gross PnL. Pass it into any criterion or build a `BaseTradingStatement`.
-- `BacktestExecutionResult` – wraps a `TradingRecord` plus execution metrics (runtime, bars processed, memory estimates). Great for profiling slow strategies.
+- `BacktestExecutionResult` – wraps the backtested `BarSeries`, ordered `TradingStatement` results, and a `BacktestRuntimeReport` (runtime metrics). Use it for batch ranking and runtime profiling.
 - `BacktestRuntimeReport` – aggregated stats from a `BacktestExecutor` run, used by the progress listener hook.
+
+> Rationale (drift sync): `BacktestExecutionResult` is defined as `BacktestExecutionResult(BarSeries, List<TradingStatement>, BacktestRuntimeReport)` in `org.ta4j.core.backtest.BacktestExecutionResult`, and criterion-score attachment behavior landed in commit `3fd8e9b8`.
 
 ## Backtesting VWAP, support/resistance, and Wyckoff stacks
 
@@ -81,6 +90,15 @@ Ta4j includes dozens of criteria organized by package:
 - `criteria.position.*` – streaks, max profit/loss per position, time in market, `PositionDurationCriterion` (mean/median/p95 style summaries), open-position cost basis and unrealized PnL when using `LiveTradingRecord`.
 
 Mix and match to build your own evaluation stack.
+
+You can standardize how returns are represented in reports:
+
+```java
+ReturnRepresentationPolicy.setDefaultRepresentation(ReturnRepresentation.DECIMAL);
+AnalysisCriterion netPct = new NetReturnCriterion(ReturnRepresentation.PERCENTAGE);
+```
+
+> Rationale (drift sync): return-format APIs are explicit in `org.ta4j.core.criteria.ReturnRepresentation` and `ReturnRepresentationPolicy` (commit `736db117`).
 
 ## Compare strategies
 

--- a/Bar-series-and-bars.md
+++ b/Bar-series-and-bars.md
@@ -34,7 +34,7 @@ series.addBar(series.barBuilder()
 
 Options to consider:
 
-- **Builders** – `TimeBarBuilder`, `TickBarBuilder`, `VolumeBarBuilder`, and the new `AmountBarBuilder` aggregate trades into bars by elapsed time, tick count, volume, or quote currency size respectively.
+- **Builders** – `TimeBarBuilder`, `TickBarBuilder`, `VolumeBarBuilder`, `AmountBarBuilder`, and `HeikinAshiBarBuilder` aggregate trades into bars by elapsed time, tick count, volume, quote-currency size, or Heikin-Ashi smoothing semantics.
 - **Begin vs. end timestamps** – Since 0.18 you can build bars anchored on begin time (`timePeriod` + `beginTime`) or end time. Use whichever matches your data source.
 - **Split series** – `series.getSubSeries(start, end)` and `series.split(...)` are handy for walk-forward tests or training/testing splits.
 - **Data Sources** – The `ta4j-examples` module includes ready-made data sources for loading historical data from APIs (Yahoo Finance, Coinbase) and files (CSV, JSON). See [Data Sources](Data-Sources.md) for comprehensive documentation.

--- a/Charting.md
+++ b/Charting.md
@@ -354,7 +354,7 @@ Here's a complete example from the ADX strategy:
 
 ```java
 // Build and run strategy
-BarSeries series = CsvTradesLoader.loadBitstampSeries();
+BarSeries series = BitStampCsvTradesFileBarSeriesDataSource.loadBitstampSeries();
 Strategy strategy = ADXStrategy.buildStrategy(series);
 BarSeriesManager seriesManager = new BarSeriesManager(series);
 TradingRecord tradingRecord = seriesManager.run(strategy);
@@ -531,7 +531,7 @@ chartWorkflow.displayChart(chart);
 Create a comprehensive performance dashboard with multiple analysis criteria:
 
 ```java
-BarSeries series = CsvTradesLoader.loadBitstampSeries();
+BarSeries series = BitStampCsvTradesFileBarSeriesDataSource.loadBitstampSeries();
 Strategy strategy = MyStrategy.buildStrategy(series);
 BarSeriesManager manager = new BarSeriesManager(series);
 TradingRecord record = manager.run(strategy);

--- a/Home.md
+++ b/Home.md
@@ -18,6 +18,7 @@ Your one-stop guide for building technical-analysis-driven trading systems in Ja
 - **Bill Williams toolkit** – Added `AlligatorIndicator`, `FractalHighIndicator` / `FractalLowIndicator`, `GatorOscillatorIndicator`, and `MarketFacilitationIndexIndicator` with a dedicated [Bill Williams Indicators](Bill-Williams-Indicators.md) guide.
 - **MACD-V momentum-state APIs** – Added momentum-state classification (`MACDVMomentumStateIndicator`, `MACDVMomentumProfile`) and rule integration helpers.
 - **New risk/quality criteria** – Added metrics like `SortinoRatioCriterion`, `PositionDurationCriterion`, and `RMultipleCriterion` for tighter backtest analysis.
+- **Threshold and risk guard rules** – Documented `AndWithThresholdRule`, `OrWithThresholdRule`, `OverOrEqualIndicatorRule`, and `RiskRewardRatioRule` patterns in [Trading Strategies](Trading-strategies.md#threshold-composition-and-risk-guards-0222).
 
 - **Unified return representation system** – Consistent formatting across all return-based criteria (multiplicative, decimal, percentage, logarithmic) via `ReturnRepresentation` and `ReturnRepresentationPolicy`
 - **New oscillators** – `TrueStrengthIndexIndicator`, `SchaffTrendCycleIndicator`, and `ConnorsRSIIndicator` expand oscillator coverage

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -30,6 +30,9 @@ For an overview of indicator categories and composition patterns, see [Technical
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core` | **Indicator** | Core ta4j indicator interface; typed value provider over bar indexes. |
+| `org.ta4j.core.indicators` | **AbstractIndicator** | Base class for indicator implementations; provides common defaults (for example stability contract). |
+| `org.ta4j.core.indicators` | **CachedIndicator** | Caching base indicator with mutation-aware latest-bar invalidation. |
+| `org.ta4j.core.indicators` | **RecursiveCachedIndicator** | CachedIndicator variant for recursive calculations. |
 | `org.ta4j.core.indicators.helpers` | **ClosePriceIndicator** | Returns the close price of a bar. |
 | `org.ta4j.core.indicators.helpers` | **OpenPriceIndicator** | Returns the open price of a bar. |
 | `org.ta4j.core.indicators.helpers` | **HighPriceIndicator** | Returns the high price of a bar. |
@@ -38,10 +41,10 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.helpers` | **MedianPriceIndicator** | Median price (high + low) / 2. |
 | `org.ta4j.core.indicators.helpers` | **TRIndicator** | True Range: max(high−low, |high−prevClose|, |low−prevClose|). |
 | `org.ta4j.core.indicators.helpers` | **VolumeIndicator** | Returns the volume of a bar. |
-| `org.ta4j.core.indicators.helpers` | **ClosePriceDifferenceIndicator** | Difference between current and previous close (extends DifferenceIndicator). |
+| `org.ta4j.core.indicators.helpers` | **ClosePriceDifferenceIndicator** | Deprecated: difference between current and previous close (use `DifferenceIndicator` + `ClosePriceIndicator`). |
 | `org.ta4j.core.indicators.helpers` | **ClosePriceRatioIndicator** | Ratio of current close to previous close. |
 | `org.ta4j.core.indicators.helpers` | **DifferenceIndicator** | Difference between two indicators or consecutive values. |
-| `org.ta4j.core.indicators.helpers` | **DifferencePercentageIndicator** | Percentage difference between two indicators. |
+| `org.ta4j.core.indicators.helpers` | **DifferencePercentageIndicator** | Deprecated: percentage difference between two indicators (use `PercentageChangeIndicator`). |
 | `org.ta4j.core.indicators.helpers` | **GainIndicator** | Positive price changes (gains) from the source indicator. |
 | `org.ta4j.core.indicators.helpers` | **LossIndicator** | Absolute value of negative price changes (losses). |
 | `org.ta4j.core.indicators.helpers` | **HighestValueIndicator** | Highest value of the source indicator over a bar count. |
@@ -50,7 +53,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.helpers` | **SumIndicator** | Sum of the source indicator over a bar count. |
 | `org.ta4j.core.indicators.helpers` | **AverageIndicator** | Average (mean) of the source indicator over a bar count. |
 | `org.ta4j.core.indicators.helpers` | **RunningTotalIndicator** | Running sum of the source indicator. |
-| `org.ta4j.core.indicators.helpers` | **CombineIndicator** | Combines two indicators with a binary operator (e.g. add, subtract). |
+| `org.ta4j.core.indicators.helpers` | **CombineIndicator** | Deprecated compatibility wrapper; combine via `BinaryOperationIndicator`. |
 | `org.ta4j.core.indicators.helpers` | **ConstantIndicator** | Constant value at every index. |
 | `org.ta4j.core.indicators.helpers` | **FixedNumIndicator** | Fixed numeric value; useful for testing or thresholds. |
 | `org.ta4j.core.indicators.helpers` | **FixedBooleanIndicator** | Fixed boolean value. |
@@ -105,6 +108,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.averages` | **ZLEMAIndicator** | Zero-lag exponential moving average. |
 | `org.ta4j.core.indicators.averages` | **ATMAIndicator** | Asymmetric triangular moving average. |
 | `org.ta4j.core.indicators.averages` | **KiJunV2Indicator** | Kihon (Ichimoku-style) midpoint of high-low range over period. |
+| `org.ta4j.core.indicators.averages` | **AbstractEMAIndicator** | Shared EMA-style smoothing base with stable NaN/reset behavior. |
 
 **Short usage**  
 - **What it is:** Smoothing of price (or other series) over a window; type varies (simple, exponential, weighted, adaptive).  
@@ -238,6 +242,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.volume` | **OnBalanceVolumeIndicator** | OBV: cumulative volume signed by close direction. |
+| `org.ta4j.core.indicators.volume` | **AbstractVWAPIndicator** | Base class for VWAP-derived indicators sharing VWAP accumulation logic. |
 | `org.ta4j.core.indicators.volume` | **AccumulationDistributionIndicator** | A/D: cumulative volume weighted by CLV. |
 | `org.ta4j.core.indicators.volume` | **ChaikinMoneyFlowIndicator** | CMF: volume-weighted money flow over period. |
 | `org.ta4j.core.indicators.volume` | **ChaikinOscillatorIndicator** | Chaikin Oscillator (A/D short − long EMA). |
@@ -272,6 +277,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.candles` | **DojiIndicator** | True when bar is doji (open ≈ close). |
+| `org.ta4j.core.indicators.candles` | **AbstractMarubozuIndicator** | Base implementation for marubozu-style candlestick pattern indicators. |
 | `org.ta4j.core.indicators.candles` | **RealBodyIndicator** | Size of real body (|close − open|). |
 | `org.ta4j.core.indicators.candles` | **UpperShadowIndicator** | Upper shadow (high − max(open, close)). |
 | `org.ta4j.core.indicators.candles` | **LowerShadowIndicator** | Lower shadow (min(open, close) − low). |
@@ -313,13 +319,17 @@ For an overview of indicator categories and composition patterns, see [Technical
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.supportresistance` | **TrendLineSupportIndicator** | Support level from trend line (e.g. swing lows). |
 | `org.ta4j.core.indicators.supportresistance` | **TrendLineResistanceIndicator** | Resistance level from trend line. |
+| `org.ta4j.core.indicators.supportresistance` | **AbstractTrendLineIndicator** | Base class for trend-line support/resistance indicators. |
 | `org.ta4j.core.indicators.supportresistance` | **BounceCountSupportIndicator** | Support estimate from clustered bounce frequency below/around price levels. |
 | `org.ta4j.core.indicators.supportresistance` | **BounceCountResistanceIndicator** | Resistance estimate from clustered bounce frequency above/around price levels. |
+| `org.ta4j.core.indicators.supportresistance` | **AbstractBounceCountIndicator** | Base class for bounce-count support/resistance indicators. |
 | `org.ta4j.core.indicators.supportresistance` | **PriceClusterSupportIndicator** | Support levels from close-price clustering with configurable tolerance. |
 | `org.ta4j.core.indicators.supportresistance` | **PriceClusterResistanceIndicator** | Resistance levels from close-price clustering with configurable tolerance. |
+| `org.ta4j.core.indicators.supportresistance` | **AbstractPriceClusterIndicator** | Base class for price-cluster support/resistance indicators. |
 | `org.ta4j.core.indicators.supportresistance` | **VolumeProfileKDEIndicator** | Smoothed volume-at-price profile using kernel density estimation. |
 | `org.ta4j.core.indicators.wyckoff` | **WyckoffPhaseIndicator** | Inferred Wyckoff phase classification from structural/volume context. |
 | `org.ta4j.core.indicators.pivotpoints` | **PivotPointIndicator** | Standard pivot point (and optionally R1/R2/S1/S2). |
+| `org.ta4j.core.indicators.pivotpoints` | **AbstractPivotPointIndicator** | Base class for session-aware pivot-point indicators. |
 | `org.ta4j.core.indicators.pivotpoints` | **DeMarkPivotPointIndicator** | DeMark pivot points. |
 | `org.ta4j.core.indicators.pivotpoints` | **StandardReversalIndicator** | Reversal level from standard pivots. |
 | `org.ta4j.core.indicators.pivotpoints` | **DeMarkReversalIndicator** | DeMark reversal levels. |
@@ -341,8 +351,11 @@ For an overview of indicator categories and composition patterns, see [Technical
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators` | **RecentSwingIndicator** | Generic recent swing (e.g. value at last swing). |
+| `org.ta4j.core.indicators` | **AbstractRecentSwingIndicator** | Base class for recent swing indicators. |
 | `org.ta4j.core.indicators` | **FractalHighIndicator** | Bill Williams fractal high confirmation indicator (no look-ahead). |
 | `org.ta4j.core.indicators` | **FractalLowIndicator** | Bill Williams fractal low confirmation indicator (no look-ahead). |
+| `org.ta4j.core.indicators` | **AbstractFractalConfirmationIndicator** | Base class for confirmed fractal indicators. |
+| `org.ta4j.core.indicators` | **AbstractRecentFractalSwingIndicator** | Base class for recent fractal swing indicators. |
 | `org.ta4j.core.indicators` | **RecentFractalSwingHighIndicator** | Most recent fractal swing high (Bill Williams style). |
 | `org.ta4j.core.indicators` | **RecentFractalSwingLowIndicator** | Most recent fractal swing low. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagPivotHighIndicator** | True at ZigZag pivot high bars. |

--- a/Moving-Average-Indicators.md
+++ b/Moving-Average-Indicators.md
@@ -42,6 +42,7 @@ Moving averages are versatile tools used in a variety of ways:
 |--------------|-----------------------------------------------|----------------------------|--------------------------------|
 | ATMA         | Asymmetric Triangular Moving Average          | ATMAIndicator              | Specialized Moving Average     |
 | DEMA         | Double Exponential Moving Average             | DoubleEMAIndicator         | Exponential Moving Average     |
+| DFMA         | Distance From Moving Average                  | DistanceFromMAIndicator    | MA-Derived Indicator           |
 | DMA          | Displaced Moving Average                      | DMAIndicator               | Specialized Moving Average     |
 | EDMA         | Exponential Displaced Moving Average          | EDMAIndicator              | Exponential Moving Average     |
 | EMA          | Exponential Moving Average                    | EMAIndicator               | Exponential Moving Average     |
@@ -58,14 +59,16 @@ Moving averages are versatile tools used in a variety of ways:
 | SMMA         | Smoothed Moving Average                       | SMMAIndicator              | Smoothed Moving Average        |
 | TEMA         | Triple Exponential Moving Average             | TripleEMAIndicator         | Exponential Moving Average     |
 | TMA          | Triangular Moving Average                     | TMAIndicator               | Simple Moving Average          |
-| VIDYA        | Chandes Variable Index Dynamic Moving Average | VIDYAIndicator             | Adaptive Moving Average        |
+| VIDYA        | Chande's Variable Index Dynamic Moving Average | VIDYAIndicator            | Adaptive Moving Average        |
 | VWMA         | Volume Weighted Moving Average                | VWMAIndicator              | Weighted Moving Average        |
-| WilderMA     | Wilders Moving Average                        | WildersMAIndicator         | Smoothed Moving Average        |
+| WilderMA     | Wilder's Moving Average                       | WildersMAIndicator         | Smoothed Moving Average        |
 | WMA          | Weighted Moving Average                       | WMAIndicator               | Weighted Moving Average        |
 | ZLEMA        | Zero Lag Exponential Moving Average           | ZLEMAIndicator             | Exponential Moving Average     |
 
 
 ## Classification of Moving Averages
+
+Most moving-average classes are in `org.ta4j.core.indicators.averages` (moved in commit `55a4eec8`, 2024-12-04). `DistanceFromMAIndicator` remains in `org.ta4j.core.indicators`.
 
 ### 1. Simple Moving Averages
 - These averages assign equal weight to all data points in the period.
@@ -128,6 +131,13 @@ Moving averages are versatile tools used in a variety of ways:
   - ATMA (Asymmetric Triangular Moving Average)
   - KiJunV2 (Kihon Moving Average)
   - DMA (Displaced Moving Average)
+
+---
+
+### 8. MA-Derived Indicators
+- These indicators use one or more moving averages as an internal baseline.
+- **Indicators**:
+  - DFMA (Distance From Moving Average)
 
 
 

--- a/Stop-Loss-and-Stop-Gain-Rules.md
+++ b/Stop-Loss-and-Stop-Gain-Rules.md
@@ -98,6 +98,15 @@ Several rules implement:
 
 This lets you query stop prices directly (for example in risk budgeting or custom position sizing flows) without duplicating threshold math.
 
+You can also call static helpers for deterministic threshold calculations in custom flows:
+
+```java
+Num hardLoss = StopLossRule.stopLossPrice(entryPrice, lossPercent, true);
+Num hardGain = StopGainRule.stopGainPrice(entryPrice, gainPercent, true);
+```
+
+> Rationale (drift sync): stop model interfaces and helper methods are now first-class in `org.ta4j.core.rules.StopLossRule` / `StopGainRule`, and ATR-based stop constructors were expanded in commits `89cd2271` and `1fa097ef`.
+
 ## Live trading usage patterns
 
 ### 1) Match your reference price to execution reality

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -1,22 +1,23 @@
 # Technical Indicators
 
-Technical indicators (a.k.a. *technicals*) transform price/volume data into structured signals that power rules and strategies. ta4j ships with 130+ indicators covering every major category plus building blocks for your own creations.
+Technical indicators (a.k.a. *technicals*) transform price/volume data into structured signals that power rules and strategies. ta4j ships with hundreds of indicators covering major categories plus building blocks for your own creations.
 
 **Exhaustive list:** For a full inventory of all indicators in ta4j-core and ta4j-examples (fully qualified names, class names, short descriptions, and usage notes), see [Indicators Inventory](Indicators-Inventory.md).
 
 | Category | Highlights | Docs |
 | --- | --- | --- |
-| Trend / Moving Averages | SMA, EMA, HMA, VIDYA, Jurik, Displaced variants, SuperTrend, Renko helpers. | [Moving Average Indicators](Moving-Average-Indicators.md) |
-| Momentum & Oscillators | RSI family, NetMomentum (new), MACD/MACDV, MACD-V momentum states, KST, Stochastics, CMO, ROC. | This page |
-| Volatility & Bands | ATR, Donchian, Bollinger, Keltner, Average True Range trailing stops. | [Bar Series & Bars](Bar-series-and-bars.md) (for ATR-based stops) |
-| Volume & Breadth | OBV, VWAP/VWMA, Accumulation/Distribution, Chaikin, Volume spikes. | Indicators package |
-| Market Structure (VWAP/SR/Wyckoff) | Anchored VWAP, VWAP bands/z-score, price clusters, bounce counts, KDE volume profile, Wyckoff phase detection. | [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md) |
+| Trend / Moving Averages | SMA, EMA, HMA, VIDYA, Jurik, displaced variants, ADX/DI, Aroon, SuperTrend, and MA-derived indicators. | [Moving Average Indicators](Moving-Average-Indicators.md) |
+| Momentum & Oscillators | RSI family, NetMomentum, MACD/MACD-V, MACD-V momentum states, KST, Stochastics, CMO, ROC. | This page |
+| Volatility & Bands | ATR, Donchian, Bollinger, Keltner, Chandelier exits, Squeeze Pro. | [Bar Series & Bars](Bar-series-and-bars.md) |
+| Volume & Breadth | OBV, VWAP/VWMA/MVWAP, Accumulation/Distribution, Chaikin family, MFI, NVI/PVI, relative-volume indicators. | [Indicators Inventory](Indicators-Inventory.md) |
+| Market Structure (VWAP/SR/Wyckoff) | Anchored VWAP, VWAP bands/z-score, price clusters, bounce counts, trend lines, KDE volume profile, Wyckoff phase/cycle analysis. | [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md) |
 | Bill Williams Toolkit | Alligator (jaw/teeth/lips), FractalHigh/Low, Gator Oscillator, Market Facilitation Index. | [Bill Williams Indicators](Bill-Williams-Indicators.md) |
 | Candle/Pattern | Hammer, Shooting Star, Three White Soldiers, DownTrend/UpTrend. | `indicators.candles` |
-| Price Transformations | RenkoUp/Down/X (0.19), Heikin Ashi builders, `BinaryOperationIndicator`/`UnaryOperationIndicator` transforms. | `indicators.renko` |
-| Oscillators | TrueStrengthIndex, SchaffTrendCycle, ConnorsRSI (0.21.0), RSI family, MACD/MACDV, KST, Stochastics, CMO, ROC. | This page |
+| Wave & Swing Structure | ZigZag state/pivots/recent swings and Elliott scenario/confidence/trend-bias toolchain. | [Trendlines & Swing Points](Trendlines-and-Swing-Points.md), [Elliott Wave Indicators](Elliott-Wave-Indicators.md) |
+| Price Transformations / Numeric Ops | RenkoUp/Down/X (0.19), Heikin Ashi builders, `BinaryOperationIndicator`/`UnaryOperationIndicator`/`NumericIndicator`. | [Indicators Inventory](Indicators-Inventory.md) |
+| Ichimoku / Pivot / Statistics | Ichimoku lines, pivot-point/reversal indicators, and statistics/regression indicators. | [Indicators Inventory](Indicators-Inventory.md) |
 
-Browse `org.ta4j.core.indicators` in your IDE for the full list—packages mirror the table above.
+Browse `org.ta4j.core.indicators` in your IDE for the full list. The table above is representative; [Indicators Inventory](Indicators-Inventory.md) is the exhaustive source of truth.
 
 ## Composition example
 
@@ -31,7 +32,7 @@ Indicator<Num> trendBias = BinaryOperationIndicator.division(fast, slow);
 Indicator<Num> blendedMomentum = BinaryOperationIndicator.add(macdv.getMacd(), netMomentum);
 ```
 
-- `BinaryOperationIndicator` / `UnaryOperationIndicator` replace the older `TransformIndicator`/`CombineIndicator` classes (removed in 0.19, enhanced in 0.21.0).
+- `BinaryOperationIndicator` / `UnaryOperationIndicator` are the preferred composition APIs. `TransformIndicator` has been removed, while `CombineIndicator` remains as a deprecated compatibility class.
 - Output indicators can feed directly into rules (`new OverIndicatorRule(trendBias, numOf(1.0))`) or become inputs to other indicators.
 
 ## Market structure workflow (VWAP + S/R + Wyckoff)
@@ -39,12 +40,23 @@ Indicator<Num> blendedMomentum = BinaryOperationIndicator.add(macdv.getMacd(), n
 ta4j now includes a complete workflow for value, location, and phase analysis:
 
 - Value: `VWAPIndicator`, `AnchoredVWAPIndicator`, `VWAPBandIndicator`, `VWAPZScoreIndicator`
-- Location: `PriceClusterSupportIndicator`, `PriceClusterResistanceIndicator`, `BounceCountSupportIndicator`, `BounceCountResistanceIndicator`, `VolumeProfileKDEIndicator`
-- Phase: `WyckoffPhaseIndicator`
+- Location: `PriceClusterSupportIndicator`, `PriceClusterResistanceIndicator`, `BounceCountSupportIndicator`, `BounceCountResistanceIndicator`, `TrendLineSupportIndicator`, `TrendLineResistanceIndicator`, `VolumeProfileKDEIndicator`
+- Phase/Cycle: `WyckoffPhaseIndicator`, `WyckoffCycleFacade`
 
 Use the dedicated guide for implementation templates and tuning advice:
 
 - [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md)
+
+## Wave-structure workflow (ZigZag + Elliott)
+
+ta4j includes a complete swing/structure toolchain for pattern-based analysis:
+
+- Swing extraction: `ZigZagStateIndicator`, `RecentZigZagSwingHighIndicator`, `RecentZigZagSwingLowIndicator`
+- Elliott interpretation: `ElliottWaveFacade`, `ElliottScenarioIndicator`, `ElliottTrendBiasIndicator`, `ElliottConfidenceScorer`
+
+Use:
+- [Trendlines & Swing Points](Trendlines-and-Swing-Points.md)
+- [Elliott Wave Indicators](Elliott-Wave-Indicators.md)
 
 ## Bill Williams workflow (0.22.3)
 
@@ -73,10 +85,11 @@ Indicators should be evaluated the same way strategies are—prefer realistic da
 
 ## Caching & stability
 
-- Every indicator extends `CachedIndicator`, so once a value is computed (except for the most recent bar) it is reused.
-- Mutating the latest bar (common with streaming data) invalidates just that slot; the rest stays cached.
-- Use `indicator.getCountOfUnstableBars()` / `indicator.isStable(index)` to understand when the values become reliable (and pass that number to `strategy.setUnstableBars(...)`).
-- When using moving `BarSeries` via `setMaximumBarCount`, cached entries older than the oldest remaining bar disappear. Always guard against `NaN` if you try to access evicted indexes.
+- Most implementations use `CachedIndicator`/`RecursiveCachedIndicator`; some thin wrappers extend `AbstractIndicator` and delegate to cached components (for example `ATRIndicator`, `KRIIndicator`).
+- Latest-bar values are cached with mutation-aware invalidation; when the current bar changes, only that slot is recomputed.
+- Use `indicator.getCountOfUnstableBars()` for warm-up size. For per-index checks, use `index >= indicator.getCountOfUnstableBars()`; for whole-series checks, use `indicator.isStable()`.
+- For strategies, pass warm-up via `strategy.setUnstableBars(...)`.
+- With moving `BarSeries` (`setMaximumBarCount`), evicted bars and their cache entries are not recoverable.
 
 ## Creating custom indicators
 
@@ -84,7 +97,7 @@ Sub-class `CachedIndicator<Num>` or compose existing indicators with operations.
 
 - Accept dependencies via constructor injections (`Indicator<Num> base`) rather than pulling directly from a `BarSeries`.
 - Respect the `Num` abstraction: use `Num` arithmetic (`plus`, `minus`, etc.) and produce values via the series `NumFactory`.
-- Override `getUnstableBars()` / `isStable()` when your indicator requires warm-up bars (e.g., multi-stage EMAs).
+- Override `getCountOfUnstableBars()` when your indicator requires warm-up bars (e.g., multi-stage EMA pipelines).
 - If you need state across indices, store it in the indicator (ta4j handles thread safety by design if you limit state to the calculation path).
 
 ## Tips
@@ -93,7 +106,7 @@ Sub-class `CachedIndicator<Num>` or compose existing indicators with operations.
 - When working with unconventional chart types (Renko, Heikin Ashi), prefer the dedicated builders/indicators shipped in 0.18/0.19/0.21.0—they keep the math consistent across strategies.
 - Combine price- and volume-driven indicators to reduce false positives (e.g., `new AndIndicatorRule(new OverIndicatorRule(macdv, zero), new OverIndicatorRule(vwma, close))`).
 - Document indicator usage inside strategies so others know the intent—especially if the indicator is non-standard or parameter-sensitive.
-Technicals also need to be backtested on historic data to see how effective they would have been to predict future prices. [Some examples](Usage-examples.html) are available in this sense.
+Technicals also need to be backtested on historic data to see how effective they would have been in predicting future prices. [Some examples](Usage-examples.md#playing-with-indicators) are available for this.
 
 ### Visualizing indicators
 
@@ -110,9 +123,3 @@ chartWorkflow.builder()
     .withLineColor(Color.ORANGE)
     .display();
 ```
-
-### Caching mechanism
-
-Some indicators need recursive calls and/or values from the previous bars in order to calculate their last value. For that reason, a caching mechanism has been implemented for all the indicators provided by ta4j. This system avoids calculating the same value twice. Therefore, if a value has been already calculated it is retrieved from cache the next time it is requested. **Values for the last Bar will not be cached**. This allows you to modify the last bar of the BarSeries by adding price/trades to it and to recalculate results with indicators.
-
-**Warning!** If a maximum bar count has been set for the related bar Series, then the results calculated for evicted bars are evicted too. They also cannot be recomputed since the related bars have been removed. That being said, moving bar Series should not be used when you need to access long-term past bars.

--- a/Trading-strategies.md
+++ b/Trading-strategies.md
@@ -26,15 +26,16 @@ Key points:
 
 - `Rule#isSatisfied(int index)` is stateless. Pass the `TradingRecord` when the rule depends on open positions or previous signals.
 - Composition is fluent (`and`, `or`, `xor`, `negation`), making it easy to express “enter when fast SMA crosses slow SMA **and** RSI recovers above 40.”
-- Since 0.19 you can use `VoteRule` to require agreement between multiple rules (e.g., "at least 3 out of 5 oscillators must agree"). In 0.21.0, return representation is unified across all criteria for consistent formatting.
-- `InSlopeRule` is satisfied when the slope of one indicator is within a boundary of another (e.g. for trend strength or momentum alignment).
+- Since 0.19 you can use `VoteRule` to require agreement between multiple rules (e.g., "at least 3 out of 5 oscillators must agree"). Return formatting can be controlled globally via `ReturnRepresentationPolicy` or per criterion via `ReturnRepresentation`.
+- `InSlopeRule` is satisfied when an indicator slope falls within configured numeric bounds (e.g. for trend strength or momentum alignment).
+- `HourOfDayRule` and `MinuteOfHourRule` let you gate entries/exits to explicit time windows without custom calendar code.
 
 ## Compose richer logic
 
 ```java
 Rule trendFilter = new OverIndicatorRule(sma200, sma400);
 Rule momentumKick = new CrossedUpIndicatorRule(macd, signalLine);
-Rule renkoBreak = new RenkoUpIndicator(series, brickSize);
+Rule renkoBreak = new BooleanIndicatorRule(new RenkoUpIndicator(series, brickSize));
 
 Indicator<Num> netMomentum = new NetMomentumIndicator(series);
 Rule entryRule = new VoteRule(2, trendFilter, momentumKick, renkoBreak)
@@ -56,6 +57,44 @@ The **exit** rule triggers if MACD crosses below its signal line, price falls 3%
 For the full stop toolkit (fixed %, fixed amount, trailing, volatility, ATR) and live-trading usage guidance, see [Stop Loss & Stop Gain Rules](Stop-Loss-and-Stop-Gain-Rules.md).
 
 Use numeric indicator helpers like `BinaryOperationIndicator` and `UnaryOperationIndicator` when you need on-the-fly math (ratios, differences, powers) without writing custom indicator classes—each helper still benefits from caching.
+
+## Threshold composition and risk guards (0.22.2+)
+
+Recent ta4j releases added rule primitives that let you express lookback-window conjunction/disjunction and explicit reward-to-risk gating without custom rule classes.
+
+```java
+Rule trigger = new CrossedUpIndicatorRule(fast, slow);
+Rule momentum = new OverOrEqualIndicatorRule(rsi, numOf(50));
+Rule trend = new OverOrEqualIndicatorRule(closePrice, sma200);
+
+// Entry is valid if BOTH rules have been satisfied at least once in the last 3 bars.
+Rule entryRule = new AndWithThresholdRule(trigger, momentum.and(trend), 3);
+
+Indicator<Num> stopPrice = new ConstantIndicator<>(series, numOf(95));
+Indicator<Num> targetPrice = new ConstantIndicator<>(series, numOf(110));
+Rule rrFloor = new RiskRewardRatioRule(closePrice, stopPrice, targetPrice, true, numOf(2.0));
+
+// Exit is valid if EITHER condition has been satisfied at least once in the last 2 bars.
+Rule protectiveExit = new OrWithThresholdRule(
+        new UnderOrEqualIndicatorRule(closePrice, stopPrice),
+        new OverOrEqualIndicatorRule(closePrice, targetPrice),
+        2
+).and(rrFloor);
+```
+
+Use these when:
+
+- You want two logical branches to be considered satisfied if they occur anywhere inside a rolling window (`AndWithThresholdRule` / `OrWithThresholdRule`).
+- You need inclusive comparisons (`>=` or `<=`) with `OverOrEqualIndicatorRule` / `UnderOrEqualIndicatorRule` to avoid strict inequality misses at exact levels.
+- You want entries or exits gated by a minimum projected reward-to-risk ratio via `RiskRewardRatioRule`.
+
+Compared with `VoteRule`, threshold rules evaluate two pre-composed branches over a lookback window, so they are often clearer for "condition A and condition B happened recently" logic.
+
+For Elliott-wave workflows, ta4j also ships scenario-aware rules in `org.ta4j.core.rules.elliott` (for example `ElliottScenarioValidRule`, `ElliottScenarioDirectionRule`, `ElliottScenarioRiskRewardRule`, `ElliottTrendBiasRule`, `ElliottImpulsePhaseRule`) so you can gate entries by wave validity, direction, and risk/reward state.
+
+> Rationale (drift sync): Elliott scenario and trend-bias rule coverage expanded in commit `bebb758e`.
+
+> Rationale (drift sync): threshold/window rules and serialization/time rule additions came in commit `b62d9bad`, including `AndWithThresholdRule`, `OrWithThresholdRule`, `HourOfDayRule`, and `MinuteOfHourRule`.
 
 ## MACD-V momentum-state filters (0.22.3)
 
@@ -82,6 +121,16 @@ Strategy strategy = new BaseStrategy("SMA + MACDV hybrid", entryRule, exitRule);
 strategy.setUnstableBars(30); // optional: indicators already report their own unstable window
 ```
 
+You can also choose short-first execution by defining the strategy starting type:
+
+```java
+Strategy shortFirst = new BaseStrategy(
+        "short breakout",
+        entryRule,
+        exitRule,
+        Trade.TradeType.SELL);
+```
+
 Running it is identical regardless of complexity:
 
 ```java
@@ -91,6 +140,8 @@ TradingRecord record = manager.run(strategy);
 
 `BarSeriesManager` wires your entry/exit rules to simulated orders, applies the configured cost/execution models, and returns a `TradingRecord` containing every trade so you can plug it into analysis criteria or ChartMaker visualizations.
 
+> Rationale (drift sync): `Strategy#getStartingType()` and `BaseStrategy(..., TradeType startingType)` are now first-class, and `org.ta4j.core.backtest.BarSeriesManager#run(Strategy)` defaults to `strategy.getStartingType()` (commit `b112d34b`).
+
 The same strategy class can be used in [backtests](Backtesting.md) and [live trading](Live-trading.md) contexts.
 
 ## Parameterizing and Named strategies
@@ -99,20 +150,42 @@ For reusable presets, implement `NamedStrategy`. The new registry system keeps c
 
 ```java
 public final class SmaCrossNamedStrategy extends NamedStrategy {
-    @Override
-    protected Strategy build(BarSeries series) {
+    public SmaCrossNamedStrategy(BarSeries series, int fastPeriod, int slowPeriod) {
+        super(buildLabel(
+                SmaCrossNamedStrategy.class,
+                String.valueOf(fastPeriod),
+                String.valueOf(slowPeriod)),
+                entryRule(series, fastPeriod, slowPeriod),
+                exitRule(series, fastPeriod, slowPeriod));
+    }
+
+    public SmaCrossNamedStrategy(BarSeries series, String... parameters) {
+        this(series, Integer.parseInt(parameters[0]), Integer.parseInt(parameters[1]));
+    }
+
+    private static Rule entryRule(BarSeries series, int fastPeriod, int slowPeriod) {
         ClosePriceIndicator close = new ClosePriceIndicator(series);
-        SMAIndicator fast = new SMAIndicator(close, parameters().getInt("fastPeriod"));
-        SMAIndicator slow = new SMAIndicator(close, parameters().getInt("slowPeriod"));
-        return new BaseStrategy(entryRule(fast, slow), exitRule(fast, slow));
+        SMAIndicator fast = new SMAIndicator(close, fastPeriod);
+        SMAIndicator slow = new SMAIndicator(close, slowPeriod);
+        return new CrossedUpIndicatorRule(fast, slow);
+    }
+
+    private static Rule exitRule(BarSeries series, int fastPeriod, int slowPeriod) {
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        SMAIndicator fast = new SMAIndicator(close, fastPeriod);
+        SMAIndicator slow = new SMAIndicator(close, slowPeriod);
+        return new CrossedDownIndicatorRule(fast, slow);
     }
 }
 
 NamedStrategy.initializeRegistry(SmaCrossNamedStrategy.class.getPackageName());
-Strategy preset = NamedStrategy.lookup("SmaCrossNamedStrategy_fast14_slow50").instantiate(series);
+Strategy preset = new SmaCrossNamedStrategy(series, "14", "50");
+Optional<Class<? extends NamedStrategy>> registered = NamedStrategy.lookup("SmaCrossNamedStrategy");
 ```
 
 In practice the registry maps friendly identifiers (like `fast14_slow50`) back to indicator wiring, so front-ends, parameter sweeps, or config files can request a preset without touching the Java source.
+
+> Rationale (drift sync): `RenkoUpIndicator` is an `Indicator<Boolean>` (`org.ta4j.core.indicators.renko.RenkoUpIndicator`), so it must be wrapped (for example with `BooleanIndicatorRule`) before `VoteRule` use. `NamedStrategy.lookup(...)` returns `Optional<Class<? extends NamedStrategy>>` (no `.instantiate(...)` API) in `org.ta4j.core.strategy.named.NamedStrategy`; registry/lookup behavior came from commits `eaeecdb2` and `87d6a227`.
 
 This is ideal for:
 
@@ -144,5 +217,5 @@ That JSON payload captures the full rule graph, making it safe to persist strate
 - Normalize indicator scales when combining oscillators with price-based rules.
 - Use `strategy.setUnstableBars(...)` (optional now that indicators track `getCountOfUnstableBars()`) and/or `Indicator.isStable()` to avoid acting before indicators warm up.
 - Encapsulate repeated rule snippets into helper methods or custom `Rule` implementations—readability matters when strategies grow complex.
-- Keep entry/exit rules symmetric when building short strategies, or wrap separate long/short strategies via `CombinedBuySellStrategy`.
+- Keep entry/exit rules symmetric when building short strategies, or keep separate long/short `Strategy` instances and run them with the desired `TradeType`.
 - When mixing timeframes or data sources, align them into the same `BarSeries` (or into multiple series managed by your own coordinator) to avoid implicit look-ahead.

--- a/Usage-examples.md
+++ b/Usage-examples.md
@@ -10,8 +10,8 @@ The [`ta4j-examples`](https://github.com/ta4j/ta4j/tree/master/ta4j-examples/src
 ## Bar series & `Num`
 
 - **[BuildBarSeries](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java)** – demonstrates bar builders, sub-series, and moving windows.
-- **[CsvBarsDataSource](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/CsvBarsDataSource.java)** / **[BitstampCsvTradesDataSource](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/BitstampCsvTradesDataSource.java)** – ingest historical OHLCV data.
-- **[AdaptiveJsonBarsSerializer](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/AdaptiveJsonBarsSerializer.java)** – parse Coinbase/Binance OHLC JSON payloads (introduced in 0.19).
+- **[CsvFileBarSeriesDataSource](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/CsvFileBarSeriesDataSource.java)** / **[BitStampCsvTradesFileBarSeriesDataSource](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/BitStampCsvTradesFileBarSeriesDataSource.java)** – ingest historical OHLCV and trade-level CSV data.
+- **[JsonFileBarSeriesDataSource](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/datasources/JsonFileBarSeriesDataSource.java)** – parse Coinbase/Binance OHLC JSON payloads via the adaptive JSON type adapter.
 - **[CompareNumTypes](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java)** – compare `DecimalNum` vs `DoubleNum` implementations
 - **[DecimalNumPrecisionPerformanceTest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/num/DecimalNumPrecisionPerformanceTest.java)** – benchmark precision vs. performance trade-offs for `DecimalNum` (see [Num](Num.md#performance-characteristics) for details)
 
@@ -71,8 +71,8 @@ Strategy examples that use charting:
 
 - **[SimpleMovingAverageBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java)** / **[SimpleMovingAverageRangeBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageRangeBacktest.java)** – baseline moving-average crossover tests.
 - **[MovingAverageCrossOverRangeBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/MovingAverageCrossOverRangeBacktest.java)** – parameter sweeps over SMA periods.
-- **[MultiStrategyBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/MultiStrategyBacktest.java)** – evaluate several strategies across the same dataset.
-- **[TopStrategiesExample](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtest/TopStrategiesExample.java)** – uses the `BacktestExecutor` (introduced in 0.19) to keep a rolling leaderboard of strategies.
+- **[BacktestPerformanceTuningHarness](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java)** – benchmark indicator-heavy backtests and optimization settings on larger datasets.
+- **[YahooFinanceBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/YahooFinanceBacktest.java)** / **[CoinbaseBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/backtesting/CoinbaseBacktest.java)** – run backtests with HTTP-sourced market data.
 - **[CashFlowToChart](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java)** and **[BuyAndSellSignalsToChart](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java)** – visualize equity curves and trade signals.
 - **[TradeCost](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/TradeCost.java)** – study how transaction/holding costs impact returns.
 - **[StrategyExecutionLogging](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/logging/StrategyExecutionLogging.java)** – trace rule evaluations line-by-line.
@@ -92,6 +92,7 @@ Strategy examples that use charting:
 ## Bots & live trading
 
 - **[TradingBotOnMovingBarSeries](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingBarSeries.java)** – continuously updates a moving bar series and reacts to strategy signals.
+- **[MACDVMomentumStateStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/MACDVMomentumStateStrategy.java)** – demonstrates MACD-V momentum-state strategy wiring for regime-aware entries/exits.
 - **ConcurrentBarSeries for live trading**: Since 0.22.2, use `ConcurrentBarSeries` for thread-safe bar ingestion in multi-threaded live trading scenarios. See [Live Trading](Live-trading.md) and [Bar Series & Bars](Bar-series-and-bars.md#concurrent-bar-series-for-multi-threaded-scenarios) for comprehensive documentation and examples.
 - **LiveTradingRecord (partial fills, cost basis, position book)**: For bots that receive partial fills or need per-lot cost basis and unrealized PnL, use `LiveTradingRecord` with `recordFill(ExecutionFill)` or `enter`/`exit`. See the [Live Trading – LiveTradingRecord walkthrough](Live-trading.md#walkthrough-livetradingrecord-with-partial-fills-and-cost-basis) for a step-by-step code guide and criteria (`OpenPositionCostBasisCriterion`, `OpenPositionUnrealizedProfitCriterion`).
 


### PR DESCRIPTION
## Summary
- reconcile wiki pages with recent ta4j core/examples drift
- refresh indicator inventory and indicator docs for current surface area
- fix stale examples/data-source/chart snippets and add strategy rule coverage

## Validation
- git status --short
- git diff --check
- internal markdown link scan on changed pages
- placeholder scan (TODO/TBD/FIXME) on changed pages

@coderabbitai full review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new base indicator classes and helper methods for stop loss/gain price calculations.
  * Introduced threshold composition patterns and risk guard rules in strategy documentation.
  * Added new moving-average derived indicators and data source variants for backtesting.

* **Documentation**
  * Expanded technical indicator inventory with hundreds of indicators and wave-structure guidance.
  * Updated backtesting guidance with new execution patterns and return representation standardization.
  * Enhanced trading strategy documentation with improved rule formatting and short-first strategy examples.

* **Deprecations**
  * Marked select indicators as deprecated with migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->