### PR TITLE
docs: refresh wiki for 0.22.7 production release

### DIFF
--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -80,10 +80,10 @@ The Elliott Wave indicators in ta4j are built on several key principles:
 
 ### Internal Implementation Boundary
 
-Some Elliott package classes are internal implementation details (for example, scenario-rule/scoring internals used to build ranked alternatives).
+Some Elliott package classes are internal implementation details (for example, `ElliottScenarioRuleSupport` and generator/scoring helpers used to build ranked alternatives).
 
-- These internals are intentionally not surfaced in general wiki pages.
-- This dedicated Elliott page is the right place to discuss Elliott internals when needed.
+- Public strategy rules live in `org.ta4j.core.rules.elliott` and are documented below.
+- Package-private abstract indicator bases are omitted from [Indicators Inventory](Indicators-Inventory.md).
 
 ### Component Hierarchy
 
@@ -498,7 +498,14 @@ ElliottWaveFacade facade = ElliottWaveFacade.from(
 );
 ```
 
-When a custom Fibonacci tolerance is provided, the phase indicator uses a custom `ElliottFibonacciValidator` with that tolerance instead of the default (0.05). When a compressor is provided, `filteredWaveCount()` uses it to filter swings before counting; otherwise, `filteredWaveCount()` returns the same as `waveCount()`.
+When a custom Fibonacci tolerance is provided, both `phase()` and `scenarios()` share the same `ElliottFibonacciValidator` instance (default tolerance is `0.05`). This keeps phase validation and scenario ranking aligned on the same Fibonacci bands. You can also construct `ElliottFibonacciValidator` directly when building custom generators or tests:
+
+```java
+Num tolerance = series.numFactory().numOf(0.25);
+ElliottFibonacciValidator validator = new ElliottFibonacciValidator(series.numFactory(), tolerance);
+```
+
+When a compressor is provided, `filteredWaveCount()` uses it to filter swings before counting; otherwise, `filteredWaveCount()` returns the same as `waveCount()`.
 
 ---
 
@@ -672,6 +679,7 @@ SwingDetector detector = SwingDetectors.fractal(5);
 ElliottWaveAnalysisRunner runner = ElliottWaveAnalysisRunner.builder()
     .swingDetector(detector)
     .degree(ElliottDegree.INTERMEDIATE)
+    .logicProfile(ElliottLogicProfile.ORTHODOX_CLASSICAL) // optional 0.22.7 preset
     .higherDegrees(1)
     .lowerDegrees(1)
     .minConfidence(0.15)
@@ -713,6 +721,10 @@ Each per-degree `ElliottAnalysisResult` includes:
 | `trendBias` | Aggregate directional bias across scenarios |
 
 Use `breakdownFor(ElliottScenario)` to get the confidence breakdown for a specific scenario.
+
+### ElliottLogicProfile presets (0.22.7)
+
+`ElliottLogicProfile` packages reusable runner defaults (hierarchical swing sensitivity, enabled scenario families, and confidence-model style). Apply a preset with `ElliottWaveAnalysisRunner.Builder#logicProfile(...)` and override individual builder settings afterward when needed. Presets include `ORTHODOX_CLASSICAL`, `HIERARCHICAL_SWING`, `BTC_RELAXED_IMPULSE`, `BTC_RELAXED_CORRECTIVE`, and `ANCHOR_FIRST_HYBRID`.
 
 ### Walk-forward adapters
 
