### PR TITLE
[codex] Fix wiki root and sidebar links

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
       - main
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,8 +13,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages-${{ github.ref }}"
@@ -22,6 +20,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -107,6 +107,9 @@ jobs:
           path: ./_site
   deploy:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+    permissions:
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     needs: build
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,10 @@
 name: Deploy GitHub Pages
 
 on:
+  pull_request:
+    branches:
+      - master
+      - main
   push:
     branches:
       - master
@@ -13,7 +17,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -29,11 +33,80 @@ jobs:
         with:
           source: .
           destination: ./_site
+      - name: Validate generated site
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          test -f index.md
+          test -f Home.md
+          grep -Fq "{% include_relative Home.md %}" index.md
+          test -f ./_site/index.html
+          grep -Fq "https://javadoc.io/doc/org.ta4j/ta4j-core" ./_site/index.html
+
+          source_stale_pattern='oss\.sonatype\.org/service/local/repositories/releases/archive|Javadoc \(0([.][0-9]+)+\)|clas="sidebar"|href="/ta4j-wiki/|Release-notes\.html|Found-a-bug\.html|Branching-model\.html|How-to-contribute|Maven-notes\.html'
+          generated_stale_pattern='oss\.sonatype\.org/service/local/repositories/releases/archive|Javadoc \(0([.][0-9]+)+\)|clas="sidebar"|Release-notes\.html|Found-a-bug\.html|Branching-model\.html|How-to-contribute|Maven-notes\.html'
+
+          if grep -E "$source_stale_pattern" _layouts/default.html _Sidebar.md Home.md index.md; then
+            echo "Stale source sidebar/root link found."
+            exit 1
+          fi
+
+          while IFS= read -r -d '' html; do
+            if grep -E "$generated_stale_pattern" "$html"; then
+              echo "Stale generated sidebar/root link found in $html."
+              exit 1
+            fi
+          done < <(find ./_site -name '*.html' -print0)
+
+          failures=0
+          while IFS= read -r -d '' html; do
+            html_path=${html#./_site/}
+            base_dir=$(dirname "$html_path")
+            while IFS= read -r href; do
+              case "$href" in
+                ""|"#"*|http://*|https://*|mailto:*|tel:*|//*)
+                  continue
+                  ;;
+              esac
+
+              href=${href%%#*}
+              href=${href%%\?*}
+              [[ -z "$href" ]] && continue
+
+              if [[ "$href" == "/ta4j-wiki" ]]; then
+                target="index.html"
+              elif [[ "$href" == "/ta4j-wiki/"* ]]; then
+                target=${href#/ta4j-wiki/}
+              elif [[ "$href" == "/" ]]; then
+                target="index.html"
+              elif [[ "$href" == /* ]]; then
+                target=${href#/}
+              elif [[ "$base_dir" == "." ]]; then
+                target=$href
+              else
+                target="$base_dir/$href"
+              fi
+
+              if [[ -z "$target" || "$target" == */ ]]; then
+                target="${target}index.html"
+              fi
+
+              if [[ ! -f "./_site/$target" ]]; then
+                echo "$html: unresolved href $href -> ./_site/$target"
+                failures=1
+              fi
+            done < <(grep -hoE 'href="[^"]+"' "$html" | sed -E 's/^href="(.*)"$/\1/')
+          done < <(find ./_site -name '*.html' -print0)
+
+          exit "$failures"
       - name: Upload artifact
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./_site
   deploy:
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     needs: build
     environment:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
   <body>
     <div class="wrapper">
       <header>
-        <a href="/ta4j-wiki/"> <h3>Ta4j Wiki</h3> </a>
+        <a href="{{ '/' | relative_url }}"> <h3>Ta4j Wiki</h3> </a>
         <p>Documentation, examples and further information of the ta4j project</p>
         {% if site.show_downloads %}
           <ul>
@@ -32,33 +32,40 @@
           <!-- Custom div for the sidebar-->
         <div>
             <nav>
-                <dl class="sidebar" >
-                    <dt class="sidebar">General</dt>                    
-                        <dd><a target="_blank" href="https://oss.sonatype.org/service/local/repositories/releases/archive/org/ta4j/ta4j-core/0.21.0/ta4j-core-0.21.0-javadoc.jar/!/index.html">Javadoc (0.21.0)</a></dd>
-                        <dd><a target="_blank" href="https://oss.sonatype.org/service/local/repositories/releases/archive/org/ta4j/ta4j-core/0.19/ta4j-core-0.19-javadoc.jar/!/index.html">Javadoc (0.19)</a></dd>
-						<dd><a href="Release-notes.html">Release Notes</a></dd>
-                        <dd><a href="Roadmap-and-Tasks.html">Roadmap</a></dd>
-                        <dd><a href="FAQ.html">FAQ</a></dd>
-                    <dt clas="sidebar">User's guide</dt>
-                        <dd><a href="Getting-started.html">Getting Started</a></dd>
-                        <dd><a href="Bar-series-and-bars.html">Bar series and Bars</a></dd>
-                        <dd><a href="Technical-indicators.html">Technical Indicators</a></dd>
-                        <dd><a href="Moving-Average-Indicators.html">Moving Average Indicators</a></dd>
-                        <dd><a href="Trading-strategies.html">Trading Strategies</a></dd>
-                        <dd><a href="Backtesting.html">Backtesting</a></dd>
-                        <dd><a href="Live-trading.html">Live Trading</a></dd>
-                        <dd><a href="Num.html">Num</a></dd>
-                    <dt clas="sidebar">Contributing</dt>
-                        <dd><a href="Found-a-bug.html">Found a bug</a></dd>
-                        <dd><a href="Branching-model.html">Branching model</a></dd>
-                        <dd><a href="How-to-contribute">How to Contribute</a></dd>
-                        <dd><a href="XLS-Testing.html">XLS Testing</a></dd>
-                    <dt clas="sidebar">Development Features</dt>
-                        
-                    <dt class="sidebar">Miscellaneous</dt>
-                        <dd><a href="Related-projects.html">Related Projects</a></dd>
-                        <dd><a href="Alternative-libraries">Alternative Libraries</a></dd>
-                        <dd><a href="Maven-notes.html">Maven Notes</a></dd>
+                <dl class="sidebar">
+                    <dt class="sidebar">General</dt>
+                        <dd><a target="_blank" href="https://javadoc.io/doc/org.ta4j/ta4j-core">Javadoc (latest release)</a></dd>
+                        <dd><a target="_blank" href="https://github.com/ta4j/ta4j/blob/master/CHANGELOG.md">Release Notes</a></dd>
+                        <dd><a href="{{ '/Roadmap-and-Tasks.html' | relative_url }}">Roadmap</a></dd>
+                        <dd><a href="{{ '/FAQ.html' | relative_url }}">FAQ</a></dd>
+                    <dt class="sidebar">User's guide</dt>
+                        <dd><a href="{{ '/Getting-started.html' | relative_url }}">Getting Started</a></dd>
+                        <dd><a href="{{ '/Bar-series-and-bars.html' | relative_url }}">Bar series and Bars</a></dd>
+                        <dd><a href="{{ '/Data-Sources.html' | relative_url }}">Data Sources</a></dd>
+                        <dd><a href="{{ '/Num.html' | relative_url }}">Num</a></dd>
+                        <dd><a href="{{ '/Technical-indicators.html' | relative_url }}">Technical Indicators</a></dd>
+                        <dd><a href="{{ '/Indicators-Inventory.html' | relative_url }}">Indicators Inventory</a></dd>
+                        <dd><a href="{{ '/Moving-Average-Indicators.html' | relative_url }}">Moving Average Indicators</a></dd>
+                        <dd><a href="{{ '/Bill-Williams-Indicators.html' | relative_url }}">Bill Williams Indicators</a></dd>
+                        <dd><a href="{{ '/Trendlines-and-Swing-Points.html' | relative_url }}">Trendlines and Swing Points</a></dd>
+                        <dd><a href="{{ '/Elliott-Wave-Indicators.html' | relative_url }}">Elliott Wave Indicators</a></dd>
+                        <dd><a href="{{ '/VWAP-Support-Resistance-and-Wyckoff.html' | relative_url }}">VWAP, S/R and Wyckoff Guide</a></dd>
+                    <dt class="sidebar">Build Strategies</dt>
+                        <dd><a href="{{ '/Trading-strategies.html' | relative_url }}">Trading Strategies</a></dd>
+                        <dd><a href="{{ '/Stop-Loss-and-Stop-Gain-Rules.html' | relative_url }}">Stop Loss and Stop Gain Rules</a></dd>
+                        <dd><a href="{{ '/Backtesting.html' | relative_url }}">Backtesting</a></dd>
+                        <dd><a href="{{ '/Analysis-Criteria-and-Risk-Metrics.html' | relative_url }}">Analysis Criteria and Risk Metrics</a></dd>
+                        <dd><a href="{{ '/Walk-Forward-Research.html' | relative_url }}">Walk-Forward Research</a></dd>
+                        <dd><a href="{{ '/Live-trading.html' | relative_url }}">Live Trading</a></dd>
+                        <dd><a href="{{ '/Charting.html' | relative_url }}">Charting</a></dd>
+                        <dd><a href="{{ '/Usage-examples.html' | relative_url }}">Usage Examples</a></dd>
+                    <dt class="sidebar">Project and Community</dt>
+                        <dd><a target="_blank" href="https://github.com/ta4j/ta4j/blob/master/.github/CONTRIBUTING.md">How to Contribute</a></dd>
+                        <dd><a target="_blank" href="https://github.com/ta4j/ta4j/issues/new/choose">Found a bug</a></dd>
+                        <dd><a target="_blank" href="https://github.com/ta4j/ta4j/blob/master/RELEASE_PROCESS.md">Release Process</a></dd>
+                        <dd><a href="{{ '/XLS-Testing.html' | relative_url }}">XLS Testing</a></dd>
+                        <dd><a href="{{ '/Related-projects.html' | relative_url }}">Related Projects</a></dd>
+                        <dd><a href="{{ '/Alternative-libraries.html' | relative_url }}">Alternative Libraries</a></dd>
                 </dl>
             </nav>
         </div>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+{% include_relative Home.md %}


### PR DESCRIPTION
## Summary
- Restore the GitHub Pages root by adding `index.md` that delegates to the canonical `Home.md` wiki page.
- Refresh the rendered site sidebar so it no longer points at deleted wiki pages.
- Replace pinned Sonatype Javadoc archive links with the evergreen javadoc.io latest-release entry.
- Extend the Pages workflow so PRs run the official Jekyll build and native shell validation without deploying; deployment remains push-only for `master`/`main`.

## Root Cause
PR #34 deleted `README.md` without adding a replacement root page, so the Pages artifact had `Home.html` but no `index.html`. The layout sidebar was also maintained separately from `_Sidebar.md`, leaving deleted-page links and manually pinned Javadoc versions behind.

## Validation
- `git diff --check`
- Native workflow shell block syntax check with `bash -n`
- Source stale-link guard for deleted wiki pages, pinned Sonatype Javadoc URLs, and malformed sidebar class attrs
- External sidebar link status checks for javadoc.io and main ta4j GitHub targets

Local Jekyll build was not run because this checkout has no Gemfile, `jekyll` is not installed, and Docker is present but its daemon is not running; the updated GitHub Pages workflow is the authoritative build gate.