### PR TITLE
docs: refresh ta4j wiki drift coverage

### DIFF
--- a/Backtesting.md
+++ b/Backtesting.md
@@ -31,7 +31,7 @@ List<TradingStatement> ranked = result.getTopStrategies(
 
 ## Get useful results
 
-- `TradingRecord` – chronological trades with entry/exit prices, costs, exposure, and net/gross PnL. Pass it into any criterion or build a `BaseTradingStatement`.
+- `TradingRecord` – chronological trades/positions plus configured transaction and holding cost models. Pass it into criteria directly, or generate a `TradingStatement` for richer reports.
 - `BacktestExecutionResult` – wraps the evaluated `TradingStatement` list plus a `BacktestRuntimeReport`; use it to keep both ranking data and runtime context together.
 - `BacktestRuntimeReport` – aggregated timing stats from a `BacktestExecutor` run (overall/min/max/average/median and per-strategy runtimes).
 
@@ -51,7 +51,7 @@ AnalysisCriterion net = new NetReturnCriterion();
 AnalysisCriterion buyHold = new VersusEnterAndHoldCriterion(new NetReturnCriterion());
 AnalysisCriterion romad = new ReturnOverMaxDrawdownCriterion();
 AnalysisCriterion sharpe = new SharpeRatioCriterion();
-AnalysisCriterion sortino = new SortinoRatioCriterion(0.05, SamplingFrequency.DAILY, Annualization.ANNUALIZED, ZoneOffset.UTC);
+AnalysisCriterion sortino = new SortinoRatioCriterion(0.05, SamplingFrequency.DAY, Annualization.ANNUALIZED, ZoneOffset.UTC);
 AnalysisCriterion drawdownRisk = new MonteCarloMaximumDrawdownCriterion();
 AnalysisCriterion commissions = new CommissionsImpactPercentageCriterion();
 AnalysisCriterion totalFees = new TotalFeesCriterion();
@@ -147,20 +147,27 @@ When you need cost basis, unrealized PnL, or a position book in your backtest (e
 
 ## Walk-forward optimization
 
-Use the helper methods in `ta4jexamples.walkforward.WalkForward` to slice the series into alternating training/testing windows:
+Current ta4j walk-forward APIs center around `WalkForwardConfig` and the built-in execution methods on `BarSeriesManager` / `BacktestExecutor`:
 
 ```java
-List<BarSeries> trainingSlices = WalkForward.splitSeries(series, Duration.ofDays(120), Duration.ofDays(90));
+WalkForwardConfig config = WalkForwardConfig.defaultConfig(series);
+BarSeriesManager manager = new BarSeriesManager(series);
 
-for (BarSeries training : trainingSlices) {
-    BarSeries testing = WalkForward.subseries(series, training.getEndIndex() + 1, Duration.ofDays(30));
-    Strategy tuned = tuneStrategy(training);
-    TradingRecord forwardResult = new BarSeriesManager(testing).run(tuned);
-    // evaluate and store the outcome
-}
+StrategyWalkForwardExecutionResult wf = manager.runWalkForward(strategy, config);
+List<Num> outOfSample = wf.outOfSampleCriterionValues(new GrossReturnCriterion());
 ```
 
-See the [Walk Forward example](Usage-examples.md#strategy-patterns) for a turnkey implementation.
+```java
+WalkForwardConfig config = WalkForwardConfig.defaultConfig(series);
+BacktestExecutor executor = new BacktestExecutor(series);
+
+BacktestExecutor.BacktestAndWalkForwardResult combined =
+        executor.executeWithWalkForward(strategy, config);
+```
+
+This gives you reproducible fold geometry, holdout support, and one-shot comparison between plain backtest and walk-forward outcomes.
+
+See the maintained [`ta4jexamples.walkforward.WalkForward`](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java) example for a complete setup.
 
 ## Debugging slow or flaky backtests
 
@@ -190,6 +197,11 @@ The harness supports three execution modes:
 1. **Run Once (default)**: Execute a single backtest with specified parameters. Useful for quick performance checks or production runs with known optimal settings.
 2. **Tune In-Process**: Run multiple backtests with varying parameters to find optimal settings. Tests different strategy counts, bar counts, and maximum bar count hints systematically.
 3. **Tune Across Heaps**: Fork child JVMs with different heap sizes to test memory configuration impact. Each child JVM runs a full tuning cycle.
+
+## Maintainer rationale notes
+
+- Updated walk-forward examples to current APIs based on `org.ta4j.core.walkforward.WalkForwardConfig`, `BarSeriesManager#runWalkForward(...)`, and `BacktestExecutor#executeWithWalkForward(...)` (`0.22.4`; refreshed in commit `279d9056`).
+- Kept existing backtest ranking/runtime sections intact because `BacktestExecutor#executeWithRuntimeReport(...)` and `BacktestExecutionResult#getTopStrategies(...)` remain the supported batch workflow (`@since 0.19` in `BacktestExecutor`).
 
 ### Quick Start
 

--- a/Bar-series-and-bars.md
+++ b/Bar-series-and-bars.md
@@ -56,7 +56,7 @@ Common choices:
 - `VolumeBarAggregator` for volume-threshold bars.
 - `RenkoBarAggregator` for brick-based trend views.
 
-Note: range/volume/Renko aggregators require contiguous, evenly spaced source bars.
+Note: range/volume/Renko aggregators assume contiguous, ordered source bars.
 
 ## Working with live data
 

--- a/Bar-series-and-bars.md
+++ b/Bar-series-and-bars.md
@@ -36,8 +36,27 @@ Options to consider:
 
 - **Builders** – `TimeBarBuilder`, `TickBarBuilder`, `VolumeBarBuilder`, and the new `AmountBarBuilder` aggregate trades into bars by elapsed time, tick count, volume, or quote currency size respectively.
 - **Begin vs. end timestamps** – Since 0.18 you can build bars anchored on begin time (`timePeriod` + `beginTime`) or end time. Use whichever matches your data source.
-- **Split series** – `series.getSubSeries(start, end)` is the standard way to create train/test or walk-forward slices.
+- **Split series** – `series.getSubSeries(start, end)` is the standard way to create train/test or walk-forward slices. The resulting series inherits the source max-bar-count setting.
 - **Data Sources** – The `ta4j-examples` module includes ready-made data sources for loading historical data from APIs (Yahoo Finance, Coinbase) and files (CSV, JSON). See [Data Sources](Data-Sources.md) for comprehensive documentation.
+
+## Aggregating an existing series into alternate bar types
+
+When you already have a time-based series and want alternate bar constructions for analysis, use the aggregator package.
+
+```java
+BarAggregator renko = new RenkoBarAggregator(2.0, 2);
+BarSeries renkoSeries = new BaseBarSeriesAggregator(renko)
+        .aggregate(series, "btc_renko");
+```
+
+Common choices:
+
+- `DurationBarAggregator` for higher timeframe rollups.
+- `RangeBarAggregator` for fixed price-range bars.
+- `VolumeBarAggregator` for volume-threshold bars.
+- `RenkoBarAggregator` for brick-based trend views.
+
+Note: range/volume/Renko aggregators require contiguous, evenly spaced source bars.
 
 ## Working with live data
 
@@ -175,7 +194,7 @@ Note: Side and liquidity data are optional—exchanges may not provide this info
 `ConcurrentBarSeries` uses `ReentrantReadWriteLock` to provide:
 - **Multiple concurrent readers**: Read operations (getters, indicator evaluation) can proceed in parallel
 - **Exclusive writers**: Write operations (bar ingestion, modifications) are serialized
-- **Safe iteration**: All read methods return defensive copies or use read locks internally
+- **Safe access patterns**: Read operations are lock-protected, and `getBarData()` returns an immutable snapshot (`List.copyOf(...)`)
 
 Example concurrent usage:
 
@@ -217,6 +236,12 @@ executorService.submit(() -> {
 - Maximum bar count settings
 
 Transient locks are reinitialized on deserialization, and the trade bar builder is recreated lazily on the next ingestion call.
+
+## Rationale Notes (2026-03-06)
+
+- Added aggregator guidance because ta4j now includes `RangeBarAggregator`, `VolumeBarAggregator`, and `RenkoBarAggregator` (`org.ta4j.core.aggregator.*`), introduced in commit `3d6ca7b7`.
+- Clarified sub-series behavior to match `BaseBarSeries#getSubSeries(...)` and `ConcurrentBarSeries#getSubSeries(...)`, which carry forward max-bar-count behavior.
+- Clarified concurrency wording to match `ConcurrentBarSeries#getBarData()` (immutable snapshot return) and lock usage (`ReentrantReadWriteLock` in `ConcurrentBarSeries`), added in commit `dc759436`.
 
 ### When to use ConcurrentBarSeries
 

--- a/Charting.md
+++ b/Charting.md
@@ -631,6 +631,8 @@ workflow.displayChart(chart, "My Custom Chart");
 
 See the following example classes in the ta4j-examples project for more charting patterns:
 
+- [ChartWorkflow](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/charting/workflow/ChartWorkflow.java) - Facade API for rendering, displaying, and saving charts
+- [IndicatorsToChart](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java) - Minimal indicator overlay flow using the builder API
 - [ADXStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java) - Complex chart with overlays and sub-charts
 - [NetMomentumStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/NetMomentumStrategy.java) - Analysis criterion overlay example
 - [BuyAndSellSignalsToChart](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java) - Simple trading record visualization
@@ -658,3 +660,8 @@ For large datasets:
 - Consider using sub-charts instead of many overlays
 - Reduce the number of indicators displayed simultaneously
 - Use the `save()` method instead of `display()` for batch processing
+
+### Sync rationale (2026-03-06)
+
+- Revalidated `ChartWorkflow`, `ChartBuilder`, and `TimeAxisMode.BAR_INDEX` guidance against current examples/charting sources.
+- Confirmed non-trading-gap handling references align with commits `66fceb95` (introducing `TimeAxisMode`) and `b9c04cf3` (BAR_INDEX behavior hardening/tests).

--- a/Data-Sources.md
+++ b/Data-Sources.md
@@ -590,3 +590,8 @@ The ta4j data sources provide a unified, domain-driven API for loading historica
 - **Common Features:** Domain-driven interface, automatic pagination, response caching, unit testing support
 
 All data sources implement `BarSeriesDataSource`, making it easy to switch between sources or support multiple sources in your application.
+
+### Sync rationale (2026-03-06)
+
+- Confirmed this page against `BarSeriesDataSource`, `YahooFinanceHttpBarSeriesDataSource`, and `CoinbaseHttpBarSeriesDataSource` in `ta4j-examples`, including `loadSeriesInstance(...)` and cache-enabled constructors introduced/expanded in commit `b112d34b`.
+- Kept interval and pagination guidance aligned with provider enums (`YahooFinanceInterval`, `CoinbaseInterval`) and current implementation defaults.

--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -140,8 +140,9 @@ ElliottSwingIndicator (alternating swings)
 
 ### Change tracking relevant to this guide
 
-- This guide covers the stable Elliott API surface used in the `0.22.x` line (`ElliottTrendBias`, `ElliottTrendBiasIndicator`, scenario sets, analyzer/facade workflows, and confidence scoring behavior).
-- Confidence scoring applies softer penalties outside preferred extension ranges (rather than hard pass/fail), so marginally overextended wave-3/wave-5 structures are down-weighted instead of treated as binary invalid.
+- Commit `bebb758e` (2026-02-12, #1435) is the baseline for the current confidence/trend-bias model used here (`ElliottTrendBias`, `ElliottTrendBiasIndicator`, `ElliottConfidenceScorer`, and `elliott.confidence` factors).
+- Commit `279d9056` (2026-03-05, #1448) expanded the Elliott workflow with automatic multi-timeframe analysis (`ElliottWaveAnalysisRunner`, `ElliottWaveAnalysisResult`, and updated `ElliottWaveAnalyzer`/`ElliottWaveFacade` integration).
+- Confidence scoring uses soft penalties outside preferred extension ranges (instead of hard pass/fail), so mildly overextended wave-3/wave-5 structures are down-weighted rather than discarded.
 - For release-by-release history, see [Release Notes](Release-notes.md).
 
 ---

--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -141,7 +141,7 @@ ElliottSwingIndicator (alternating swings)
 ### Change tracking relevant to this guide
 
 - Commit `bebb758e` (2026-02-12, #1435) is the baseline for the current confidence/trend-bias model used here (`ElliottTrendBias`, `ElliottTrendBiasIndicator`, `ElliottConfidenceScorer`, and `elliott.confidence` factors).
-- Commit `279d9056` (2026-03-05, #1448) expanded the Elliott workflow with automatic multi-timeframe analysis (`ElliottWaveAnalysisRunner`, `ElliottWaveAnalysisResult`, and updated `ElliottWaveAnalyzer`/`ElliottWaveFacade` integration).
+- Commit `279d9056` (2026-03-05, #1448) expanded the Elliott workflow with automatic multi-timeframe analysis (for example `ElliottWaveAnalyzer`, `ElliottAnalysisResult`, and updated `ElliottWaveFacade` integration).
 - Confidence scoring uses soft penalties outside preferred extension ranges (instead of hard pass/fail), so mildly overextended wave-3/wave-5 structures are down-weighted rather than discarded.
 - For release-by-release history, see [Release Notes](Release-notes.md).
 

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -418,7 +418,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 **Short usage**  
 - **What it is:** Elliott Wave structure (swings, count, channel, ratios, projection, invalidation, phase, scenarios, confluence); trend bias across scenarios; pluggable analyzer with swing detectors and confidence profiles.  
 - **Theory:** Elliott Wave Theory models market structure in impulsive and corrective waves with Fibonacci relationships.  
-- **When to use:** When applying Elliott-based rules or targets; use confluence, invalidation, and trend bias for robustness; use ElliottWaveAnalyzer for one-shot analysis with custom detectors.  
+- **When to use:** When applying Elliott-based rules or targets; use confluence, invalidation, and trend bias for robustness; use ElliottWaveAnalyzer for one-shot analysis with custom detectors.
 - **When not to use:** When wave rules or degree are not clearly defined; interpretation is subjective.  
 - *Future: use cases, example code.*  
 - See also: [Elliott Wave Indicators](Elliott-Wave-Indicators.md).
@@ -551,7 +551,7 @@ These types live in `org.ta4j.core.indicators` and its subpackages and are part 
 
 ## Summary
 
-- **ta4j-core** currently provides 247 indicator classes across helpers, averages, volatility, momentum, trend, volume, candles, pivots, swing, Elliott, statistics, renko, and analysis.
+- **ta4j-core** currently provides indicator classes across helpers, averages, volatility, momentum, trend, volume, candles, pivots, swing, Elliott, statistics, renko, and analysis.
 - The inventory also tracks supporting public types (facades, enums, records, interfaces) in indicator packages that are required for complete API coverage.
 - **ta4j-examples** adds charting-oriented indicators (labels, channel boundary).  
 - All entries above use the **fully qualified name** and **class name** and a **short description as in the ta4j codebase**.  

--- a/Live-trading.md
+++ b/Live-trading.md
@@ -229,8 +229,8 @@ executorService.submit(() -> {
             trade.getTime(),
             trade.getVolume(),
             trade.getPrice(),
-            trade.getSide(),
-            trade.getLiquidity()
+            mapSide(trade),       // map broker payload -> RealtimeBar.Side
+            mapLiquidity(trade)   // map broker payload -> RealtimeBar.Liquidity
         );
     }
 });
@@ -291,3 +291,8 @@ For the full implementation playbook, see [VWAP, Support/Resistance, and Wyckoff
 - **[TradingBotOnMovingBarSeries](Usage-examples.md#bots--live-trading)** – minimal bot loop using a moving bar series.
 - [Backtesting](Backtesting.md) – explains how to test cost models and execution assumptions before deploying.
 - [Bar Series & Bars](Bar-series-and-bars.md) – details data ingestion, moving windows, and live updates.
+
+### Sync rationale (2026-03-06)
+
+- Clarified the `ConcurrentBarSeries.ingestTrade(...)` live loop example to use explicit side/liquidity mapping helpers so broker DTOs can be adapted to `RealtimeBar.Side` / `RealtimeBar.Liquidity`.
+- Verified `LiveTradingRecord`, `ExecutionFill`, `ExecutionMatchPolicy`, and open-position criteria references against commit `b112d34b`; verified `ConcurrentBarSeries` guidance against commit `dc759436`.

--- a/Moving-Average-Indicators.md
+++ b/Moving-Average-Indicators.md
@@ -69,7 +69,7 @@ Package: `org.ta4j.core.indicators.averages` (ta4j mainline `0.22.4-SNAPSHOT`).
 Notes:
 - `AbstractEMAIndicator` is an internal base class used by EMA-family implementations, not a standalone trading indicator.
 - Commit `d0ef59e7` (2026-02-06, "Update Indicator Unstable Counts") adjusted warmup/unstable behavior for multiple averages (for example `SMAIndicator`, `DoubleEMAIndicator`, `TripleEMAIndicator`) without introducing new average indicator types.
-- Through commit `279d9056` (2026-03-05), the public class surface in `org.ta4j.core.indicators.averages` remains stable: 23 concrete moving-average indicators plus `AbstractEMAIndicator` as the internal EMA base.
+- Through commit `279d9056` (2026-03-05), the public class surface in `org.ta4j.core.indicators.averages` remains stable: 23 concrete moving-average indicators plus `AbstractEMAIndicator` as the internal EMA base (while other packages in the same version window added APIs such as `BarSeriesManager#runWalkForward(...)` and `BacktestExecutor#executeWithWalkForward(...)`).
 
 
 ## Classification of Moving Averages

--- a/Moving-Average-Indicators.md
+++ b/Moving-Average-Indicators.md
@@ -38,7 +38,7 @@ Moving averages are versatile tools used in a variety of ways:
 
 ## Moving Averages in TA4J
 
-Package: `org.ta4j.core.indicators.averages` (ta4j `0.22.3`).
+Package: `org.ta4j.core.indicators.averages` (ta4j mainline `0.22.4-SNAPSHOT`).
 
 | Abbreviation | Full Name                                     | Indicator Name             | Moving Average Type            |
 |--------------|-----------------------------------------------|----------------------------|--------------------------------|
@@ -68,7 +68,8 @@ Package: `org.ta4j.core.indicators.averages` (ta4j `0.22.3`).
 
 Notes:
 - `AbstractEMAIndicator` is an internal base class used by EMA-family implementations, not a standalone trading indicator.
-- As of ta4j `0.22.3` (commit `d0ef59e7`), no new moving-average indicator classes were added in this package; warmup/unstable behavior was updated in that release line.
+- Commit `d0ef59e7` (2026-02-06, "Update Indicator Unstable Counts") adjusted warmup/unstable behavior for multiple averages (for example `SMAIndicator`, `DoubleEMAIndicator`, `TripleEMAIndicator`) without introducing new average indicator types.
+- Through commit `279d9056` (2026-03-05), the public class surface in `org.ta4j.core.indicators.averages` remains stable: 23 concrete moving-average indicators plus `AbstractEMAIndicator` as the internal EMA base.
 
 
 ## Classification of Moving Averages

--- a/Num.md
+++ b/Num.md
@@ -146,6 +146,9 @@ series.addBar(bar);
 ```
 
 **Important:** A `BarSeries` has a fixed numeric backend. Mixing different `Num` types on the same series (e.g., creating a `DoubleNum` literal and feeding it into a `DecimalNum` series) will throw or produce undefined behavior—always go through `numFactory()`.
+**Important:** A `BarSeries` has a fixed numeric backend. Mixing different `Num` types on the same series (e.g., creating a `DoubleNum` literal and feeding it into a `DecimalNum` series) is rejected by runtime guards (`IllegalArgumentException` in series/bar ingestion paths). Always go through `numFactory()`.
+
+If you build a series from pre-existing bars and do not set `withNumFactory(...)`, `BaseBarSeriesBuilder` derives the series numeric backend from the first bar (`bars.getFirst().numFactory()`). Set `withNumFactory(...)` explicitly if you want strict control instead of inference.
 
 For null/NaN guards in custom code, use the static helpers on `Num`:
 
@@ -161,3 +164,9 @@ if (Num.isNaNOrNull(value)) {
 
 ## Implementing your own Num
 If you need a custom numeric type (decimal128, fixed-point integers, GPU-backed tensors, etc.), implement the `Num` interface plus a matching `NumFactory`. As long as the factory can produce `zero()`, `one()`, and `numOf(...)`, the rest of ta4j will treat it like any other `Num`.
+
+## Rationale Notes (2026-03-06)
+
+- Precision defaults and configuration were verified against `DecimalNum`/`DecimalNumFactory` updates from commit `83a4f4fc` (`DEFAULT_PRECISION=16`, configurable default `MathContext`).
+- The mixed-`Num` runtime behavior is documented based on guard rails in `BaseBarSeries#addBar(...)`, `ConcurrentBarSeries#ingestTrade(...)`, and builder consistency checks in `BaseBarSeriesBuilder#build()`.
+- Added num-factory inference note based on `BaseBarSeriesBuilder#build()` behavior introduced via commit `0af7c717`.

--- a/Stop-Loss-and-Stop-Gain-Rules.md
+++ b/Stop-Loss-and-Stop-Gain-Rules.md
@@ -53,7 +53,7 @@ Best when:
 
 These use a dynamic threshold based on volatility indicators (typically ATR multiplied by a coefficient).
 
-From 0.22.3, ATR-based rules also support constructors that accept a custom `ATRIndicator` directly, so you can share precomputed ATR pipelines instead of rebuilding ATR inside each rule.
+From 0.22.3, ATR-based rules support constructors that accept a custom `ATRIndicator` directly (including trailing variants), so you can share precomputed ATR pipelines instead of rebuilding ATR inside each rule.
 
 Best when:
 
@@ -93,6 +93,7 @@ Notes:
 - Keep one hard fail-safe stop even when using adaptive stops.
 - Avoid stacking many correlated stop rules unless each has a distinct purpose.
 - `TrailingStopGainRule` and `AverageTrueRangeTrailingStopGainRule` are two-stage: they activate only after reaching the initial gain threshold, then trigger on retracement from the favorable extreme.
+- `AverageTrueRangeTrailingStopGainRule` requires a positive ATR coefficient; invalid values fail fast with `IllegalArgumentException`.
 
 ## Using stop-price models for risk analytics
 
@@ -212,3 +213,9 @@ See also:
 - [Trading Strategies](Trading-strategies.md)
 - [Live Trading](Live-trading.md)
 - [Backtesting](Backtesting.md)
+
+## Maintainer rationale notes
+
+- Stop-rule family coverage mirrors the expanded hierarchy added in commit `89cd2271` (`BaseVolatility*`, fixed-amount, trailing, and stop-price model interfaces).
+- ATR constructor guidance reflects commit `1fa097ef` and current `AverageTrueRange*` constructors that accept `ATRIndicator` directly.
+- Added positive-coefficient note for `AverageTrueRangeTrailingStopGainRule` based on its input validation in `requirePositiveAtrCoefficient(...)`.

--- a/Trading-strategies.md
+++ b/Trading-strategies.md
@@ -27,8 +27,8 @@ Key points:
 - `Rule#isSatisfied(int index)` is stateless. Pass the `TradingRecord` when the rule depends on open positions or previous signals.
 - Composition is fluent (`and`, `or`, `xor`, `negation`), making it easy to express “enter when fast SMA crosses slow SMA **and** RSI recovers above 40.”
 - For windowed boolean composition across the last `N` bars, use `AndWithThresholdRule` / `OrWithThresholdRule` (introduced in 0.22.2). These are explicit rule classes rather than overloads on `and(...)` / `or(...)`.
-- Since 0.19 you can use `VoteRule` to require agreement between multiple rules (e.g., "at least 3 out of 5 oscillators must agree"). In 0.21.0, return representation is unified across all criteria for consistent formatting.
-- `InSlopeRule` is satisfied when the slope of one indicator is within a boundary of another (e.g. for trend strength or momentum alignment).
+- Since 0.19 you can use `VoteRule` to require agreement between multiple rules (e.g., "at least 3 out of 5 oscillators must agree"). Return-format control is handled in criteria via `ReturnRepresentation` / `ReturnRepresentationPolicy` (`@since 0.20`).
+- `InSlopeRule` is satisfied when the indicator slope (current minus prior value over `nthPrevious` bars) is within configured min/max slope bounds.
 
 ## Compose richer logic
 
@@ -47,8 +47,8 @@ Rule timedMomentumExit = new OrWithThresholdRule(
         new InSlopeRule(netMomentum, 3, series.numFactory().numOf("-10")),
         3);
 Rule exitRule = timedMomentumExit
-        .or(new StopLossRule(closePrice, numOf(3)))
-        .or(new StopGainRule(closePrice, numOf(5)));
+        .or(new StopLossRule(closePrice, series.numFactory().numOf(3)))
+        .or(new StopGainRule(closePrice, series.numFactory().numOf(5)));
 ```
 
 This configuration fires an **entry** when at least two of the following hold on the same bar:
@@ -58,7 +58,7 @@ This configuration fires an **entry** when at least two of the following hold on
 
 On top of that vote, the Net Momentum indicator must be above zero so entries only happen when breadth is positive.
 The **exit** side first evaluates `timedMomentumExit`, an `OrWithThresholdRule` over a 3-bar window: it triggers when either MACD crosses below its signal line or the Net Momentum slope rule (`InSlopeRule(netMomentum, 3, -10)`) is satisfied within that same 3-bar window.
-That combined rule is then OR'd with `StopLossRule(closePrice, numOf(3))` and `StopGainRule(closePrice, numOf(5))` as hard risk/profit boundaries.
+That combined rule is then OR'd with `StopLossRule(closePrice, series.numFactory().numOf(3))` and `StopGainRule(closePrice, series.numFactory().numOf(5))` as hard risk/profit boundaries.
 
 For the full stop toolkit (fixed %, fixed amount, trailing, volatility, ATR) and live-trading usage guidance, see [Stop Loss & Stop Gain Rules](Stop-Loss-and-Stop-Gain-Rules.md).
 
@@ -195,3 +195,9 @@ That JSON payload captures the full rule graph, making it safe to persist strate
 - Encapsulate repeated rule snippets into helper methods or custom `Rule` implementations—readability matters when strategies grow complex.
 - Keep entry/exit rules symmetric when building short strategies; for short-only operation, construct your strategy with starting type `TradeType.SELL`.
 - When mixing timeframes or data sources, align them into the same `BarSeries` (or into multiple series managed by your own coordinator) to avoid implicit look-ahead.
+
+## Maintainer rationale notes
+
+- Clarified `InSlopeRule` semantics to match the actual implementation in `org.ta4j.core.rules.InSlopeRule` (difference vs. `PreviousValueIndicator`, optional min/max bounds).
+- Kept threshold/voting composition guidance aligned with `AndWithThresholdRule` / `OrWithThresholdRule` (commit `5e5acc99`) and `VoteRule` (commit `cca0bb02`).
+- Kept MACD-V regime examples aligned with `MomentumStateRule` and `MACDVMomentumStateStrategy` updates (commit `161f7656`).

--- a/Usage-examples.md
+++ b/Usage-examples.md
@@ -82,15 +82,14 @@ Strategy examples that use charting:
 
 ## Elliott Wave analysis
 
-- **[ElliottWaveAnalysis](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/ElliottWaveAnalysis.java)** – comprehensive Elliott Wave analysis with scenario-based confidence scoring, chart visualization, and wave pivot labels. Supports command-line arguments for loading data from Yahoo Finance or Coinbase, or uses a default dataset if no arguments provided. See [Elliott Wave Indicators](Elliott-Wave-Indicators.md) for detailed documentation.
-- **[BTCUSDElliottWaveAnalysis](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/BTCUSDElliottWaveAnalysis.java)** – example Elliott Wave analysis for Bitcoin (BTC-USD) using Coinbase data with PRIMARY degree.
-- **[ETHUSDElliottWaveAnalysis](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/ETHUSDElliottWaveAnalysis.java)** – example Elliott Wave analysis for Ethereum (ETH-USD) using Coinbase data.
-- **[SP500ElliottWaveAnalysis](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/SP500ElliottWaveAnalysis.java)** – example Elliott Wave analysis for S&P 500 Index (^GSPC) using Yahoo Finance data.
-- **[ElliottWaveAdaptiveSwingAnalysis](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/ElliottWaveAdaptiveSwingAnalysis.java)** (0.22.2+) – Elliott Wave analysis using the adaptive ZigZag swing detector (volatility-adaptive reversal). Demonstrates pluggable swing detection and one-shot analysis via `ElliottWaveAnalyzer`.
-- **[ElliottWavePatternProfileDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/ElliottWavePatternProfileDemo.java)** (0.22.2+) – demonstrates confidence profiles and scenario-type–aware confidence models for different Elliott pattern types.
-- **[ElliottWaveTrendBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/ElliottWaveTrendBacktest.java)** (0.22.2+) – backtests and walk-forward tests Elliott Wave trend bias predictions over multiple datasets (e.g. ETH-USD, AAPL).
-- **[HighRewardElliottWaveBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/HighRewardElliottWaveBacktest.java)** (0.22.2+) – runs the HighRewardElliottWaveStrategy on ossified data and prints performance metrics.
-- **[HighRewardElliottWaveStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/HighRewardElliottWaveStrategy.java)** (0.22.2+) – named strategy that trades high-confidence impulse scenarios (wave 3 or 5) with trend and momentum confirmation; uses pluggable swing detectors and custom confidence profiles.
+- **[ElliottWaveIndicatorSuiteDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/ElliottWaveIndicatorSuiteDemo.java)** – consolidated Elliott Wave demo with scenario scoring, chart overlays, and optional live/ossified data loading.
+- **[ElliottWavePresetDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/ElliottWavePresetDemo.java)** – launcher for `ossified` presets (`btc`, `eth`, `sp500`) and `live` runs (Coinbase/YahooFinance).
+- **[ElliottWaveMultiDegreeAnalysisDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/demo/ElliottWaveMultiDegreeAnalysisDemo.java)** (0.22.4+) – cross-degree scenario validation and reranking for stronger trend-bias decisions.
+- **[ElliottWaveAdaptiveSwingAnalysis](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/demo/ElliottWaveAdaptiveSwingAnalysis.java)** (0.22.2+) – adaptive ZigZag swing detection demo with pluggable detector settings.
+- **[ElliottWavePatternProfileDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/demo/ElliottWavePatternProfileDemo.java)** (0.22.2+) – scenario-type confidence profile tuning demo.
+- **[ElliottWaveTrendBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/backtest/ElliottWaveTrendBacktest.java)** (0.22.2+) – trend-bias walk-forward/backtest harness for Elliott outputs.
+- **[HighRewardElliottWaveBacktest](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/backtest/HighRewardElliottWaveBacktest.java)** (0.22.2+) – backtest harness for `HighRewardElliottWaveStrategy`.
+- **[HighRewardElliottWaveStrategy](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/strategies/HighRewardElliottWaveStrategy.java)** (0.22.2+) – named strategy targeting high-confidence impulse scenarios.
 
 ## Bots & live trading
 
@@ -100,3 +99,8 @@ Strategy examples that use charting:
 - **LiveTradingRecord (partial fills, cost basis, position book)**: For bots that receive partial fills or need per-lot cost basis and unrealized PnL, use `LiveTradingRecord` with `recordFill(ExecutionFill)` or `enter`/`exit`. See the [Live Trading – LiveTradingRecord walkthrough](Live-trading.md#walkthrough-livetradingrecord-with-partial-fills-and-cost-basis) for a step-by-step code guide and criteria (`OpenPositionCostBasisCriterion`, `OpenPositionUnrealizedProfitCriterion`).
 
 Have a favorite workflow or integration that is not covered yet? Contributions to `ta4j-examples` are welcome—new examples make the wiki even more actionable.
+
+### Sync rationale (2026-03-06)
+
+- Updated Elliott example links to current classes after the reorganization in commit `279d9056` (`ElliottWaveIndicatorSuiteDemo`, `ElliottWavePresetDemo`, `demo/*`, `backtest/*`).
+- Retained live-trading pointers for `ConcurrentBarSeries` and `LiveTradingRecord` aligned with commit `b112d34b`.

--- a/VWAP-Support-Resistance-and-Wyckoff.md
+++ b/VWAP-Support-Resistance-and-Wyckoff.md
@@ -97,7 +97,9 @@ Num rangeHigh = wyckoffFacade.tradingRangeHigh(series.getEndIndex());
 ```
 
 Recent code drift note:
-- In ta4j `0.22.3` (commit `39194498`), this stack was expanded materially (VWAP derivatives, support/resistance families, and Wyckoff cycle facade/analysis). The map above reflects the current class surface in `org.ta4j.core.indicators.volume`, `supportresistance`, and `wyckoff`.
+- Commit `39194498` (2026-02-21, #1444) introduced the modern stack here: VWAP derivatives (`VWAPBandIndicator`, `VWAPDeviationIndicator`, `VWAPStandardDeviationIndicator`, `VWAPZScoreIndicator`), Wyckoff cycle analysis/facade, and KDE/cluster/bounce support-resistance indicators.
+- Commit `b814436b` (#1360) is the trendline baseline for this page (`AbstractTrendLineIndicator`, `TrendLineSupportIndicator`, `TrendLineResistanceIndicator`).
+- Commit `279d9056` (2026-03-05, #1448) extended Wyckoff analysis workflow integration (`WyckoffCycleAnalysisRunner`) while preserving the core `WyckoffPhaseIndicator`/`WyckoffCycleFacade` usage shown below.
 
 ## Backtesting how-to
 

--- a/architecture/proposed/TODO-bar-series-datasource-refactoring.md
+++ b/architecture/proposed/TODO-bar-series-datasource-refactoring.md
@@ -4,6 +4,17 @@
 
 Refactor `BarSeriesDataSource` implementations to separate data retrieval (I/O) from data parsing/transformation. This will improve maintainability, testability, and allow for better composition and reuse of components.
 
+## Status Snapshot (2026-03-06)
+
+Status: design remains proposed; current ta4j-examples architecture is still `BarSeriesDataSource` + concrete HTTP/file datasource hierarchies.
+
+Current baseline:
+- File path family: `ta4jexamples.datasources.file.AbstractFileBarSeriesDataSource`.
+- HTTP path family: `ta4jexamples.datasources.http.AbstractHttpBarSeriesDataSource`.
+- Source-specific implementations like `CoinbaseHttpBarSeriesDataSource`, `YahooFinanceHttpBarSeriesDataSource`, `CsvFileBarSeriesDataSource`, and `JsonFileBarSeriesDataSource`.
+
+The proposed `DataRetrievalClient` and `DataFormatMapper` interfaces are not yet present in `ta4j-examples`.
+
 ## Architecture Decision: File Search & Caching Location
 
 **DECISION: File search and caching logic should live in `DataRetrievalClient` (Option A)**
@@ -269,6 +280,11 @@ ta4j-examples/src/main/java/ta4jexamples/datasources/
 ├── JsonFileBarSeriesDataSource.java (refactored - composes client + mapper)
 └── BitStampCsvTradesFileBarSeriesDataSource.java (refactored - composes client + mapper)
 ```
+
+## Rationale Notes (2026-03-06)
+
+- Verified against current classes in `ta4j-examples/src/main/java/ta4jexamples/datasources/**`.
+- Confirmed this refactor has not landed in recent history up to commit `6cce8809`.
 
 ### Component Responsibilities
 
@@ -691,4 +707,3 @@ Once refactoring is complete, consider:
 3. Adding streaming clients (WebSocket, SSE, etc.)
 4. Adding more mapper formats (Parquet, Avro, etc.)
 5. Adding request/response interceptors for logging, metrics, etc.
-

--- a/architecture/proposed/TODO-bar-series-symbol-metadata.md
+++ b/architecture/proposed/TODO-bar-series-symbol-metadata.md
@@ -1,5 +1,14 @@
 # BarSeries Base/Quote Symbol Metadata (TODO PRD)
 
+## Status Snapshot (2026-03-06)
+
+Status: still proposed, not implemented in ta4j-core.
+
+What exists today:
+- `BarSeries` does not expose `getBaseSymbol()` / `getQuoteSymbol()`.
+- `BaseBarSeriesBuilder` and `ConcurrentBarSeriesBuilder` do not provide `withBaseSymbol(...)` / `withQuoteSymbol(...)`.
+- Instrument identity currently appears on `Trade` (`org.ta4j.core.Trade#getInstrument`), not series-level metadata.
+
 ## Overview
 
 Add optional symbol metadata to `BarSeries` so a series can explicitly carry its
@@ -125,3 +134,7 @@ fields so round-trips preserve them.
 - Should `withSymbolPair(base, quote)` be included for convenience?
 - Should symbols be normalized (e.g., uppercase) or stored verbatim?
 
+## Rationale Notes (2026-03-06)
+
+- Verified current API surface in `org.ta4j.core.BarSeries`, `BaseBarSeries`, `BaseBarSeriesBuilder`, `ConcurrentBarSeries`, and `ConcurrentBarSeriesBuilder`.
+- Verified recent core branch history through commit `6cce8809` with no landed series-level symbol metadata.

--- a/architecture/proposed/TODO-prd-fixed-window-rule-design.md
+++ b/architecture/proposed/TODO-prd-fixed-window-rule-design.md
@@ -1,5 +1,17 @@
 # Fixed Window Rule Design - Product Requirements Document
 
+## Status Snapshot (2026-03-06)
+
+Status: partially superseded by shipped functionality.
+
+What landed:
+- `AndWithThresholdRule` exists in `org.ta4j.core.rules` (commit `5e5acc99`) and provides fixed-window AND semantics for exactly two rules within one threshold window.
+
+What remains open from this PRD:
+- Per-rule threshold configuration.
+- Multi-rule list/builder API beyond two rules.
+- Explicit migration/positioning relative to existing `ChainRule` semantics.
+
 ## Overview
 
 This document consolidates the design proposals for implementing fixed-window rule functionality in ta4j. The goal is to provide a rule that checks if multiple rules were ALL satisfied within a fixed time window from when an initial trigger rule was satisfied, as opposed to the existing `ChainRule` which uses resetting thresholds.
@@ -557,3 +569,8 @@ public class ChainRule extends AbstractRule {
   - `pseudocode-AndWithThresholdRule-Enhanced.md`
   - `pseudocode-FixedWindowChainRule.md`
   - `pseudocode-comparison.md`
+
+## Rationale Notes (2026-03-06)
+
+- Verified shipped baseline in `org.ta4j.core.rules.AndWithThresholdRule` (commit `5e5acc99`): two-rule fixed-window check with a single threshold.
+- This PRD still captures additional, not-yet-shipped scope (multi-rule/per-rule-threshold design).

--- a/architecture/proposed/TODO-serialization-versioned-canonical-spec.md
+++ b/architecture/proposed/TODO-serialization-versioned-canonical-spec.md
@@ -4,6 +4,15 @@ Status: Draft
 Target: ta4j-core (serialization)
 Feature branch: codex/serialization-versioned-spec
 
+## Status Snapshot (2026-03-06)
+
+Status: still draft/proposed.
+
+Current baseline:
+- Serialization support exists via `ComponentSerialization`, `RuleSerialization`, and `StrategySerialization`.
+- There is no public `toVersionedJson(...)` / `fromVersionedJson(...)` API yet.
+- Canonical field ordering support exists internally in `ComponentSerialization` for descriptor stability, but not as a full versioned envelope contract.
+
 ## Summary
 Introduce a versioned, canonical JSON format for ta4j rule/strategy (and indicator) serialization. The change is
 additive: new versioned APIs coexist with existing JSON payloads, and legacy (versionless) payloads remain readable.
@@ -191,3 +200,7 @@ Phase 2 (Optional):
 - Legacy (versionless) payloads still load.
 - README documents the versioned format and API.
 
+## Rationale Notes (2026-03-06)
+
+- Verified against `org.ta4j.core.serialization.ComponentSerialization`, `RuleSerialization`, and `StrategySerialization`.
+- Confirmed no landed `toVersionedJson`/`fromVersionedJson` APIs in current ta4j-core history up to commit `6cce8809`.

--- a/architecture/proposed/TODO-trendline-negative-scoring-weights.md
+++ b/architecture/proposed/TODO-trendline-negative-scoring-weights.md
@@ -1,6 +1,10 @@
 Trendline scoring weights: support negative biases
 ==================================================
 
+Status snapshot (2026-03-06)
+- Status: still proposed.
+- Current `ScoringWeights` behavior in `AbstractTrendLineIndicator` enforces each weight in `[0,1]` and total sum of `1.0`; negative weights are not currently allowed.
+
 Context
 - Area: `ta4j-core/src/main/java/org/ta4j/core/indicators/supportresistance/AbstractTrendLineIndicator`.
 - Current rules: `ScoringWeights` fields (`touchCountWeight`, `touchesExtremeWeight`, `outsideCountWeight`, `averageDeviationWeight`, `anchorRecencyWeight`) must each be in `[0, 1]` and must sum to `1.0`. Factor scores are all in `[0, 1]`; composite score is the weighted sum. Tie-breaks prefer higher score, then higher touchCount, then fewer outsideCount, etc.
@@ -45,3 +49,7 @@ Definition of done
 - Tie-break policy decided and implemented consistently with weight signs.
 - Validation, Javadoc, and wiki updated; descriptors persist raw weights.
 - New tests cover negative weights, zero-sum rejection, tie-break behavior, and compatibility with existing defaults.
+
+Rationale notes (2026-03-06)
+- Verified against `org.ta4j.core.indicators.supportresistance.AbstractTrendLineIndicator` (`ScoringWeights` validation and weighted-score path).
+- Last substantial trendline scoring additions were shipped in commits `b814436b` and `39194498`; negative-bias scoring remains open.


### PR DESCRIPTION
## Summary
- refresh wiki pages that drifted against recent ta4j core/examples changes
- update strategy, stop-rule, bars/num, examples, and indicator inventory guidance
- annotate architecture TODO pages with current shipped-vs-proposed status snapshots

@coderabbitai full review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added walk-forward execution APIs for enhanced strategy backtesting and optimization workflows

**Documentation**
* Improved guidance on backtesting, bar aggregation, and Elliott Wave analysis
* Enhanced live trading ingestion examples with explicit data mapping
* Clarified number handling, ATR-based rule support, and indicator semantics
* Expanded charting and example class documentation for better developer experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->