@@ -1421,6 +1433,47 @@ if (!set.isEmpty()) {
 ---
 
 ## Integration with Trading Strategies
+
+### Built-in scenario rules (`org.ta4j.core.rules.elliott`)
+
+ta4j ships public `Rule` implementations that read the base case from an `ElliottScenarioIndicator` (typically `facade.scenarios()`). All rules evaluate the ranked **base** scenario unless noted otherwise.
+
+| Rule | Purpose |
+| --- | --- |
+| `ElliottScenarioValidRule` | Base scenario exists and reference price is finite |
+| `ElliottScenarioConfidenceRule` | Base confidence meets a minimum threshold |
+| `ElliottScenarioDirectionRule` | Base scenario is bullish or bearish |
+| `ElliottImpulsePhaseRule` | Base scenario is impulse-typed and in allowed `ElliottPhase` values |
+| `ElliottScenarioAlternationRule` | Wave 2/4 alternation meets a minimum duration ratio |
+| `ElliottScenarioCompletionRule` | Base scenario `expectsCompletion()` is true |
+| `ElliottScenarioRiskRewardRule` | Base scenario risk/reward meets a minimum |
+| `ElliottScenarioTargetReachedRule` | Price has reached the scenario primary target |
+| `ElliottScenarioStopViolationRule` | Price breached the corrective stop |
+| `ElliottScenarioInvalidationRule` | Price invalidated the base scenario (useful as an exit trigger) |
+| `ElliottScenarioTimeStopRule` | Trade exceeded the maximum wave-duration window |
+| `ElliottTrendBiasRule` | Aggregated `ElliottTrendBias` direction and strength thresholds |
+
+Example wiring with a tolerance-aware facade:
+
+```java
+Num fibTolerance = series.numFactory().numOf(0.25);
+ElliottWaveFacade facade = ElliottWaveFacade.fractal(
+        series, 5, ElliottDegree.INTERMEDIATE, Optional.of(fibTolerance), Optional.empty());
+ElliottScenarioIndicator scenarios = facade.scenarios();
+ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+Rule entryRule = new ElliottScenarioValidRule(scenarios, close)
+        .and(new ElliottScenarioConfidenceRule(scenarios, 0.6))
+        .and(new ElliottImpulsePhaseRule(scenarios, ElliottPhase.WAVE3))
+        .and(new ElliottScenarioDirectionRule(scenarios, true))
+        .and(new ElliottTrendBiasRule(scenarios, true, 0.5));
+
+Rule exitRule = new ElliottScenarioInvalidationRule(scenarios, close)
+        .or(new ElliottScenarioTargetReachedRule(scenarios, close, true))
+        .or(new ElliottScenarioTimeStopRule(scenarios, 2.0));
+```
+
+Prefer these rules over ad-hoc anonymous `Rule` implementations when the built-in semantics match your strategy.
 
 ### Basic Scenario-Aware Rule
 

--- a/Elliott-Wave-Quickstart.md
+++ b/Elliott-Wave-Quickstart.md
@@ -10,7 +10,10 @@ For full theory, component internals, scenario scoring, and advanced usage, see 
 BarSeries series = ...;
 int index = series.getEndIndex();
 
-ElliottWaveFacade facade = ElliottWaveFacade.fractal(series, 5, ElliottDegree.INTERMEDIATE);
+// Optional: loosen/tighten Fibonacci validation for both phase() and scenarios()
+Num fibTolerance = series.numFactory().numOf(0.25);
+ElliottWaveFacade facade = ElliottWaveFacade.fractal(
+        series, 5, ElliottDegree.INTERMEDIATE, Optional.of(fibTolerance), Optional.empty());
 
 ElliottPhase phase = facade.phase().getValue(index);
 ElliottScenarioSet scenarios = facade.scenarios().getValue(index);
@@ -19,11 +22,15 @@ Num invalidation = facade.invalidationLevel().getValue(index);
 
 Use this path when you need indicator-style access inside rules or chart overlays.
 
+For strategy entries/exits, prefer the public rules in `org.ta4j.core.rules.elliott` (for example `ElliottScenarioConfidenceRule`, `ElliottImpulsePhaseRule`, `ElliottScenarioInvalidationRule`) wired to `facade.scenarios()` — see [Elliott Wave Indicators — Built-in scenario rules](Elliott-Wave-Indicators.md#built-in-scenario-rules-orgta4jcoreruleselliott).
+
 ## 2) Use one-shot analysis for reports
 
 ```java
-ElliottWaveAnalysisRunner runner = ElliottWaveAnalysisRunner.defaultRunner();
-ElliottWaveAnalysis analysis = runner.analyze(series, series.getEndIndex());
+ElliottWaveAnalysisRunner runner = ElliottWaveAnalysisRunner.builder()
+        .logicProfile(ElliottLogicProfile.ORTHODOX_CLASSICAL) // optional 0.22.7 preset
+        .build();
+ElliottWaveAnalysisResult result = runner.analyze(series);
 ```
 
 Use this path when you want report generation or standalone analysis steps.

--- a/Elliott-Wave-Quickstart.md
+++ b/Elliott-Wave-Quickstart.md
@@ -28,6 +28,7 @@ For strategy entries/exits, prefer the public rules in `org.ta4j.core.rules.elli
 
 ```java
 ElliottWaveAnalysisRunner runner = ElliottWaveAnalysisRunner.builder()
+        .degree(ElliottDegree.INTERMEDIATE)
         .logicProfile(ElliottLogicProfile.ORTHODOX_CLASSICAL) // optional 0.22.7 preset
         .build();
 ElliottWaveAnalysisResult result = runner.analyze(series);

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -139,9 +139,10 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators` | **ChopIndicator** | Choppiness Index (0–100); measures trend vs range. |
 | `org.ta4j.core.indicators` | **UlcerIndexIndicator** | Ulcer Index; depth and duration of drawdowns. |
 | `org.ta4j.core.indicators` | **SqueezeProIndicator** | Squeeze Pro; momentum in low volatility (e.g. Bollinger vs Keltner). |
+| `org.ta4j.core.indicators` | **CompressionIndicator** | Composite contraction score (0–100) from inverted ATR, Bollinger width, and Donchian width percentile ranks. |
 
 **Short usage**  
-- **What it is:** ATR measures volatility; Bollinger/Keltner/Donchian define channels; Chandelier/Chop/Ulcer/SqueezePro add exit or regime context.  
+- **What it is:** ATR measures volatility; Bollinger/Keltner/Donchian define channels; Chandelier/Chop/Ulcer/SqueezePro add exit or regime context; CompressionIndicator scores tightening regimes.
 - **Theory:** Volatility expands in trends and contracts in consolidation; bands and ATR-based stops adapt to current volatility.  
 - **When to use:** Stops (ATR, Chandelier), breakout/mean-reversion (bands, %B), and filtering (Chop, SqueezePro).  
 - **When not to use:** When volatility input (e.g. ATR) is not yet stable (respect unstable bars).  
@@ -225,9 +226,14 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.trend` | **UpTrendIndicator** | Boolean: price in uptrend (e.g. above MA). |
 | `org.ta4j.core.indicators.trend` | **DownTrendIndicator** | Boolean: price in downtrend. |
 | `org.ta4j.core.indicators` | **VortexIndicator** | Vortex (+VI, −VI, and oscillator) trend-strength/direction indicator. |
+| `org.ta4j.core.indicators` | **TrendScoreIndicator** | Directional composite (−100 to +100) from EMA alignment, MACD histogram, and signed ADX strength/change. |
+| `org.ta4j.core.indicators` | **TrendConclusionIndicator** | Composite (0–100) estimating whether a strong trend has cooled (ADX fade, MACD mean reversion, price recenter, compression). |
+| `org.ta4j.core.indicators` | **EntryEdgeIndicator** | Rolling realized entry edge in basis points vs an unconditional baseline; uses only matured forward returns (no look-ahead). |
+| `org.ta4j.core.indicators` | **EdgeDecaySlopeIndicator** | Rolling slope of an edge indicator; positive values indicate improving edge, negative values indicate decay. |
+| `org.ta4j.core.indicators` | **StretchZScoreIndicator** | Z-score of deviation between a source and reference indicator (e.g. price vs SMA or VWAP stretch). |
 
 **Short usage**  
-- **What it is:** ADX/DI measure trend strength and direction; Aroon and Ichimoku add structure; SuperTrend gives a single trend line.  
+- **What it is:** ADX/DI measure trend strength and direction; Aroon and Ichimoku add structure; SuperTrend gives a single trend line; TrendScore/TrendConclusion compress multi-factor regime context; EntryEdge/EdgeDecaySlope quantify signal quality over time.
 - **Theory:** Trend strength (ADX) filters choppy markets; Ichimoku and SuperTrend provide levels and direction.  
 - **When to use:** Filtering entries (e.g. only when ADX &gt; 25), trend-following exits (SuperTrend), and multi-timeframe structure (Ichimoku).  
 - **When not to use:** In ranging markets (ADX low) for trend-only strategies; SuperTrend can whipsaw in chop.  
@@ -302,6 +308,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.candles` | **ThreeBlackCrowsIndicator** | Three black crows. |
 | `org.ta4j.core.indicators.candles` | **ThreeInsideUpIndicator** | Three inside up. |
 | `org.ta4j.core.indicators.candles` | **ThreeInsideDownIndicator** | Three inside down. |
+| `org.ta4j.core.indicators.candles` | **AbstractMarubozuIndicator** | Base class for marubozu pattern indicators (body-to-range ratio threshold). |
 
 **Short usage**  
 - **What it is:** Single- or multi-candle pattern detectors returning boolean (or equivalent) at each bar.  
@@ -350,6 +357,8 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators` | **FractalLowIndicator** | Bill Williams fractal low confirmation indicator (no look-ahead). |
 | `org.ta4j.core.indicators` | **RecentFractalSwingHighIndicator** | Most recent fractal swing high (Bill Williams style). |
 | `org.ta4j.core.indicators` | **RecentFractalSwingLowIndicator** | Most recent fractal swing low. |
+| `org.ta4j.core.indicators` | **AbstractFractalConfirmationIndicator** | Base class for Bill Williams fractal confirmation indicators. |
+| `org.ta4j.core.indicators` | **AbstractRecentFractalSwingIndicator** | Base class for most-recent fractal swing high/low price indicators. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagPivotHighIndicator** | True at ZigZag pivot high bars. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagPivotLowIndicator** | True at ZigZag pivot low bars. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagStateIndicator** | ZigZag state (e.g. current segment direction and levels). |
@@ -436,8 +445,14 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.statistics` | **VarianceIndicator** | Variance of source over period; defaults to sample variance and supports explicit sample/population modes. |
 | `org.ta4j.core.indicators.statistics` | **MeanDeviationIndicator** | Mean absolute deviation. |
 | `org.ta4j.core.indicators.statistics` | **CovarianceIndicator** | Covariance between two indicators. |
-| `org.ta4j.core.indicators.statistics` | **CorrelationCoefficientIndicator** | Correlation between two series; supports sample/population variance normalization. |
+| `org.ta4j.core.indicators.statistics` | **CorrelationCoefficientIndicator** | Correlation between two series; supports sample/population variance normalization; unstable bars follow variance/covariance warm-up. |
 | `org.ta4j.core.indicators.statistics` | **PearsonCorrelationIndicator** | Pearson correlation. |
+| `org.ta4j.core.indicators.statistics` | **KendallTauIndicator** | Rolling Kendall tau-b rank correlation (ordinal association with tie corrections). |
+| `org.ta4j.core.indicators.statistics` | **SpearmanRankCorrelationIndicator** | Rolling Spearman rank correlation (Pearson on ranks with average-rank ties). |
+| `org.ta4j.core.indicators.statistics` | **LaggedCorrelationIndicator** | Rolling Pearson correlation with configurable lag between the two series. |
+| `org.ta4j.core.indicators.statistics` | **DistanceCorrelationIndicator** | Rolling distance correlation (detects linear and non-linear dependence; O(n²) per index). |
+| `org.ta4j.core.indicators.statistics` | **MutualInformationIndicator** | Rolling mutual information from equal-width binned windows (natural log, nats). |
+| `org.ta4j.core.indicators.statistics` | **RegimeSegmentedCorrelationIndicator** | Rolling Pearson correlation using only bars where a Boolean regime indicator is true. |
 | `org.ta4j.core.indicators.statistics` | **SimpleLinearRegressionIndicator** | Moving simple linear regression (slope/intercept). |
 | `org.ta4j.core.indicators.statistics` | **StandardErrorIndicator** | Standard error of regression (or estimate); supports sample/population standard-deviation modes. |
 | `org.ta4j.core.indicators.statistics` | **SigmaIndicator** | Z-score (value in standard deviations from mean); supports sample/population standard-deviation modes. |
@@ -448,9 +463,9 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.numeric` | **NumericIndicator** | Wraps a numeric expression (e.g. from indicator arithmetic) as an indicator. |
 
 **Short usage**  
-- **What it is:** Variance, std dev, correlation, regression, z-score, growth rate; numeric combinators (binary/unary); sample/population mode selection via `SampleType`.
+- **What it is:** Variance, std dev, correlation (Pearson, Kendall, Spearman, lagged, distance, regime-segmented), mutual information, regression, z-score, growth rate; numeric combinators (binary/unary); sample/population mode selection via `SampleType`.
 - **Theory:** Statistics describe distribution and relationship between series; operations allow custom formulas.  
-- **When to use:** Volatility (std dev), normalization (z-score), and composing indicators (Binary/Unary).  
+- **When to use:** Volatility (std dev), normalization (z-score), lead/lag analysis (`LaggedCorrelationIndicator`), non-linear dependence checks (`DistanceCorrelationIndicator`), and regime-conditioned correlation (`RegimeSegmentedCorrelationIndicator`).
 - **When not to use:** When period is too short for stable statistics.  
 - *Future: use cases, example code.*
 

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -308,7 +308,6 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.candles` | **ThreeBlackCrowsIndicator** | Three black crows. |
 | `org.ta4j.core.indicators.candles` | **ThreeInsideUpIndicator** | Three inside up. |
 | `org.ta4j.core.indicators.candles` | **ThreeInsideDownIndicator** | Three inside down. |
-| `org.ta4j.core.indicators.candles` | **AbstractMarubozuIndicator** | Base class for marubozu pattern indicators (body-to-range ratio threshold). |
 
 **Short usage**  
 - **What it is:** Single- or multi-candle pattern detectors returning boolean (or equivalent) at each bar.  
@@ -357,8 +356,6 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators` | **FractalLowIndicator** | Bill Williams fractal low confirmation indicator (no look-ahead). |
 | `org.ta4j.core.indicators` | **RecentFractalSwingHighIndicator** | Most recent fractal swing high (Bill Williams style). |
 | `org.ta4j.core.indicators` | **RecentFractalSwingLowIndicator** | Most recent fractal swing low. |
-| `org.ta4j.core.indicators` | **AbstractFractalConfirmationIndicator** | Base class for Bill Williams fractal confirmation indicators. |
-| `org.ta4j.core.indicators` | **AbstractRecentFractalSwingIndicator** | Base class for most-recent fractal swing high/low price indicators. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagPivotHighIndicator** | True at ZigZag pivot high bars. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagPivotLowIndicator** | True at ZigZag pivot low bars. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagStateIndicator** | ZigZag state (e.g. current segment direction and levels). |

--- a/Stop-Loss-and-Stop-Gain-Rules.md
+++ b/Stop-Loss-and-Stop-Gain-Rules.md
@@ -60,6 +60,15 @@ Best when:
 - Volatility regimes shift frequently.
 - You want stops that widen in high vol and tighten in low vol.
 
+## Entry hygiene rules (0.22.7)
+
+These rules complement stop exits when gating new entries:
+
+- `EdgeHealthyRule` — requires an edge indicator (typically `EntryEdgeIndicator`) to stay above a minimum level and optionally above a minimum slope (`EdgeDecaySlopeIndicator`).
+- `LossTriggeredCooldownRule` — blocks entries for a configurable number of bars after a losing closed position; supports optional reset rules and trade-side filters.
+
+Use them with regime filters (`TrendScoreIndicator`, `CompressionIndicator`) rather than as standalone risk controls.
+
 ## Quick selection guide
 
 - Trend-following swing systems:
@@ -233,6 +242,7 @@ See also:
 ## Maintainer rationale notes
 
 - Stop-rule family coverage mirrors the expanded hierarchy added in commit `89cd2271` (`BaseVolatility*`, fixed-amount, trailing, and stop-price model interfaces).
+- Documented entry hygiene rules `EdgeHealthyRule` and `LossTriggeredCooldownRule` (0.22.7).
 - ATR constructor guidance reflects commit `1fa097ef` and current `AverageTrueRange*` constructors that accept `ATRIndicator` directly.
 - Added positive-coefficient note for `AverageTrueRangeTrailingStopGainRule` based on its input validation in `requirePositiveAtrCoefficient(...)`.
 - Stop-price helper examples now include `StopLossRule.stopLossPriceFromDistance(...)`, `StopGainRule.stopGainPriceFromDistance(...)`, and `StopGainRule.trailingStopGainPriceFromDistance(...)`, which are used by the fixed-amount and volatility rule implementations.

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -7,7 +7,9 @@ Technical indicators (a.k.a. *technicals*) transform price/volume data into stru
 | Category | Highlights | Docs |
 | --- | --- | --- |
 | Trend / Moving Averages | SMA, EMA, HMA, VIDYA, Jurik, Displaced variants, SuperTrend, Renko helpers. | [Moving Average Indicators](Moving-Average-Indicators.md) |
-| Momentum & Oscillators | RSI family, NetMomentum (new), MACD/MACDV, MACD-V momentum states, KST, Stochastics, CMO, ROC. | This page |
+| Momentum & Oscillators | RSI family, NetMomentum, MACD/MACDV, MACD-V momentum states, KST, Stochastics, CMO, ROC. | This page |
+| Regime & signal quality | TrendScore, TrendConclusion, Compression, EntryEdge, EdgeDecaySlope, StretchZScore. | This page |
+| Advanced correlation | Kendall tau, Spearman, lagged/distance/regime-segmented correlation, mutual information. | [Indicators Inventory](Indicators-Inventory.md) §11 |
 | Volatility & Bands | ATR, Donchian, Bollinger, Keltner, Average True Range trailing stops. | [Bar Series & Bars](Bar-series-and-bars.md) (for ATR-based stops) |
 | Volume & Breadth | OBV, VWAP/VWMA, Accumulation/Distribution, Chaikin, Force Index, Ease of Movement, Klinger Volume Oscillator. | Indicators package |
 | Market Structure (VWAP/SR/Wyckoff) | Anchored VWAP, VWAP bands/z-score, price clusters, bounce counts, KDE volume profile, Wyckoff phase/cycle detection. | [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md) |
@@ -78,6 +80,31 @@ ta4j's volume package includes price/volume pressure oscillators that complement
 - `KlingerVolumeOscillatorIndicator` applies the Klinger volume-force formula and returns the short/long EMA spread (default `34/55`).
 
 Use them as participation or divergence filters; avoid treating them as standalone entries when volume quality is poor.
+
+## Regime and signal-quality workflow (0.22.7)
+
+ta4j 0.22.7 adds composite regime and edge-scoring indicators for strategy gating:
+
+- **Trend pressure:** `TrendScoreIndicator` (−100 to +100) combines EMA alignment, MACD histogram state, and signed ADX strength/change.
+- **Trend cooldown:** `TrendConclusionIndicator` (0–100) estimates whether a prior trend has likely cooled (ADX fade, MACD mean reversion, price recenter, compression).
+- **Contraction:** `CompressionIndicator` (0–100) scores tightening regimes from inverted ATR, Bollinger width, and Donchian width percentile ranks.
+- **Signal edge:** `EntryEdgeIndicator` reports realized entry edge in basis points using only matured forward returns (no look-ahead).
+- **Edge trajectory:** `EdgeDecaySlopeIndicator` tracks whether edge is improving or decaying over a lookback window.
+- **Stretch:** `StretchZScoreIndicator` normalizes deviation between any source/reference pair (close vs SMA, price vs VWAP, etc.).
+
+Pair edge indicators with `EdgeHealthyRule` and loss hygiene with `LossTriggeredCooldownRule` (see [Trading Strategies](Trading-strategies.md) and [Stop Loss & Stop Gain Rules](Stop-Loss-and-Stop-Gain-Rules.md)).
+
+## Advanced correlation workflow (0.22.7)
+
+Beyond Pearson/`CorrelationCoefficientIndicator`, ta4j now ships:
+
+- `KendallTauIndicator` and `SpearmanRankCorrelationIndicator` for rank-based association.
+- `LaggedCorrelationIndicator` for lead/lag analysis between two series.
+- `DistanceCorrelationIndicator` for non-linear dependence (prefer modest windows; O(n²) per index).
+- `MutualInformationIndicator` for binned mutual information (interpret as discretized MI for the configured bin count).
+- `RegimeSegmentedCorrelationIndicator` for Pearson correlation over bars where a Boolean regime is active.
+
+Use `SampleType` and `getCountOfUnstableBars()` when mixing rolling statistics with strategy warm-up.
 
 ## MACD-V momentum-state workflow (0.22.3)
 

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -9,7 +9,7 @@ Technical indicators (a.k.a. *technicals*) transform price/volume data into stru
 | Trend / Moving Averages | SMA, EMA, HMA, VIDYA, Jurik, Displaced variants, SuperTrend, Renko helpers. | [Moving Average Indicators](Moving-Average-Indicators.md) |
 | Momentum & Oscillators | RSI family, NetMomentum, MACD/MACDV, MACD-V momentum states, KST, Stochastics, CMO, ROC. | This page |
 | Regime & signal quality | TrendScore, TrendConclusion, Compression, EntryEdge, EdgeDecaySlope, StretchZScore. | This page |
-| Advanced correlation | Kendall tau, Spearman, lagged/distance/regime-segmented correlation, mutual information. | [Indicators Inventory](Indicators-Inventory.md) §11 |
+| Advanced correlation | Kendall tau, Spearman, lagged/distance/regime-segmented correlation, mutual information. | [Indicators Inventory §11](Indicators-Inventory.md#11-statistics--numeric) |
 | Volatility & Bands | ATR, Donchian, Bollinger, Keltner, Average True Range trailing stops. | [Bar Series & Bars](Bar-series-and-bars.md) (for ATR-based stops) |
 | Volume & Breadth | OBV, VWAP/VWMA, Accumulation/Distribution, Chaikin, Force Index, Ease of Movement, Klinger Volume Oscillator. | Indicators package |
 | Market Structure (VWAP/SR/Wyckoff) | Anchored VWAP, VWAP bands/z-score, price clusters, bounce counts, KDE volume profile, Wyckoff phase/cycle detection. | [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md) |

--- a/Trading-strategies.md
+++ b/Trading-strategies.md
@@ -213,6 +213,33 @@ That JSON payload captures the full rule graph, making it safe to persist strate
 - **Live trading** – Feed real-time bars into a moving `BarSeries`, call `strategy.shouldEnter(index, record)` / `shouldExit(...)`, then execute trades through your broker (see [Live Trading](Live-trading.md)).
 - **Diagnostics** – Mirror the approach in `ta4jexamples.logging.StrategyExecutionLogging` to trace which rule triggered each trade.
 
+## Regime and edge gating (0.22.7)
+
+Use composite indicators to filter entries when trend quality or signal edge is weak:
+
+```java
+ClosePriceIndicator close = new ClosePriceIndicator(series);
+SMAIndicator fast = new SMAIndicator(close, 9);
+SMAIndicator slow = new SMAIndicator(close, 21);
+Indicator<Boolean> entrySignal = new CrossIndicator(fast, slow);
+
+TrendScoreIndicator trendScore = new TrendScoreIndicator(series, 9, 21, 9, 14, 14);
+EntryEdgeIndicator entryEdge = new EntryEdgeIndicator(entrySignal, series, 5, 20);
+EdgeDecaySlopeIndicator edgeSlope = new EdgeDecaySlopeIndicator(entryEdge, 10);
+
+Rule signalRule = new BooleanIndicatorRule(entrySignal);
+Rule trendFilter = new OverIndicatorRule(trendScore, numOf(25));
+Rule edgeFilter = new EdgeHealthyRule(entryEdge, 50, edgeSlope, 0);
+Rule cooldown = new LossTriggeredCooldownRule(series, 5);
+
+Rule entryRule = signalRule.and(trendFilter).and(edgeFilter).and(cooldown);
+```
+
+- `EdgeHealthyRule` enforces minimum edge level and optional minimum edge slope.
+- `LossTriggeredCooldownRule` blocks new entries for N bars after a losing closed position (optional reset rule and side filter).
+
+See [Indicators Inventory](Indicators-Inventory.md) for `TrendConclusionIndicator`, `CompressionIndicator`, and `StretchZScoreIndicator`.
+
 ## Best practices
 
 - Normalize indicator scales when combining oscillators with price-based rules.
@@ -228,3 +255,4 @@ That JSON payload captures the full rule graph, making it safe to persist strate
 - Kept MACD-V regime examples aligned with `MomentumStateRule` and `MACDVMomentumStateStrategy` updates (commit `161f7656`).
 - Short-first guidance follows `Strategy#getStartingType()` and `BaseStrategy(..., TradeType)` from commit `b112d34b`.
 - Serialization examples now use `Strategy#toJson()`, `Strategy.fromJson(...)`, `Rule#toJson()`, and `Rule.fromJson(...)` from `org.ta4j.core.Strategy` / `org.ta4j.core.Rule` rather than only the lower-level `StrategySerialization` API introduced in commit `b62d9bad`.
+- Added regime/edge gating section for `TrendScoreIndicator`, `EntryEdgeIndicator`, `EdgeHealthyRule`, and `LossTriggeredCooldownRule` (ta4j 0.22.7, commits `fd6e1284` and follow-ups).

--- a/Trading-strategies.md
+++ b/Trading-strategies.md
@@ -221,15 +221,19 @@ Use composite indicators to filter entries when trend quality or signal edge is 
 ClosePriceIndicator close = new ClosePriceIndicator(series);
 SMAIndicator fast = new SMAIndicator(close, 9);
 SMAIndicator slow = new SMAIndicator(close, 21);
-Indicator<Boolean> entrySignal = new CrossIndicator(fast, slow);
+// CrossIndicator(up, low) is true when up crosses below low; use (slow, fast) for a bullish cross.
+Indicator<Boolean> entrySignal = new CrossIndicator(slow, fast);
 
 TrendScoreIndicator trendScore = new TrendScoreIndicator(series, 9, 21, 9, 14, 14);
 EntryEdgeIndicator entryEdge = new EntryEdgeIndicator(entrySignal, series, 5, 20);
 EdgeDecaySlopeIndicator edgeSlope = new EdgeDecaySlopeIndicator(entryEdge, 10);
 
 Rule signalRule = new BooleanIndicatorRule(entrySignal);
-Rule trendFilter = new OverIndicatorRule(trendScore, numOf(25));
-Rule edgeFilter = new EdgeHealthyRule(entryEdge, 50, edgeSlope, 0);
+Rule trendFilter = new OverIndicatorRule(trendScore, series.numFactory().numOf(25));
+Rule edgeFilter = new EdgeHealthyRule(entryEdge,
+        new ConstantIndicator<>(series, series.numFactory().numOf(50)),
+        edgeSlope,
+        null);
 Rule cooldown = new LossTriggeredCooldownRule(series, 5);
 
 Rule entryRule = signalRule.and(trendFilter).and(edgeFilter).and(cooldown);

--- a/VWAP-Support-Resistance-and-Wyckoff.md
+++ b/VWAP-Support-Resistance-and-Wyckoff.md
@@ -25,6 +25,7 @@ Combined, they answer:
 - `VWAPStandardDeviationIndicator`: volume-weighted standard deviation around VWAP.
 - `VWAPBandIndicator`: VWAP bands (`VWAP +/- multiplier * stdDev`).
 - `VWAPZScoreIndicator`: normalized deviation (`deviation / stdDev`).
+- `StretchZScoreIndicator`: generic stretch z-score between any source/reference pair (for example close vs VWAP or vs a band midpoint).
 
 ### Support/resistance family
 


### PR DESCRIPTION
## Summary

- Sync `Indicators-Inventory.md` with 15 missing indicator classes (regime/edge scoring, advanced correlation family, compression, abstract bases).
- Add 0.22.7 workflow sections to `Technical-indicators.md`, `Trading-strategies.md`, and `Stop-Loss-and-Stop-Gain-Rules.md` for regime gating and entry hygiene.
- Document `StretchZScoreIndicator` in the VWAP/SR guide.

coderabbitai

## Test plan

- [x] Indicator inventory diff vs `ta4j-core` (only duplicate `MACDVIndicator` shim remains ambiguous by name)
- [x] `git diff --check` passes
- [ ] Review rendered markdown on GitHub wiki

## Drift report

**Newly documented (inventory + guides):**
- Statistics: `KendallTauIndicator`, `SpearmanRankCorrelationIndicator`, `LaggedCorrelationIndicator`, `DistanceCorrelationIndicator`, `MutualInformationIndicator`, `RegimeSegmentedCorrelationIndicator`
- Regime/edge: `TrendScoreIndicator`, `TrendConclusionIndicator`, `CompressionIndicator`, `EntryEdgeIndicator`, `EdgeDecaySlopeIndicator`, `StretchZScoreIndicator`
- Rules (guides): `EdgeHealthyRule`, `LossTriggeredCooldownRule`

**Follow-up gaps (maintainer decision):**
- Elliott scenario rules (`ElliottScenario*Rule`) still lack a dedicated wiki page (inventory scout flagged 61 name-only gaps; most are internal/analysis types)
- No `ta4j-examples` walkthrough yet for regime/edge gating (core API documented only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added 15+ new technical indicators for volatility analysis, trend analysis, candlestick patterns, swing analysis, and statistical correlations.
  * New comprehensive guidance on regime and signal-quality workflows with entry edge analysis capabilities.
  * Added advanced correlation analysis documentation covering multiple statistical methods.
  * New entry hygiene rules and regime/edge gating strategies documentation for trading workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ta4j/ta4j-wiki/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->