### PR TITLE
CF-289 document forecast indicators

### DIFF
--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -73,9 +73,10 @@ The raw `PredictionSnapshot.Forecast<Num>` summary remains useful for diagnostic
 - `isStable()`: whether the forecast is usable at this decision index.
 - `mean()`, `median()`, `standardDeviation()`: summary values.
 - `quantiles()`: configured quantile probabilities to values.
-- `quantile(probability)`: one configured quantile value.
+- `hasQuantile(probability)`: whether a valid quantile probability is available.
+- `quantile(probability)`: one configured quantile value, or `null` when a valid probability was not configured.
 
-Only request quantiles that were configured on the underlying Monte Carlo projection. For example, `priceForecast.getValue(index).quantile(0.05)` and `priceForecast.quantile(0.05).getValue(index)` both work with the default quantile set, while advanced return-projection builders must include any non-default probabilities in `quantiles(...)`.
+Direct lookup and projection helpers handle missing quantiles differently. `priceForecast.getValue(index).quantile(0.90)` returns `null` when `0.90` was not configured, while `priceForecast.quantile(0.90).getValue(index)` returns `NaN` so the result composes safely as an `Indicator<Num>`. Invalid probabilities outside `[0, 1]` still throw.
 
 ## Point Projection Indicators
 
@@ -273,7 +274,8 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | Projection values are `NaN` early in the series. | Warm-up and lookback requirements are not met. | Start reading after `forecast.getCountOfUnstableBars()`. |
-| Quantile projection is `NaN` at a stable index. | The probability was not included in `quantiles(...)`. | The default quantile set includes `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`; for other probabilities add that exact value with `MonteCarloReturnProjectionIndicator.builder(state).quantiles(...)`. |
+| Direct quantile lookup returns `null`. | The probability was valid but was not included in `quantiles(...)`. | Use `forecast.hasQuantile(probability)` before direct `forecast.quantile(probability)`, or configure that probability on the Monte Carlo builder. |
+| Quantile projection is `NaN` at a stable index. | The probability was valid but was not included in `quantiles(...)`. | The default quantile set includes `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`; for other probabilities add that exact value with `MonteCarloReturnProjectionIndicator.builder(state).quantiles(...)`. |
 | Point forecast is `NaN`. | The source forecast is unstable, the projection requested a missing quantile, or source data is invalid. | Check warm-up, configured quantiles, and source price/return validity. |
 | A constructor rejects the return input. | The stream declares a non-log `ReturnRepresentation`. | Use `LogReturnIndicator` or another `ReturnIndicator` that explicitly returns `ReturnRepresentation.LOG`. Decimal, percentage, and multiplicative returns need separate projection support. |
 | `MonteCarloPriceForecastIndicator` rejects a custom log-return state. | The state uses a custom `ReturnIndicator` whose source price cannot be inferred. | Use `LogReturnToPriceForecastIndicator` with the explicit price indicator and an explicit `MonteCarloReturnProjectionIndicator`. |

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -1,0 +1,309 @@
+# Forecast Indicators
+
+Forecast indicators estimate a future distribution from data available at a decision index. They are useful when a strategy needs a probabilistic price or return outlook instead of a single backward-looking technical signal.
+
+The forecast API lives mostly in `org.ta4j.core.indicators.forecast`. `LogReturnIndicator` is a normal helper indicator in `org.ta4j.core.indicators.helpers` and can be used outside forecasting pipelines.
+
+## When to use them
+
+Use forecast indicators when you want to answer questions such as:
+
+- What is the median expected close price five bars from now?
+- What are the 5th and 95th percentile price outcomes for the next session?
+- Is the forecast distribution wide enough that a signal should be ignored?
+- How does a signal perform when evaluated against a fixed future horizon?
+
+Do not treat a forecast as a guaranteed target. A forecast distribution is an input to risk management, strategy rules, sizing, and research. It should still be validated with realistic execution assumptions and out-of-sample tests.
+
+## Quick Start: Price Forecast Distribution
+
+This example builds the standard EWMA-volatility Monte Carlo pipeline and returns forecast prices, not returns.
+
+```java
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.indicators.forecast.DriftMode;
+import org.ta4j.core.indicators.forecast.EwmaReturnForecastStateConfig;
+import org.ta4j.core.indicators.forecast.ForecastDistribution;
+import org.ta4j.core.indicators.forecast.ForecastDistributionIndicator;
+import org.ta4j.core.indicators.forecast.ForecastIndicators;
+import org.ta4j.core.indicators.forecast.MonteCarloForecastConfig;
+import org.ta4j.core.indicators.forecast.ShockModel;
+import org.ta4j.core.indicators.forecast.VolatilityUpdateMode;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.num.Num;
+
+BarSeries series = ...;
+ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+EwmaReturnForecastStateConfig stateConfig = EwmaReturnForecastStateConfig.builder()
+        .initializationBarCount(30)
+        .decayFactor(0.94)
+        .driftMode(DriftMode.ZERO)
+        .build();
+
+MonteCarloForecastConfig forecastConfig = MonteCarloForecastConfig.builder()
+        .horizon(5)
+        .iterationCount(2_000)
+        .lookbackBarCount(252)
+        .seed(42L)
+        .shockModel(ShockModel.STANDARDIZED_EMPIRICAL)
+        .volatilityUpdateMode(VolatilityUpdateMode.CONSTANT)
+        .quantiles(0.05, 0.5, 0.95)
+        .build();
+
+ForecastDistributionIndicator<Num> priceForecast =
+        ForecastIndicators.ewmaVolatilityClosePriceForecast(close, stateConfig, forecastConfig);
+
+int index = series.getEndIndex();
+ForecastDistribution<Num> distribution = priceForecast.getValue(index);
+
+if (distribution.defined()) {
+    Num downside = distribution.quantile(0.05);
+    Num median = distribution.median();
+    Num upside = distribution.quantile(0.95);
+}
+```
+
+At each index, `ForecastDistribution<Num>` contains:
+
+- `index()`: the decision index where the forecast was made.
+- `horizon()`: the configured number of bars ahead.
+- `sampleCount()`: the number of simulated samples summarized.
+- `defined()`: whether the forecast is usable.
+- `mean()`, `median()`, `standardDeviation()`: summary values.
+- `quantiles()`: configured quantile probabilities to values.
+- `quantile(probability)`: one configured quantile value.
+
+Only request quantiles that were configured in `MonteCarloForecastConfig`. For example, `distribution.quantile(0.05)` is available only if `0.05` was included in `quantiles(...)`.
+
+## Point Forecasts
+
+Many rules and indicators need one `Num` value. Use `ForwardForecastIndicator` with a reducer when you want one point from a distribution.
+
+```java
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.forecast.ForecastReducers;
+import org.ta4j.core.indicators.forecast.ForwardForecastIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.rules.OverIndicatorRule;
+import org.ta4j.core.Rule;
+
+Indicator<Num> medianForecast =
+        new ForwardForecastIndicator(priceForecast, ForecastReducers.median());
+
+Indicator<Num> downsideForecast =
+        new ForwardForecastIndicator(priceForecast, ForecastReducers.quantile(0.05));
+
+Rule forecastAboveCurrentPrice = new OverIndicatorRule(medianForecast, close);
+```
+
+There is also a convenience factory for the common median close-price case:
+
+```java
+Indicator<Num> medianPriceForecast =
+        ForecastIndicators.ewmaVolatilityMedianClosePriceForecast(close, stateConfig, forecastConfig);
+```
+
+Reducers return `NaN` when the source distribution is undefined or when the requested quantile is missing. That makes reduced forecasts safe to compose with normal ta4j rules and indicators.
+
+## Manual Pipeline
+
+The convenience factory builds this pipeline:
+
+```mermaid
+graph TD
+    CP["ClosePriceIndicator or another price Indicator<Num>"] --> LR["LogReturnIndicator"]
+    LR --> EWMA["EwmaReturnForecastStateIndicator"]
+    LR --> MC["MonteCarloReturnForecastIndicator"]
+    EWMA --> MC
+    MC --> PRICE["LogReturnToPriceForecastIndicator"]
+    PRICE --> REDUCE["ForwardForecastIndicator (optional)"]
+```
+
+Use the manual pipeline when you need direct access to return forecasts, a custom price source, a custom reducer, or intermediate state diagnostics.
+
+```java
+import org.ta4j.core.indicators.forecast.EwmaReturnForecastStateIndicator;
+import org.ta4j.core.indicators.forecast.ForecastDistributionIndicator;
+import org.ta4j.core.indicators.forecast.LogReturnToPriceForecastIndicator;
+import org.ta4j.core.indicators.forecast.MonteCarloReturnForecastIndicator;
+import org.ta4j.core.indicators.helpers.LogReturnIndicator;
+import org.ta4j.core.num.Num;
+
+LogReturnIndicator returns = new LogReturnIndicator(close);
+EwmaReturnForecastStateIndicator state =
+        new EwmaReturnForecastStateIndicator(returns, stateConfig);
+
+ForecastDistributionIndicator<Num> returnForecast =
+        new MonteCarloReturnForecastIndicator(returns, state, forecastConfig);
+
+ForecastDistributionIndicator<Num> priceForecast =
+        new LogReturnToPriceForecastIndicator(close, returnForecast);
+```
+
+`MonteCarloReturnForecastIndicator` produces a cumulative log-return distribution over the configured horizon. `LogReturnToPriceForecastIndicator` converts it to a price distribution with:
+
+```text
+forecastPrice = priceAtDecisionIndex * exp(cumulativeLogReturn)
+```
+
+## Configuration Guide
+
+### EWMA State
+
+`EwmaReturnForecastStateIndicator` estimates rolling return state from a log-return source.
+
+| Setting | Default | Meaning | Common tuning |
+| --- | --- | --- | --- |
+| `initializationBarCount` | `30` | Number of valid return observations required before state is defined. | Increase for slower, steadier estimates; decrease for faster adaptation. |
+| `decayFactor` | `0.94` | EWMA persistence in `(0, 1)`. Higher values react more slowly. | Use higher values for daily data and lower values for shorter bars only after validation. |
+| `driftMode` | `DriftMode.ZERO` | Drift used in simulated paths. | Prefer `ZERO` as a conservative default; use `ROLLING_MEAN` only when the rolling mean has validated predictive value. |
+
+The state output is a `ReturnForecastState` with rolling `mean`, forecast `drift`, `variance`, and `volatility`.
+
+### Monte Carlo Forecast
+
+`MonteCarloForecastConfig` controls horizon, samples, shock model, and returned quantiles.
+
+| Setting | Default | Meaning | Common tuning |
+| --- | --- | --- | --- |
+| `horizon` | `1` | Number of bars ahead to forecast. | Match the holding period or evaluation label. |
+| `iterationCount` | `1_000` | Number of simulated paths. | Increase for smoother quantiles; reduce only for latency-sensitive live loops after measuring. |
+| `lookbackBarCount` | `252` | Number of historical returns used for empirical shocks. | Match the market regime window you want represented. |
+| `seed` | `42L` | Base random seed. | Keep fixed for reproducible research and tests. |
+| `shockModel` | `STANDARDIZED_EMPIRICAL` | Source of simulated return shocks. | See the shock model table below. |
+| `volatilityUpdateMode` | `CONSTANT` | Volatility behavior inside each simulated path. | Use `EWMA` only when path-dependent volatility is part of the model assumption. |
+| `volatilityDecayFactor` | `0.94` | EWMA decay used when volatility updates are enabled. | Usually match the state decay factor. |
+| `quantiles` | `0.05, 0.25, 0.5, 0.75, 0.95` | Distribution percentiles to include. | Configure only the percentiles your strategy or report consumes. |
+
+### Shock Models
+
+| Shock model | Behavior | Use when |
+| --- | --- | --- |
+| `HISTORICAL_BOOTSTRAP` | Samples raw historical returns from the lookback window. | You want the recent empirical return distribution without rescaling by current volatility. |
+| `STANDARDIZED_EMPIRICAL` | Samples standardized residuals and scales them by the current EWMA state. | You want empirical tail shape with current volatility and drift. This is the default. |
+| `NORMAL` | Draws standard normal shocks and scales them by the current EWMA state. | You want a simple parametric baseline and accept thinner tails than many markets show. |
+
+### Volatility Update Modes
+
+| Mode | Behavior | Tradeoff |
+| --- | --- | --- |
+| `CONSTANT` | Uses the decision-index volatility for every simulated step in a path. | Simple, reproducible, and usually the first model to validate. |
+| `EWMA` | Updates path volatility after each simulated step using `volatilityDecayFactor`. | More dynamic, but adds another assumption that must be tested. |
+
+## Warm-Up and Undefined Values
+
+Forecast indicators deliberately return undefined distributions until enough valid data is available.
+
+Important warm-up rules:
+
+- `LogReturnIndicator` is unstable for `source.getCountOfUnstableBars() + barCount` bars.
+- `EwmaReturnForecastStateIndicator` is unstable for `returnIndicator.getCountOfUnstableBars() + initializationBarCount - 1` bars.
+- `MonteCarloReturnForecastIndicator` is unstable until both the state is stable and the configured return lookback is available.
+- With the default one-bar log return and default `lookbackBarCount(252)`, the standard Monte Carlo return forecast first becomes eligible at index `252` when all returns are valid.
+
+Undefined values can also occur after warm-up when:
+
+- A source price is zero, negative, `NaN`, or infinite.
+- A return in the required initialization window is invalid.
+- The historical lookback does not contain enough valid returns.
+- A price forecast cannot be converted because the decision-index price is invalid or non-positive.
+
+Always check `distribution.defined()` before reading summary values in reporting code. Point-forecast reducers return `NaN` for undefined distributions, which normal ta4j rules will treat as not satisfying comparisons.
+
+## Avoiding Look-Ahead Bias
+
+Forecast indicators are designed to produce `getValue(i)` using only source data available at or before index `i`. The forecast horizon describes what the distribution is about; it does not allow the indicator to read future bars.
+
+For research:
+
+- Generate the forecast at decision index `i`.
+- Compare it later with the realized value at `i + horizon`.
+- Do not feed realized future returns back into the strategy rule at `i`.
+- Match `horizon` to the execution and holding-period assumption you are testing.
+
+For live trading:
+
+- Evaluate the forecast only after the decision bar contains the data your execution model assumes.
+- Prefer next-open or broker-confirmed execution unless your system truly can act on the current close.
+- Keep the moving `BarSeries` large enough to retain the return lookback plus warm-up margin.
+
+## Practical Strategy Patterns
+
+### Median Direction Filter
+
+Use the median point forecast as a directional filter:
+
+```java
+Indicator<Num> medianForecast =
+        ForecastIndicators.ewmaVolatilityMedianClosePriceForecast(close, stateConfig, forecastConfig);
+
+Rule bullishForecast = new OverIndicatorRule(medianForecast, close);
+```
+
+This is intentionally minimal. In real strategies, add costs, slippage, and a required edge threshold so tiny forecast differences do not trigger trades.
+
+### Downside Risk Filter
+
+Use a low quantile to avoid entries when the downside tail is too close.
+
+```java
+Indicator<Num> fifthPercentilePrice =
+        new ForwardForecastIndicator(priceForecast, ForecastReducers.quantile(0.05));
+
+Rule downsideAboveStop = new OverIndicatorRule(fifthPercentilePrice, plannedStopPrice);
+```
+
+`plannedStopPrice` can be any `Indicator<Num>` on the same series, such as an ATR stop, support indicator, or fixed threshold indicator.
+
+### Distribution Width Filter
+
+Use `ForecastReducers.standardDeviation()` when you want to avoid forecasts that are too uncertain, or require enough spread for a volatility strategy. The result is in the same unit as the distribution: log-return units for return forecasts and price units for price forecasts.
+
+## Choosing Return or Price Space
+
+Use return forecasts when:
+
+- You are comparing forecasts across instruments with different price levels.
+- You want cumulative log-return quantiles for research labels.
+- You are building position sizing or risk logic in return space.
+
+Use price forecasts when:
+
+- Strategy rules compare the forecast to current price, stops, targets, support, resistance, or chart overlays.
+- You want report output in user-facing price units.
+
+`LogReturnToPriceForecastIndicator` is the bridge between the two.
+
+## Reproducibility Notes
+
+The Monte Carlo indicator mixes the configured seed with the decision index and horizon. That means the same seed, index, horizon, inputs, and configuration produce the same distribution independent of call order. This is important for cached indicators, tests, and chart rendering.
+
+Do not rely on a seed to make an invalid forecast defined. Reproducibility only applies once the data and warm-up requirements are satisfied.
+
+## Common Problems
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `distribution.defined()` is false early in the series. | Warm-up and lookback requirements are not met. | Start reading after `forecast.getCountOfUnstableBars()`. |
+| A configured quantile throws when requested. | The probability was not included in `quantiles(...)`. | Add that exact probability to `MonteCarloForecastConfig`. |
+| Point forecast is `NaN`. | The source distribution is undefined or the reducer requested a missing quantile. | Check `defined()` on the distribution source and config. |
+| Price forecast is undefined while return forecast is defined. | Decision-index price is non-positive or invalid. | Check the source price indicator and data feed. |
+| Live forecasts disappear with a moving series. | The series evicted bars required by the lookback. | Increase `setMaximumBarCount` or reduce lookback after validation. |
+
+## API Map
+
+| Type | Package | Purpose |
+| --- | --- | --- |
+| `LogReturnIndicator` | `org.ta4j.core.indicators.helpers` | Normal numeric helper indicator for `log(x[i] / x[i - n])`. |
+| `EwmaReturnForecastStateConfig` | `org.ta4j.core.indicators.forecast` | EWMA state configuration. |
+| `EwmaReturnForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Rolling return mean, drift, variance, and volatility estimator. |
+| `ReturnForecastState` | `org.ta4j.core.indicators.forecast` | State record produced by the EWMA estimator. |
+| `MonteCarloForecastConfig` | `org.ta4j.core.indicators.forecast` | Monte Carlo horizon, iteration, seed, shock, volatility, and quantile settings. |
+| `MonteCarloReturnForecastIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return forecast distribution indicator. |
+| `ForecastDistribution` | `org.ta4j.core.indicators.forecast` | Immutable distribution summary record. |
+| `ForecastDistributionIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for distribution-valued forecasts. |
+| `LogReturnToPriceForecastIndicator` | `org.ta4j.core.indicators.forecast` | Converts cumulative log-return distributions to price distributions. |
+| `ForwardForecastIndicator` | `org.ta4j.core.indicators.forecast` | Reduces a distribution to one `Num` point forecast. |
+| `ForecastReducers` | `org.ta4j.core.indicators.forecast` | Built-in reducers for mean, median, standard deviation, and quantiles. |
+| `ForecastIndicators` | `org.ta4j.core.indicators.forecast` | Convenience factories for standard forecast pipelines. |

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -2,7 +2,7 @@
 
 Forecast indicators estimate a future return or price distribution from data available at a decision index. They are useful when a strategy needs a probabilistic outlook instead of a single backward-looking technical signal.
 
-The forecast API lives mostly in `org.ta4j.core.indicators.forecast`. `LogReturnIndicator` is a normal helper indicator in `org.ta4j.core.indicators.helpers`, `EWMAIndicator` is a reusable average in `org.ta4j.core.indicators.averages`, and forecast summaries use the walk-forward prediction model via `PredictionSnapshot.Forecast`.
+The forecast API lives under `org.ta4j.core.indicators.forecast`. The root package contains the primary indicators most users instantiate, while state contracts, projection contracts, and conversion adapters live in `forecast.state`, `forecast.projection`, and `forecast.adapters`. `LogReturnIndicator` is a normal helper indicator in `org.ta4j.core.indicators.helpers`, `EWMAIndicator` is a reusable average in `org.ta4j.core.indicators.averages`, and forecast summaries use the walk-forward prediction model via `PredictionSnapshot.Forecast`.
 
 **Release status:** These APIs are introduced by the matching ta4j feature branch for CF-289 and should be published with ta4j 0.22.9 or newer. Until that ta4j change is merged and released, use this guide with the matching ta4j branch rather than the current release artifacts.
 
@@ -25,9 +25,9 @@ This example builds an EWMA-volatility Monte Carlo pipeline and projects forecas
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.forecast.EwmaReturnForecastStateIndicator;
-import org.ta4j.core.indicators.forecast.ForecastProjectionIndicator;
 import org.ta4j.core.indicators.forecast.MonteCarloPriceForecastIndicator;
-import org.ta4j.core.indicators.forecast.ReturnForecastStateIndicator;
+import org.ta4j.core.indicators.forecast.projection.ForecastProjectionIndicator;
+import org.ta4j.core.indicators.forecast.state.ReturnForecastStateIndicator;
 import org.ta4j.core.indicators.helpers.LogReturnIndicator;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.walkforward.PredictionSnapshot;
@@ -65,6 +65,16 @@ The setup has three business decisions:
 
 The default EWMA state uses a 30-bar initialization window, `0.94` decay, and zero drift. The default Monte Carlo projection uses standardized empirical shocks, 1,000 simulations, a 252-return lookback, and default quantiles of `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`.
 
+## Architecture
+
+The forecasting layer is organized around three responsibilities:
+
+- **Hidden state estimators** build latent state from source indicators. `EwmaReturnForecastStateIndicator` is the initial estimator; its reusable contracts and state record live in `org.ta4j.core.indicators.forecast.state`.
+- **Projection indicators** turn hidden state into a forward `PredictionSnapshot.Forecast<Num>`. `MonteCarloReturnProjectionIndicator` projects cumulative log returns; `MonteCarloPriceForecastIndicator` is the constructor-first price forecast path for the common log-return workflow. Projection contracts and point adapters live in `org.ta4j.core.indicators.forecast.projection`.
+- **Adapters and glue** bridge forecast domains or API shapes. `LogReturnToPriceForecastIndicator` lives in `org.ta4j.core.indicators.forecast.adapters` because it converts an explicit log-return projection into price space rather than estimating state or simulating paths itself.
+
+The root `forecast` package intentionally stays focused on the primary indicators users choose and compose. Framework types, data records, and conversion bridges are grouped under subpackages so custom estimators and custom projection models have obvious extension points without turning the root package into a catch-all.
+
 The raw `PredictionSnapshot.Forecast<Num>` summary remains useful for diagnostics and metadata. At each index, it contains:
 
 - `decisionIndex()` / `index()`: the decision index where the forecast was made.
@@ -76,7 +86,7 @@ The raw `PredictionSnapshot.Forecast<Num>` summary remains useful for diagnostic
 - `hasQuantile(probability)`: whether a valid quantile probability is available.
 - `quantile(probability)`: one configured quantile value, or `null` when a valid probability was not configured.
 
-Direct lookup and projection helpers handle missing quantiles differently. `priceForecast.getValue(index).quantile(0.90)` returns `null` when `0.90` was not configured, while `priceForecast.quantile(0.90).getValue(index)` returns `NaN` so the result composes safely as an `Indicator<Num>`. Invalid probabilities outside `[0, 1]` still throw.
+In the CF-289/0.22.9 API, direct lookup and projection helpers handle missing quantiles differently. `priceForecast.getValue(index).quantile(0.90)` returns `null` when `0.90` was not configured, while `priceForecast.quantile(0.90).getValue(index)` returns `NaN` so the result composes safely as an `Indicator<Num>`. Invalid probabilities outside `[0, 1]` still throw.
 
 ## Point Projection Indicators
 
@@ -148,6 +158,23 @@ The state output is a `ReturnForecastState` with rolling `mean`, forecast `drift
 | `volatilityUpdateMode(...)` | `CONSTANT` | Volatility behavior inside each simulated path. | Use `EWMA` only when path-dependent volatility is part of the model assumption. |
 | `volatilityDecayFactor(...)` | `0.94` | EWMA decay used when volatility updates are enabled. | Usually match the state decay factor. |
 | `quantiles(...)` | `0.05, 0.25, 0.5, 0.75, 0.95` | Forecast percentiles to include. | Configure only the percentiles your strategy or report consumes. |
+
+The constructor-first `MonteCarloPriceForecastIndicator` uses the default quantile set. For custom price quantiles, build the tuned return projection and wrap it with the explicit price adapter:
+
+```java
+BarSeries series = ...;
+LogReturnIndicator returns = new LogReturnIndicator(series);
+ReturnForecastStateIndicator state = new EwmaReturnForecastStateIndicator(returns);
+ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+MonteCarloReturnProjectionIndicator returnProjection =
+        MonteCarloReturnProjectionIndicator.builder(state)
+                .horizon(5)
+                .quantiles(0.05, 0.5, 0.90, 0.95)
+                .build();
+ForecastProjectionIndicator priceForecast =
+        new LogReturnToPriceForecastIndicator(close, returnProjection);
+```
 
 ### Shock Models
 
@@ -271,7 +298,7 @@ Use price forecasts when:
 - Strategy rules compare the forecast to current price, stops, targets, support, resistance, or chart overlays.
 - You want report output in user-facing price units.
 
-`MonteCarloPriceForecastIndicator` is the standard price-space path when state comes from `LogReturnIndicator`. `LogReturnToPriceForecastIndicator` is the explicit reducer bridge for advanced cases: it accepts an explicit price indicator plus an explicit `ReturnForecastProjectionIndicator` and rejects non-log return projections.
+`MonteCarloPriceForecastIndicator` is the standard price-space path when state comes from `LogReturnIndicator`. `LogReturnToPriceForecastIndicator` is the explicit adapter bridge for advanced cases: it accepts an explicit price indicator plus an explicit `ReturnForecastProjectionIndicator` and rejects non-log return projections.
 
 ## Reproducibility Notes
 
@@ -284,8 +311,8 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | Projection values are `NaN` early in the series. | Warm-up and lookback requirements are not met. | Start reading after `priceForecast.getCountOfUnstableBars()` or set the same unstable-bar count on the strategy. |
-| Direct quantile lookup returns `null`. | The probability was valid but was not included in `quantiles(...)`. | Use `forecast.hasQuantile(probability)` before direct `forecast.quantile(probability)`, or configure that probability on the Monte Carlo builder. |
-| Quantile projection is `NaN` at a stable index. | The probability was valid but was not included in `quantiles(...)`. | The default quantile set includes `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`; for other probabilities add that exact value with `MonteCarloReturnProjectionIndicator.builder(state).quantiles(...)`. |
+| Direct quantile lookup returns `null`. | The probability was valid but was not included in the projection source's `quantiles(...)`. | Use `forecast.hasQuantile(probability)` before direct `forecast.quantile(probability)`. For custom price quantiles, build a tuned `MonteCarloReturnProjectionIndicator` and wrap it with `LogReturnToPriceForecastIndicator`. |
+| Quantile projection is `NaN` at a stable index. | The probability was valid but was not included in `quantiles(...)`. | The default quantile set includes `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`; for custom price quantiles, build a tuned `MonteCarloReturnProjectionIndicator` and wrap it with `LogReturnToPriceForecastIndicator`. |
 | Point forecast is `NaN`. | The source forecast is unstable, the projection requested a missing quantile, or source data is invalid. | Check warm-up, configured quantiles, and source price/return validity. |
 | A constructor rejects the return input. | The stream declares a non-log `ReturnRepresentation`. | Use `LogReturnIndicator` or another `ReturnIndicator` that explicitly returns `ReturnRepresentation.LOG`. Decimal, percentage, and multiplicative returns need separate projection support. |
 | `MonteCarloPriceForecastIndicator` rejects a custom log-return state. | The state uses a custom `ReturnIndicator` whose source price cannot be inferred. | Use `LogReturnToPriceForecastIndicator` with the explicit price indicator and an explicit `MonteCarloReturnProjectionIndicator`. |
@@ -299,17 +326,17 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | `LogReturnIndicator` | `org.ta4j.core.indicators.helpers` | Normal numeric helper indicator for `log(x[i] / x[i - n])`. |
 | `ReturnIndicator` | `org.ta4j.core.indicators` | Semantic contract for indicators that promise return-stream output in a declared `ReturnRepresentation`. |
 | `EWMAIndicator` | `org.ta4j.core.indicators.averages` | Reusable EWMA indicator with explicit decay and SMA initialization. |
-| `ForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for hidden state used by forecast projections. |
-| `ReturnForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for hidden state derived from a `ReturnIndicator`. |
+| `ForecastStateIndicator` | `org.ta4j.core.indicators.forecast.state` | Indicator interface for hidden state used by forecast projections. |
+| `ReturnForecastStateIndicator` | `org.ta4j.core.indicators.forecast.state` | Indicator interface for hidden state derived from a `ReturnIndicator`. |
 | `EwmaReturnForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Builds `ReturnForecastState` from a log-return `ReturnIndicator` using EWMA mean and variance. |
 | `EwmaReturnForecastStateIndicator.DriftMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting zero drift or rolling-mean drift. |
-| `ReturnForecastState` | `org.ta4j.core.indicators.forecast` | State record consumed by return forecast indicators. |
-| `ForecastProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for forecast summaries with point projection methods. |
-| `ReturnForecastProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Interface for return projections that declare a `ReturnRepresentation`. |
+| `ReturnForecastState` | `org.ta4j.core.indicators.forecast.state` | State record consumed by return forecast indicators. |
+| `ForecastProjectionIndicator` | `org.ta4j.core.indicators.forecast.projection` | Indicator interface for forecast summaries with point projection methods. |
+| `ReturnForecastProjectionIndicator` | `org.ta4j.core.indicators.forecast.projection` | Interface for return projections that declare a `ReturnRepresentation`. |
 | `MonteCarloPriceForecastIndicator` | `org.ta4j.core.indicators.forecast` | Constructor-first price forecast indicator that infers the price source from `LogReturnIndicator`. |
 | `MonteCarloReturnProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return projection indicator with constructor defaults and a builder for advanced simulation settings. |
 | `MonteCarloReturnProjectionIndicator.ShockModel` | `org.ta4j.core.indicators.forecast` | Nested enum selecting historical bootstrap, standardized empirical, or normal shocks. |
 | `MonteCarloReturnProjectionIndicator.VolatilityUpdateMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting constant or EWMA path volatility. |
-| `LogReturnToPriceForecastIndicator` | `org.ta4j.core.indicators.forecast` | Reducer that converts an explicit cumulative log-return projection to a price projection. |
-| `ForwardForecastIndicator` | `org.ta4j.core.indicators.forecast` | Adapter used by point projection methods to expose one `Num` forecast. |
+| `LogReturnToPriceForecastIndicator` | `org.ta4j.core.indicators.forecast.adapters` | Adapter that converts an explicit cumulative log-return projection to a price projection. |
+| `ForwardForecastIndicator` | `org.ta4j.core.indicators.forecast.projection` | Adapter used by point projection methods to expose one `Num` forecast. |
 | `PredictionSnapshot.Forecast` | `org.ta4j.core.walkforward` | Walk-forward prediction summary type used by forecast indicators. |

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -1,8 +1,8 @@
 # Forecast Indicators
 
-Forecast indicators estimate a future distribution from data available at a decision index. They are useful when a strategy needs a probabilistic price or return outlook instead of a single backward-looking technical signal.
+Forecast indicators estimate a future return or price distribution from data available at a decision index. They are useful when a strategy needs a probabilistic outlook instead of a single backward-looking technical signal.
 
-The forecast API lives mostly in `org.ta4j.core.indicators.forecast`. `LogReturnIndicator` is a normal helper indicator in `org.ta4j.core.indicators.helpers` and can be used outside forecasting pipelines.
+The forecast API lives mostly in `org.ta4j.core.indicators.forecast`. `LogReturnIndicator` is a normal helper indicator in `org.ta4j.core.indicators.helpers`, `EWMAIndicator` is a reusable average in `org.ta4j.core.indicators.averages`, and forecast summaries use the walk-forward prediction model via `PredictionSnapshot.Forecast`.
 
 ## When to use them
 
@@ -10,49 +10,49 @@ Use forecast indicators when you want to answer questions such as:
 
 - What is the median expected close price five bars from now?
 - What are the 5th and 95th percentile price outcomes for the next session?
-- Is the forecast distribution wide enough that a signal should be ignored?
+- Is the forecast summary wide enough that a signal should be ignored?
 - How does a signal perform when evaluated against a fixed future horizon?
 
-Do not treat a forecast as a guaranteed target. A forecast distribution is an input to risk management, strategy rules, sizing, and research. It should still be validated with realistic execution assumptions and out-of-sample tests.
+Do not treat a forecast as a guaranteed target. A forecast is an input to risk management, strategy rules, sizing, and research. It should still be validated with realistic execution assumptions and out-of-sample tests.
 
-## Quick Start: Price Forecast Distribution
+## Quick Start: Price Forecast
 
-This example builds the standard EWMA-volatility Monte Carlo pipeline and returns forecast prices, not returns.
+This example builds an EWMA-volatility Monte Carlo pipeline and projects forecast prices, not returns.
 
 ```java
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.forecast.DriftMode;
-import org.ta4j.core.indicators.forecast.EwmaReturnForecastStateConfig;
-import org.ta4j.core.indicators.forecast.ForecastDistributionIndicator;
-import org.ta4j.core.indicators.forecast.ForecastIndicators;
-import org.ta4j.core.indicators.forecast.MonteCarloForecastConfig;
-import org.ta4j.core.indicators.forecast.ShockModel;
-import org.ta4j.core.indicators.forecast.VolatilityUpdateMode;
+import org.ta4j.core.indicators.forecast.ForecastPredictionIndicator;
+import org.ta4j.core.indicators.forecast.ForecastStateIndicator;
+import org.ta4j.core.indicators.forecast.LogReturnToPriceForecastIndicator;
+import org.ta4j.core.indicators.forecast.MonteCarloReturnForecastIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.LogReturnIndicator;
 import org.ta4j.core.num.Num;
 
 BarSeries series = ...;
 ClosePriceIndicator close = new ClosePriceIndicator(series);
+LogReturnIndicator returns = new LogReturnIndicator(close);
 
-EwmaReturnForecastStateConfig stateConfig = EwmaReturnForecastStateConfig.builder()
-        .initializationBarCount(30)
-        .decayFactor(0.94)
-        .driftMode(DriftMode.ZERO)
-        .build();
+ForecastStateIndicator state = ForecastStateIndicator.ofEwma(
+        returns,
+        30,
+        0.94,
+        ForecastStateIndicator.DriftMode.ZERO);
 
-MonteCarloForecastConfig forecastConfig = MonteCarloForecastConfig.builder()
-        .horizon(5)
-        .iterationCount(2_000)
-        .lookbackBarCount(252)
-        .seed(42L)
-        .shockModel(ShockModel.STANDARDIZED_EMPIRICAL)
-        .volatilityUpdateMode(VolatilityUpdateMode.CONSTANT)
-        .quantiles(0.05, 0.5, 0.95)
-        .build();
+ForecastPredictionIndicator returnForecast =
+        MonteCarloReturnForecastIndicator.builder(returns, state)
+                .horizon(5)
+                .iterationCount(2_000)
+                .lookbackBarCount(252)
+                .seed(42L)
+                .shockModel(MonteCarloReturnForecastIndicator.ShockModel.STANDARDIZED_EMPIRICAL)
+                .volatilityUpdateMode(MonteCarloReturnForecastIndicator.VolatilityUpdateMode.CONSTANT)
+                .quantiles(0.05, 0.5, 0.95)
+                .build();
 
-ForecastDistributionIndicator priceForecast =
-        ForecastIndicators.ewmaVolatilityClosePriceForecast(close, stateConfig, forecastConfig);
+ForecastPredictionIndicator priceForecast =
+        new LogReturnToPriceForecastIndicator(close, returnForecast);
 
 Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
 Indicator<Num> medianForecast = priceForecast.median();
@@ -64,11 +64,11 @@ Num median = medianForecast.getValue(index);
 Num upside = upsideForecast.getValue(index);
 ```
 
-Use `ForecastDistributionIndicator` projection methods for strategy rules, chart overlays, and other ta4j data flows. Each projection shifts the index lookup onto a normal `Indicator<Num>` and returns `NaN` while the source distribution is unstable.
+Use `ForecastPredictionIndicator` projection methods for strategy rules, chart overlays, and other ta4j data flows. Each projection shifts the index lookup onto a normal `Indicator<Num>` and returns `NaN` while the source forecast is unstable.
 
-The raw `ForecastDistribution<Num>` snapshot remains useful for diagnostics and metadata. At each index, it contains:
+The raw `PredictionSnapshot.Forecast<Num>` summary remains useful for diagnostics and metadata. At each index, it contains:
 
-- `index()`: the decision index where the forecast was made.
+- `decisionIndex()` / `index()`: the decision index where the forecast was made.
 - `horizon()`: the configured number of bars ahead.
 - `sampleCount()`: the number of simulated samples summarized.
 - `isStable()`: whether the forecast is usable at this decision index.
@@ -76,17 +76,17 @@ The raw `ForecastDistribution<Num>` snapshot remains useful for diagnostics and 
 - `quantiles()`: configured quantile probabilities to values.
 - `quantile(probability)`: one configured quantile value.
 
-Only request quantile projections that were configured in `MonteCarloForecastConfig`. For example, `priceForecast.quantile(0.05)` returns useful values only if `0.05` was included in `quantiles(...)`.
+Only request quantile projections that were configured on `MonteCarloReturnForecastIndicator.Builder`. For example, `priceForecast.quantile(0.05)` returns useful values only if `0.05` was included in `quantiles(...)`.
 
 ## Point Projection Indicators
 
-Many rules and indicators need one `Num` value per index. `ForecastDistributionIndicator` exposes projection methods that return normal `Indicator<Num>` instances.
+Many rules and indicators need one `Num` value per index. `ForecastPredictionIndicator` exposes projection methods that return normal `Indicator<Num>` instances.
 
 ```java
 import org.ta4j.core.Indicator;
+import org.ta4j.core.Rule;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.OverIndicatorRule;
-import org.ta4j.core.Rule;
 
 Indicator<Num> medianForecast = priceForecast.median();
 Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
@@ -95,51 +95,23 @@ Indicator<Num> forecastWidth = priceForecast.standardDeviation();
 Rule forecastAboveCurrentPrice = new OverIndicatorRule(medianForecast, close);
 ```
 
-There is also a convenience factory for the common median close-price case:
+Projection indicators return `NaN` when the source forecast is unstable or when the requested quantile is missing. That makes projected forecasts safe to compose with normal ta4j rules and indicators, including `UnaryOperationIndicator` and `BinaryOperationIndicator`.
 
-```java
-Indicator<Num> medianPriceForecast =
-        ForecastIndicators.ewmaVolatilityMedianClosePriceForecast(close, stateConfig, forecastConfig);
-```
-
-Projection indicators return `NaN` when the source distribution is unstable or when the requested quantile is missing. That makes projected forecasts safe to compose with normal ta4j rules and indicators, including `UnaryOperationIndicator` and `BinaryOperationIndicator`.
-
-## Manual Pipeline
-
-The convenience factory builds this pipeline:
+## Pipeline
 
 ```mermaid
 graph TD
     CP["ClosePriceIndicator or another price Indicator<Num>"] --> LR["LogReturnIndicator"]
-    LR --> EWMA["EwmaReturnForecastStateIndicator"]
-    LR --> MC["MonteCarloReturnForecastIndicator"]
-    EWMA --> MC
+    LR --> STATE["ForecastStateIndicator.ofEwma(...)"]
+    LR --> MC["MonteCarloReturnForecastIndicator.builder(...).build()"]
+    STATE --> MC
     MC --> PRICE["LogReturnToPriceForecastIndicator"]
     PRICE --> PROJECT["median(), quantile(), mean(), standardDeviation()"]
 ```
 
-Use the manual pipeline when you need direct access to return forecasts, a custom price source, custom point projections, or intermediate state diagnostics.
+Use this explicit pipeline when you need direct access to return forecasts, a custom price source, custom point projections, or intermediate state diagnostics. The API intentionally avoids a god factory so each stage remains reusable and testable.
 
-```java
-import org.ta4j.core.indicators.forecast.EwmaReturnForecastStateIndicator;
-import org.ta4j.core.indicators.forecast.ForecastDistributionIndicator;
-import org.ta4j.core.indicators.forecast.LogReturnToPriceForecastIndicator;
-import org.ta4j.core.indicators.forecast.MonteCarloReturnForecastIndicator;
-import org.ta4j.core.indicators.helpers.LogReturnIndicator;
-import org.ta4j.core.num.Num;
-
-LogReturnIndicator returns = new LogReturnIndicator(close);
-EwmaReturnForecastStateIndicator state =
-        new EwmaReturnForecastStateIndicator(returns, stateConfig);
-
-ForecastDistributionIndicator returnForecast =
-        new MonteCarloReturnForecastIndicator(returns, state, forecastConfig);
-
-ForecastDistributionIndicator priceForecast =
-        new LogReturnToPriceForecastIndicator(close, returnForecast);
-```
-
-`MonteCarloReturnForecastIndicator` produces a cumulative log-return distribution over the configured horizon. `LogReturnToPriceForecastIndicator` converts it to a price distribution with:
+`MonteCarloReturnForecastIndicator` produces a cumulative log-return forecast over the configured horizon. `LogReturnToPriceForecastIndicator` converts it to a price forecast with:
 
 ```text
 forecastPrice = priceAtDecisionIndex * exp(cumulativeLogReturn)
@@ -149,54 +121,55 @@ forecastPrice = priceAtDecisionIndex * exp(cumulativeLogReturn)
 
 ### EWMA State
 
-`EwmaReturnForecastStateIndicator` estimates rolling return state from a log-return source.
+`ForecastStateIndicator.ofEwma(...)` estimates rolling return state from a log-return source.
 
-| Setting | Default | Meaning | Common tuning |
+| Parameter | Default in examples | Meaning | Common tuning |
 | --- | --- | --- | --- |
 | `initializationBarCount` | `30` | Number of valid return observations required before state is stable. | Increase for slower, steadier estimates; decrease for faster adaptation. |
 | `decayFactor` | `0.94` | EWMA persistence in `(0, 1)`. Higher values react more slowly. | Use higher values for daily data and lower values for shorter bars only after validation. |
-| `driftMode` | `DriftMode.ZERO` | Drift used in simulated paths. | Prefer `ZERO` as a conservative default; use `ROLLING_MEAN` only when the rolling mean has validated predictive value. |
+| `driftMode` | `ForecastStateIndicator.DriftMode.ZERO` | Drift used in simulated paths. | Prefer `ZERO` as a conservative default; use `ROLLING_MEAN` only when the rolling mean has validated predictive value. |
 
 The state output is a `ReturnForecastState` with rolling `mean`, forecast `drift`, `variance`, and `volatility`.
 
 ### Monte Carlo Forecast
 
-`MonteCarloForecastConfig` controls horizon, samples, shock model, and returned quantiles.
+`MonteCarloReturnForecastIndicator.builder(...)` controls horizon, samples, shock model, and returned quantiles.
 
-| Setting | Default | Meaning | Common tuning |
+| Builder method | Default | Meaning | Common tuning |
 | --- | --- | --- | --- |
-| `horizon` | `1` | Number of bars ahead to forecast. | Match the holding period or evaluation label. |
-| `iterationCount` | `1_000` | Number of simulated paths. | Increase for smoother quantiles; reduce only for latency-sensitive live loops after measuring. |
-| `lookbackBarCount` | `252` | Number of historical returns used for empirical shocks. | Match the market regime window you want represented. |
-| `seed` | `42L` | Base random seed. | Keep fixed for reproducible research and tests. |
-| `shockModel` | `STANDARDIZED_EMPIRICAL` | Source of simulated return shocks. | See the shock model table below. |
-| `volatilityUpdateMode` | `CONSTANT` | Volatility behavior inside each simulated path. | Use `EWMA` only when path-dependent volatility is part of the model assumption. |
-| `volatilityDecayFactor` | `0.94` | EWMA decay used when volatility updates are enabled. | Usually match the state decay factor. |
-| `quantiles` | `0.05, 0.25, 0.5, 0.75, 0.95` | Distribution percentiles to include. | Configure only the percentiles your strategy or report consumes. |
+| `horizon(...)` | `1` | Number of bars ahead to forecast. | Match the holding period or evaluation label. |
+| `iterationCount(...)` | `1_000` | Number of simulated paths. | Increase for smoother quantiles; reduce only for latency-sensitive live loops after measuring. |
+| `lookbackBarCount(...)` | `252` | Number of historical returns used for empirical shocks. | Match the market regime window you want represented. |
+| `seed(...)` | `42L` | Base random seed. | Keep fixed for reproducible research and tests. |
+| `shockModel(...)` | `STANDARDIZED_EMPIRICAL` | Source of simulated return shocks. | See the shock model table below. |
+| `volatilityUpdateMode(...)` | `CONSTANT` | Volatility behavior inside each simulated path. | Use `EWMA` only when path-dependent volatility is part of the model assumption. |
+| `volatilityDecayFactor(...)` | `0.94` | EWMA decay used when volatility updates are enabled. | Usually match the state decay factor. |
+| `quantiles(...)` | `0.05, 0.25, 0.5, 0.75, 0.95` | Forecast percentiles to include. | Configure only the percentiles your strategy or report consumes. |
 
 ### Shock Models
 
 | Shock model | Behavior | Use when |
 | --- | --- | --- |
-| `HISTORICAL_BOOTSTRAP` | Samples raw historical returns from the lookback window. | You want the recent empirical return distribution without rescaling by current volatility. |
-| `STANDARDIZED_EMPIRICAL` | Samples standardized residuals and scales them by the current EWMA state. | You want empirical tail shape with current volatility and drift. This is the default. |
-| `NORMAL` | Draws standard normal shocks and scales them by the current EWMA state. | You want a simple parametric baseline and accept thinner tails than many markets show. |
+| `MonteCarloReturnForecastIndicator.ShockModel.HISTORICAL_BOOTSTRAP` | Samples raw historical returns from the lookback window. | You want the recent empirical return distribution without rescaling by current volatility. |
+| `MonteCarloReturnForecastIndicator.ShockModel.STANDARDIZED_EMPIRICAL` | Samples standardized residuals and scales them by the current EWMA state. | You want empirical tail shape with current volatility and drift. This is the default. |
+| `MonteCarloReturnForecastIndicator.ShockModel.NORMAL` | Draws standard normal shocks and scales them by the current EWMA state. | You want a simple parametric baseline and accept thinner tails than many markets show. |
 
 ### Volatility Update Modes
 
 | Mode | Behavior | Tradeoff |
 | --- | --- | --- |
-| `CONSTANT` | Uses the decision-index volatility for every simulated step in a path. | Simple, reproducible, and usually the first model to validate. |
-| `EWMA` | Updates path volatility after each simulated step using `volatilityDecayFactor`. | More dynamic, but adds another assumption that must be tested. |
+| `MonteCarloReturnForecastIndicator.VolatilityUpdateMode.CONSTANT` | Uses the decision-index volatility for every simulated step in a path. | Simple, reproducible, and usually the first model to validate. |
+| `MonteCarloReturnForecastIndicator.VolatilityUpdateMode.EWMA` | Updates path volatility after each simulated step using `volatilityDecayFactor`. | More dynamic, but adds another assumption that must be tested. |
 
 ## Warm-Up and Unstable Values
 
-Forecast indicators deliberately return unstable distributions until enough valid data is available.
+Forecast indicators deliberately return unstable summaries until enough valid data is available.
 
 Important warm-up rules:
 
 - `LogReturnIndicator` is unstable for `source.getCountOfUnstableBars() + barCount` bars.
-- `EwmaReturnForecastStateIndicator` is unstable for `returnIndicator.getCountOfUnstableBars() + initializationBarCount - 1` bars.
+- `EWMAIndicator` is unstable for `source.getCountOfUnstableBars() + barCount - 1` bars.
+- `ForecastStateIndicator.ofEwma(...)` is unstable until its EWMA mean and variance sources are stable.
 - `MonteCarloReturnForecastIndicator` is unstable until both the state is stable and the configured return lookback is available.
 - With the default one-bar log return and default `lookbackBarCount(252)`, the standard Monte Carlo return forecast first becomes eligible at index `252` when all returns are valid.
 
@@ -207,11 +180,11 @@ Unstable values can also occur after warm-up when:
 - The historical lookback does not contain enough valid returns.
 - A price forecast cannot be converted because the decision-index price is invalid or non-positive.
 
-Prefer projection indicators for rule and indicator composition. If you intentionally inspect raw `ForecastDistribution` snapshots in reporting or diagnostics, check `isStable()` before reading summary values. Projection indicators return `NaN` for unstable distributions, which normal ta4j rules will treat as not satisfying comparisons.
+Prefer projection indicators for rule and indicator composition. If you intentionally inspect raw `PredictionSnapshot.Forecast` summaries in reporting or diagnostics, check `isStable()` before reading summary values. Projection indicators return `NaN` for unstable summaries, which normal ta4j rules will treat as not satisfying comparisons.
 
 ## Avoiding Look-Ahead Bias
 
-Forecast indicators are designed to produce `getValue(i)` using only source data available at or before index `i`. The forecast horizon describes what the distribution is about; it does not allow the indicator to read future bars.
+Forecast indicators are designed to produce `getValue(i)` using only source data available at or before index `i`. The forecast horizon describes what the summary is about; it does not allow the indicator to read future bars.
 
 For research:
 
@@ -233,8 +206,7 @@ For live trading:
 Use the median point forecast as a directional filter:
 
 ```java
-Indicator<Num> medianForecast =
-        ForecastIndicators.ewmaVolatilityMedianClosePriceForecast(close, stateConfig, forecastConfig);
+Indicator<Num> medianForecast = priceForecast.median();
 
 Rule bullishForecast = new OverIndicatorRule(medianForecast, close);
 ```
@@ -254,9 +226,9 @@ Rule downsideAboveStop = new OverIndicatorRule(fifthPercentilePrice, plannedStop
 
 `plannedStopPrice` can be any `Indicator<Num>` on the same series, such as an ATR stop, support indicator, or fixed threshold indicator.
 
-### Distribution Width Filter
+### Forecast Width Filter
 
-Use `priceForecast.standardDeviation()` when you want to avoid forecasts that are too uncertain, or require enough spread for a volatility strategy. The result is in the same unit as the distribution: log-return units for return forecasts and price units for price forecasts.
+Use `priceForecast.standardDeviation()` when you want to avoid forecasts that are too uncertain, or require enough spread for a volatility strategy. The result is in the same unit as the forecast summary: log-return units for return forecasts and price units for price forecasts.
 
 ## Choosing Return or Price Space
 
@@ -275,7 +247,7 @@ Use price forecasts when:
 
 ## Reproducibility Notes
 
-The Monte Carlo indicator mixes the configured seed with the decision index and horizon. That means the same seed, index, horizon, inputs, and configuration produce the same distribution independent of call order. This is important for cached indicators, tests, and chart rendering.
+The Monte Carlo indicator mixes the configured seed with the decision index and horizon. That means the same seed, index, horizon, inputs, and configuration produce the same forecast independent of call order. This is important for cached indicators, tests, and chart rendering.
 
 Do not rely on a seed to make an invalid forecast stable. Reproducibility only applies once the data and warm-up requirements are satisfied.
 
@@ -284,8 +256,8 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | Projection values are `NaN` early in the series. | Warm-up and lookback requirements are not met. | Start reading after `forecast.getCountOfUnstableBars()`. |
-| Quantile projection is `NaN` at a stable index. | The probability was not included in `quantiles(...)`. | Add that exact probability to `MonteCarloForecastConfig`. |
-| Point forecast is `NaN`. | The source distribution is unstable, the projection requested a missing quantile, or source data is invalid. | Check warm-up, configured quantiles, and source price/return validity. |
+| Quantile projection is `NaN` at a stable index. | The probability was not included in `quantiles(...)`. | Add that exact probability to `MonteCarloReturnForecastIndicator.builder(...).quantiles(...)`. |
+| Point forecast is `NaN`. | The source forecast is unstable, the projection requested a missing quantile, or source data is invalid. | Check warm-up, configured quantiles, and source price/return validity. |
 | Price forecast is unstable while return forecast is stable. | Decision-index price is non-positive or invalid. | Check the source price indicator and data feed. |
 | Live forecasts disappear with a moving series. | The series evicted bars required by the lookback. | Increase `setMaximumBarCount` or reduce lookback after validation. |
 
@@ -294,13 +266,14 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | Type | Package | Purpose |
 | --- | --- | --- |
 | `LogReturnIndicator` | `org.ta4j.core.indicators.helpers` | Normal numeric helper indicator for `log(x[i] / x[i - n])`. |
-| `EwmaReturnForecastStateConfig` | `org.ta4j.core.indicators.forecast` | EWMA state configuration. |
-| `EwmaReturnForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Rolling return mean, drift, variance, and volatility estimator. |
-| `ReturnForecastState` | `org.ta4j.core.indicators.forecast` | State record produced by the EWMA estimator. |
-| `MonteCarloForecastConfig` | `org.ta4j.core.indicators.forecast` | Monte Carlo horizon, iteration, seed, shock, volatility, and quantile settings. |
-| `MonteCarloReturnForecastIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return forecast distribution indicator. |
-| `ForecastDistribution` | `org.ta4j.core.indicators.forecast` | Immutable distribution summary record. |
-| `ForecastDistributionIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for distribution-valued forecasts with point projection methods. |
-| `LogReturnToPriceForecastIndicator` | `org.ta4j.core.indicators.forecast` | Converts cumulative log-return distributions to price distributions. |
+| `EWMAIndicator` | `org.ta4j.core.indicators.averages` | Reusable EWMA indicator with explicit decay and SMA initialization. |
+| `ForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Converts mean and variance indicators into `ReturnForecastState`, with `ofEwma(...)` for the standard state pipeline. |
+| `ForecastStateIndicator.DriftMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting zero drift or rolling-mean drift. |
+| `ReturnForecastState` | `org.ta4j.core.indicators.forecast` | State record consumed by return forecast indicators. |
+| `MonteCarloReturnForecastIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return forecast indicator with builder-owned configuration. |
+| `MonteCarloReturnForecastIndicator.ShockModel` | `org.ta4j.core.indicators.forecast` | Nested enum selecting historical bootstrap, standardized empirical, or normal shocks. |
+| `MonteCarloReturnForecastIndicator.VolatilityUpdateMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting constant or EWMA path volatility. |
+| `ForecastPredictionIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for forecast summaries with point projection methods. |
+| `LogReturnToPriceForecastIndicator` | `org.ta4j.core.indicators.forecast` | Converts cumulative log-return forecasts to price forecasts. |
 | `ForwardForecastIndicator` | `org.ta4j.core.indicators.forecast` | Adapter used by point projection methods to expose one `Num` forecast. |
-| `ForecastIndicators` | `org.ta4j.core.indicators.forecast` | Convenience factories for standard forecast pipelines. |
+| `PredictionSnapshot.Forecast` | `org.ta4j.core.walkforward` | Walk-forward prediction summary type used by forecast indicators. |

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -30,23 +30,32 @@ import org.ta4j.core.indicators.forecast.MonteCarloPriceForecastIndicator;
 import org.ta4j.core.indicators.forecast.ReturnForecastStateIndicator;
 import org.ta4j.core.indicators.helpers.LogReturnIndicator;
 import org.ta4j.core.num.Num;
+import org.ta4j.core.walkforward.PredictionSnapshot;
 
 BarSeries series = ...;
 LogReturnIndicator returns = new LogReturnIndicator(series);
 ReturnForecastStateIndicator state = new EwmaReturnForecastStateIndicator(returns);
 ForecastProjectionIndicator priceForecast = new MonteCarloPriceForecastIndicator(state, 5);
 
+int index = series.getEndIndex();
+PredictionSnapshot.Forecast<Num> forecast = priceForecast.getValue(index);
+if (forecast.isStable()) {
+    Num directDownside = forecast.quantile(0.05);
+    Num directMedian = forecast.median();
+    Num directUpside = forecast.quantile(0.95);
+}
+
+// Equivalent convenience path: same values at the same index, easier to compose.
 Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
 Indicator<Num> medianForecast = priceForecast.median();
 Indicator<Num> upsideForecast = priceForecast.quantile(0.95);
 
-int index = series.getEndIndex();
-Num downside = downsideForecast.getValue(index);
-Num median = medianForecast.getValue(index);
-Num upside = upsideForecast.getValue(index);
+Num helperDownside = downsideForecast.getValue(index);
+Num helperMedian = medianForecast.getValue(index);
+Num helperUpside = upsideForecast.getValue(index);
 ```
 
-Use `ForecastProjectionIndicator` projection methods for strategy rules, chart overlays, and other ta4j data flows. Each projection shifts the index lookup onto a normal `Indicator<Num>` and returns `NaN` while the source forecast is unstable.
+Direct `priceForecast.getValue(index)` access is the normal `Indicator` path when reporting or inspecting a full forecast summary. `ForecastProjectionIndicator` methods such as `median()` and `quantile(...)` are convenience adapters for strategy rules, chart overlays, and other ta4j data flows that need one `Indicator<Num>` value per index. Each projection returns `NaN` while the source forecast is unstable.
 
 The setup has three business decisions:
 

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -83,14 +83,12 @@ Direct lookup and projection helpers handle missing quantiles differently. `pric
 Direct `priceForecast.getValue(index)` access returns the full forecast summary. When rules and other indicators need one `Num` value per index, `ForecastProjectionIndicator` exposes convenience projection methods that adapt summary fields into normal `Indicator<Num>` instances.
 
 ```java
-import org.ta4j.core.Indicator;
-import org.ta4j.core.Rule;
-import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
-import org.ta4j.core.indicators.numeric.BinaryOperationIndicator;
-import org.ta4j.core.num.Num;
-import org.ta4j.core.rules.OverIndicatorRule;
-
+BarSeries series = ...;
+LogReturnIndicator returns = new LogReturnIndicator(series);
+ReturnForecastStateIndicator state = new EwmaReturnForecastStateIndicator(returns);
+ForecastProjectionIndicator priceForecast = new MonteCarloPriceForecastIndicator(state, 5);
 ClosePriceIndicator close = new ClosePriceIndicator(series);
+
 // Adapter forms of priceForecast.getValue(index).median()/quantile(...).
 Indicator<Num> medianForecast = priceForecast.median();
 Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
@@ -212,7 +210,12 @@ For live trading:
 Use the median point forecast as a directional filter. The rule needs an `Indicator<Num>`, so use the projection-helper adapter for the same value available from `priceForecast.getValue(index).median()`.
 
 ```java
+BarSeries series = ...;
+LogReturnIndicator returns = new LogReturnIndicator(series);
+ReturnForecastStateIndicator state = new EwmaReturnForecastStateIndicator(returns);
+ForecastProjectionIndicator priceForecast = new MonteCarloPriceForecastIndicator(state, 5);
 ClosePriceIndicator close = new ClosePriceIndicator(series);
+
 Indicator<Num> medianForecast = priceForecast.median();
 
 Rule bullishForecast = new OverIndicatorRule(medianForecast, close);
@@ -225,9 +228,13 @@ This is intentionally minimal. In real strategies, add costs, slippage, and a re
 Use a low quantile to avoid entries when the downside tail is too close. The direct value is `priceForecast.getValue(index).quantile(0.05)`; the helper form adapts that value for rule composition.
 
 ```java
-Indicator<Num> fifthPercentilePrice =
-        priceForecast.quantile(0.05);
+BarSeries series = ...;
+LogReturnIndicator returns = new LogReturnIndicator(series);
+ReturnForecastStateIndicator state = new EwmaReturnForecastStateIndicator(returns);
+ForecastProjectionIndicator priceForecast = new MonteCarloPriceForecastIndicator(state, 5);
 
+Indicator<Num> fifthPercentilePrice = priceForecast.quantile(0.05);
+Indicator<Num> plannedStopPrice = ...;
 Rule downsideAboveStop = new OverIndicatorRule(fifthPercentilePrice, plannedStopPrice);
 ```
 
@@ -238,7 +245,10 @@ Rule downsideAboveStop = new OverIndicatorRule(fifthPercentilePrice, plannedStop
 Use a price-quantile spread when you want to avoid forecasts that are too uncertain, or require enough spread for a volatility strategy. For one-off reporting, subtract the direct quantile values from `priceForecast.getValue(index)`; for indicators or rules, use the equivalent helper adapters.
 
 ```java
-import org.ta4j.core.indicators.numeric.BinaryOperationIndicator;
+BarSeries series = ...;
+LogReturnIndicator returns = new LogReturnIndicator(series);
+ReturnForecastStateIndicator state = new EwmaReturnForecastStateIndicator(returns);
+ForecastProjectionIndicator priceForecast = new MonteCarloPriceForecastIndicator(state, 5);
 
 Indicator<Num> fifthPercentilePrice = priceForecast.quantile(0.05);
 Indicator<Num> ninetyFifthPercentilePrice = priceForecast.quantile(0.95);

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -26,20 +26,15 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.forecast.EwmaReturnForecastStateIndicator;
 import org.ta4j.core.indicators.forecast.ForecastProjectionIndicator;
-import org.ta4j.core.indicators.forecast.MonteCarloReturnProjectionIndicator;
-import org.ta4j.core.indicators.forecast.ReturnForecastProjectionIndicator;
+import org.ta4j.core.indicators.forecast.MonteCarloPriceForecastIndicator;
 import org.ta4j.core.indicators.forecast.ReturnForecastStateIndicator;
-import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.LogReturnIndicator;
 import org.ta4j.core.num.Num;
 
 BarSeries series = ...;
-ClosePriceIndicator close = new ClosePriceIndicator(series);
-
-LogReturnIndicator returns = new LogReturnIndicator(close);
+LogReturnIndicator returns = new LogReturnIndicator(series);
 ReturnForecastStateIndicator state = new EwmaReturnForecastStateIndicator(returns);
-ReturnForecastProjectionIndicator projection = new MonteCarloReturnProjectionIndicator(state, 5);
-ForecastProjectionIndicator priceForecast = projection.toPriceForecast(close);
+ForecastProjectionIndicator priceForecast = new MonteCarloPriceForecastIndicator(state, 5);
 
 Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
 Indicator<Num> medianForecast = priceForecast.median();
@@ -53,12 +48,11 @@ Num upside = upsideForecast.getValue(index);
 
 Use `ForecastProjectionIndicator` projection methods for strategy rules, chart overlays, and other ta4j data flows. Each projection shifts the index lookup onto a normal `Indicator<Num>` and returns `NaN` while the source forecast is unstable.
 
-The setup has three business decisions and one optional reducer:
+The setup has three business decisions:
 
 - `LogReturnIndicator` declares the source stream as log returns through the `ReturnIndicator` semantic contract.
 - `EwmaReturnForecastStateIndicator` provides hidden return state from that log-return stream.
-- `MonteCarloReturnProjectionIndicator` projects cumulative log returns from the state indicator.
-- `projection.toPriceForecast(close)` uses `LogReturnToPriceForecastIndicator` internally to convert cumulative log returns into decision-index prices.
+- `MonteCarloPriceForecastIndicator` projects prices from that state and infers the source price indicator from `LogReturnIndicator`.
 
 The default EWMA state uses a 30-bar initialization window, `0.94` decay, and zero drift. The default Monte Carlo projection uses standardized empirical shocks, 1,000 simulations, a 252-return lookback, and default quantiles of `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`.
 
@@ -72,7 +66,7 @@ The raw `PredictionSnapshot.Forecast<Num>` summary remains useful for diagnostic
 - `quantiles()`: configured quantile probabilities to values.
 - `quantile(probability)`: one configured quantile value.
 
-Only request quantile projections that were configured on `MonteCarloReturnProjectionIndicator.Builder`. For example, `priceForecast.quantile(0.05)` returns useful values only if `0.05` was included in `quantiles(...)`.
+Only request quantile projections that were configured on the underlying Monte Carlo projection. For example, `priceForecast.quantile(0.05)` works with the default quantile set, while advanced return-projection builders must include any non-default probabilities in `quantiles(...)`.
 
 ## Point Projection Indicators
 
@@ -81,9 +75,11 @@ Many rules and indicators need one `Num` value per index. `ForecastProjectionInd
 ```java
 import org.ta4j.core.Indicator;
 import org.ta4j.core.Rule;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.OverIndicatorRule;
 
+ClosePriceIndicator close = new ClosePriceIndicator(series);
 Indicator<Num> medianForecast = priceForecast.median();
 Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
 Indicator<Num> forecastWidth = priceForecast.standardDeviation();
@@ -99,15 +95,13 @@ Projection indicators return `NaN` when the source forecast is unstable or when 
 graph TD
     CP["ClosePriceIndicator or another price Indicator<Num>"] --> LR["LogReturnIndicator"]
     LR --> STATE["new EwmaReturnForecastStateIndicator(returns)"]
-    STATE --> MC["new MonteCarloReturnProjectionIndicator(state, horizon)"]
-    MC --> PRICE["projection.toPriceForecast(close)"]
-    CP --> PRICE
+    STATE --> PRICE["new MonteCarloPriceForecastIndicator(state, horizon)"]
     PRICE --> PROJECT["median(), quantile(), mean(), standardDeviation()"]
 ```
 
-Use this pipeline when you need direct access to return forecasts, a custom price source, custom point projections, or intermediate state diagnostics. The API intentionally avoids a god factory so each stage remains reusable and testable.
+Use this pipeline for normal strategy rules, chart overlays, and reports in price units. The API intentionally avoids a god factory so the return source, state model, and projection model remain reusable and testable.
 
-`MonteCarloReturnProjectionIndicator` produces a cumulative log-return forecast over the configured horizon. `LogReturnToPriceForecastIndicator` converts it to a price forecast with:
+Internally, `MonteCarloPriceForecastIndicator` produces a cumulative log-return forecast over the configured horizon and converts it to a price forecast with:
 
 ```text
 forecastPrice = priceAtDecisionIndex * exp(cumulativeLogReturn)
@@ -129,12 +123,12 @@ The state output is a `ReturnForecastState` with rolling `mean`, forecast `drift
 
 ### Monte Carlo Forecast
 
-`new MonteCarloReturnProjectionIndicator(state, horizon)` is the standard constructor for EWMA Monte Carlo forecasts. It accepts a `ReturnForecastStateIndicator`, validates that the state indicator is log-return based, and uses `state.getReturnIndicator()` for historical shocks. Use the builder only when you need to tune simulation settings beyond horizon.
+`new MonteCarloPriceForecastIndicator(state, horizon)` is the standard constructor for EWMA Monte Carlo price forecasts. It accepts a `ReturnForecastStateIndicator`, validates that the state indicator is log-return based, and infers the source price indicator from the state's `LogReturnIndicator`. Use `MonteCarloReturnProjectionIndicator.builder(state)` only when you need to tune simulation settings beyond horizon or work directly in return space.
 
 | Constructor or builder method | Default | Meaning | Common tuning |
 | --- | --- | --- | --- |
-| `new MonteCarloReturnProjectionIndicator(state)` | `1` bar | Default one-bar forecast from the supplied state indicator. | Use for next-bar forecasts. |
-| `new MonteCarloReturnProjectionIndicator(state, horizon)` | caller supplied | Number of bars ahead to forecast. | Match the holding period or evaluation label. |
+| `new MonteCarloPriceForecastIndicator(state)` | `1` bar | Default one-bar price forecast from the supplied state indicator. | Use for next-bar forecasts. |
+| `new MonteCarloPriceForecastIndicator(state, horizon)` | caller supplied | Number of bars ahead to forecast. | Match the holding period or evaluation label. |
 | `iterationCount(...)` | `1_000` | Number of simulated paths. | Increase for smoother quantiles; reduce only for latency-sensitive live loops after measuring. |
 | `lookbackBarCount(...)` | `252` | Number of historical returns used for empirical shocks. | Match the market regime window you want represented. |
 | `seed(...)` | `42L` | Base random seed. | Keep fixed for reproducible research and tests. |
@@ -168,6 +162,7 @@ Important warm-up rules:
 - `EWMAIndicator` is unstable for `source.getCountOfUnstableBars() + barCount - 1` bars.
 - `EwmaReturnForecastStateIndicator` is unstable until its EWMA mean and variance sources are stable.
 - `MonteCarloReturnProjectionIndicator` is unstable until both the state is stable and the configured return lookback is available.
+- `MonteCarloPriceForecastIndicator` is unstable until the return projection is stable and the decision-index price is positive and valid.
 - With the default one-bar log return and default `lookbackBarCount(252)`, the standard Monte Carlo return forecast first becomes eligible at index `252` when all returns are valid.
 
 Unstable values can also occur after warm-up when:
@@ -203,6 +198,7 @@ For live trading:
 Use the median point forecast as a directional filter:
 
 ```java
+ClosePriceIndicator close = new ClosePriceIndicator(series);
 Indicator<Num> medianForecast = priceForecast.median();
 
 Rule bullishForecast = new OverIndicatorRule(medianForecast, close);
@@ -240,7 +236,7 @@ Use price forecasts when:
 - Strategy rules compare the forecast to current price, stops, targets, support, resistance, or chart overlays.
 - You want report output in user-facing price units.
 
-`LogReturnToPriceForecastIndicator` is the reducer bridge between the two. It accepts an explicit price indicator plus an explicit `ReturnForecastProjectionIndicator` and rejects non-log return projections.
+`MonteCarloPriceForecastIndicator` is the standard price-space path when state comes from `LogReturnIndicator`. `LogReturnToPriceForecastIndicator` is the explicit reducer bridge for advanced cases: it accepts an explicit price indicator plus an explicit `ReturnForecastProjectionIndicator` and rejects non-log return projections.
 
 ## Reproducibility Notes
 
@@ -256,6 +252,7 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | Quantile projection is `NaN` at a stable index. | The probability was not included in `quantiles(...)`. | The default quantile set includes `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`; for other probabilities add that exact value with `MonteCarloReturnProjectionIndicator.builder(state).quantiles(...)`. |
 | Point forecast is `NaN`. | The source forecast is unstable, the projection requested a missing quantile, or source data is invalid. | Check warm-up, configured quantiles, and source price/return validity. |
 | A constructor rejects the return input. | The stream declares a non-log `ReturnRepresentation`. | Use `LogReturnIndicator` or another `ReturnIndicator` that explicitly returns `ReturnRepresentation.LOG`. Decimal, percentage, and multiplicative returns need separate projection support. |
+| `MonteCarloPriceForecastIndicator` rejects a custom log-return state. | The state uses a custom `ReturnIndicator` whose source price cannot be inferred. | Use `LogReturnToPriceForecastIndicator` with the explicit price indicator and an explicit `MonteCarloReturnProjectionIndicator`. |
 | Price forecast is unstable while return forecast is stable. | Decision-index price is non-positive or invalid. | Check the source price indicator and data feed. |
 | Live forecasts disappear with a moving series. | The series evicted bars required by the lookback. | Increase `setMaximumBarCount` or reduce lookback after validation. |
 
@@ -272,7 +269,8 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | `EwmaReturnForecastStateIndicator.DriftMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting zero drift or rolling-mean drift. |
 | `ReturnForecastState` | `org.ta4j.core.indicators.forecast` | State record consumed by return forecast indicators. |
 | `ForecastProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for forecast summaries with point projection methods. |
-| `ReturnForecastProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Interface for return projections that declare a `ReturnRepresentation` and can convert to price forecasts. |
+| `ReturnForecastProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Interface for return projections that declare a `ReturnRepresentation`. |
+| `MonteCarloPriceForecastIndicator` | `org.ta4j.core.indicators.forecast` | Constructor-first price forecast indicator that infers the price source from `LogReturnIndicator`. |
 | `MonteCarloReturnProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return projection indicator with constructor defaults and a builder for advanced simulation settings. |
 | `MonteCarloReturnProjectionIndicator.ShockModel` | `org.ta4j.core.indicators.forecast` | Nested enum selecting historical bootstrap, standardized empirical, or normal shocks. |
 | `MonteCarloReturnProjectionIndicator.VolatilityUpdateMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting constant or EWMA path volatility. |

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -75,11 +75,11 @@ The raw `PredictionSnapshot.Forecast<Num>` summary remains useful for diagnostic
 - `quantiles()`: configured quantile probabilities to values.
 - `quantile(probability)`: one configured quantile value.
 
-Only request quantile projections that were configured on the underlying Monte Carlo projection. For example, `priceForecast.quantile(0.05)` works with the default quantile set, while advanced return-projection builders must include any non-default probabilities in `quantiles(...)`.
+Only request quantiles that were configured on the underlying Monte Carlo projection. For example, `priceForecast.getValue(index).quantile(0.05)` and `priceForecast.quantile(0.05).getValue(index)` both work with the default quantile set, while advanced return-projection builders must include any non-default probabilities in `quantiles(...)`.
 
 ## Point Projection Indicators
 
-Many rules and indicators need one `Num` value per index. `ForecastProjectionIndicator` exposes projection methods that return normal `Indicator<Num>` instances.
+Direct `priceForecast.getValue(index)` access returns the full forecast summary. When rules and other indicators need one `Num` value per index, `ForecastProjectionIndicator` exposes convenience projection methods that adapt summary fields into normal `Indicator<Num>` instances.
 
 ```java
 import org.ta4j.core.Indicator;
@@ -90,6 +90,7 @@ import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.OverIndicatorRule;
 
 ClosePriceIndicator close = new ClosePriceIndicator(series);
+// Adapter forms of priceForecast.getValue(index).median()/quantile(...).
 Indicator<Num> medianForecast = priceForecast.median();
 Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
 Indicator<Num> upsideForecast = priceForecast.quantile(0.95);
@@ -98,7 +99,7 @@ Indicator<Num> forecastWidth = BinaryOperationIndicator.difference(upsideForecas
 Rule forecastAboveCurrentPrice = new OverIndicatorRule(medianForecast, close);
 ```
 
-Projection indicators return `NaN` when the source forecast is unstable or when the requested quantile is missing. That makes projected forecasts safe to compose with normal ta4j rules and indicators, including `UnaryOperationIndicator` and `BinaryOperationIndicator`.
+These helper indicators are equivalent to reading the same field from `priceForecast.getValue(index)` at the same index. They return `NaN` when the source forecast is unstable or when the requested quantile is missing. That makes projected forecasts safe to compose with normal ta4j rules and indicators, including `UnaryOperationIndicator` and `BinaryOperationIndicator`.
 
 ## Pipeline
 
@@ -107,7 +108,8 @@ graph TD
     CP["ClosePriceIndicator or another price Indicator<Num>"] --> LR["LogReturnIndicator"]
     LR --> STATE["new EwmaReturnForecastStateIndicator(returns)"]
     STATE --> PRICE["new MonteCarloPriceForecastIndicator(state, horizon)"]
-    PRICE --> PROJECT["median(), quantile(), mean(), standardDeviation()"]
+    PRICE --> DIRECT["getValue(index).median(), quantile(...), mean()"]
+    PRICE --> PROJECT["median(), quantile(), mean(), standardDeviation() adapters"]
 ```
 
 Use this pipeline for normal strategy rules, chart overlays, and reports in price units. The API intentionally avoids a god factory so the return source, state model, and projection model remain reusable and testable.
@@ -206,7 +208,7 @@ For live trading:
 
 ### Median Direction Filter
 
-Use the median point forecast as a directional filter:
+Use the median point forecast as a directional filter. The rule needs an `Indicator<Num>`, so use the projection-helper adapter for the same value available from `priceForecast.getValue(index).median()`.
 
 ```java
 ClosePriceIndicator close = new ClosePriceIndicator(series);
@@ -219,7 +221,7 @@ This is intentionally minimal. In real strategies, add costs, slippage, and a re
 
 ### Downside Risk Filter
 
-Use a low quantile to avoid entries when the downside tail is too close.
+Use a low quantile to avoid entries when the downside tail is too close. The direct value is `priceForecast.getValue(index).quantile(0.05)`; the helper form adapts that value for rule composition.
 
 ```java
 Indicator<Num> fifthPercentilePrice =
@@ -232,7 +234,7 @@ Rule downsideAboveStop = new OverIndicatorRule(fifthPercentilePrice, plannedStop
 
 ### Forecast Width Filter
 
-Use a price-quantile spread when you want to avoid forecasts that are too uncertain, or require enough spread for a volatility strategy.
+Use a price-quantile spread when you want to avoid forecasts that are too uncertain, or require enough spread for a volatility strategy. For one-off reporting, subtract the direct quantile values from `priceForecast.getValue(index)`; for indicators or rules, use the equivalent helper adapters.
 
 ```java
 import org.ta4j.core.indicators.numeric.BinaryOperationIndicator;

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -21,9 +21,9 @@ This example builds the standard EWMA-volatility Monte Carlo pipeline and return
 
 ```java
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.forecast.DriftMode;
 import org.ta4j.core.indicators.forecast.EwmaReturnForecastStateConfig;
-import org.ta4j.core.indicators.forecast.ForecastDistribution;
 import org.ta4j.core.indicators.forecast.ForecastDistributionIndicator;
 import org.ta4j.core.indicators.forecast.ForecastIndicators;
 import org.ta4j.core.indicators.forecast.MonteCarloForecastConfig;
@@ -54,17 +54,19 @@ MonteCarloForecastConfig forecastConfig = MonteCarloForecastConfig.builder()
 ForecastDistributionIndicator priceForecast =
         ForecastIndicators.ewmaVolatilityClosePriceForecast(close, stateConfig, forecastConfig);
 
-int index = series.getEndIndex();
-ForecastDistribution<Num> distribution = priceForecast.getValue(index);
+Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
+Indicator<Num> medianForecast = priceForecast.median();
+Indicator<Num> upsideForecast = priceForecast.quantile(0.95);
 
-if (distribution.isStable()) {
-    Num downside = distribution.quantile(0.05);
-    Num median = distribution.median();
-    Num upside = distribution.quantile(0.95);
-}
+int index = series.getEndIndex();
+Num downside = downsideForecast.getValue(index);
+Num median = medianForecast.getValue(index);
+Num upside = upsideForecast.getValue(index);
 ```
 
-At each index, `ForecastDistribution<Num>` contains:
+Use `ForecastDistributionIndicator` projection methods for strategy rules, chart overlays, and other ta4j data flows. Each projection shifts the index lookup onto a normal `Indicator<Num>` and returns `NaN` while the source distribution is unstable.
+
+The raw `ForecastDistribution<Num>` snapshot remains useful for diagnostics and metadata. At each index, it contains:
 
 - `index()`: the decision index where the forecast was made.
 - `horizon()`: the configured number of bars ahead.
@@ -74,7 +76,7 @@ At each index, `ForecastDistribution<Num>` contains:
 - `quantiles()`: configured quantile probabilities to values.
 - `quantile(probability)`: one configured quantile value.
 
-Only request quantiles that were configured in `MonteCarloForecastConfig`. For example, `distribution.quantile(0.05)` is available only if `0.05` was included in `quantiles(...)`.
+Only request quantile projections that were configured in `MonteCarloForecastConfig`. For example, `priceForecast.quantile(0.05)` returns useful values only if `0.05` was included in `quantiles(...)`.
 
 ## Point Projection Indicators
 
@@ -205,7 +207,7 @@ Unstable values can also occur after warm-up when:
 - The historical lookback does not contain enough valid returns.
 - A price forecast cannot be converted because the decision-index price is invalid or non-positive.
 
-Always check `distribution.isStable()` before reading summary values in reporting code. Projection indicators return `NaN` for unstable distributions, which normal ta4j rules will treat as not satisfying comparisons.
+Prefer projection indicators for rule and indicator composition. If you intentionally inspect raw `ForecastDistribution` snapshots in reporting or diagnostics, check `isStable()` before reading summary values. Projection indicators return `NaN` for unstable distributions, which normal ta4j rules will treat as not satisfying comparisons.
 
 ## Avoiding Look-Ahead Bias
 
@@ -281,9 +283,9 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| `distribution.isStable()` is false early in the series. | Warm-up and lookback requirements are not met. | Start reading after `forecast.getCountOfUnstableBars()`. |
-| A configured quantile throws when requested. | The probability was not included in `quantiles(...)`. | Add that exact probability to `MonteCarloForecastConfig`. |
-| Point forecast is `NaN`. | The source distribution is unstable or the projection requested a missing quantile. | Check `isStable()` on the distribution source and config. |
+| Projection values are `NaN` early in the series. | Warm-up and lookback requirements are not met. | Start reading after `forecast.getCountOfUnstableBars()`. |
+| Quantile projection is `NaN` at a stable index. | The probability was not included in `quantiles(...)`. | Add that exact probability to `MonteCarloForecastConfig`. |
+| Point forecast is `NaN`. | The source distribution is unstable, the projection requested a missing quantile, or source data is invalid. | Check warm-up, configured quantiles, and source price/return validity. |
 | Price forecast is unstable while return forecast is stable. | Decision-index price is non-positive or invalid. | Check the source price indicator and data feed. |
 | Live forecasts disappear with a moving series. | The series evicted bars required by the lookback. | Increase `setMaximumBarCount` or reduce lookback after validation. |
 

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -76,13 +76,15 @@ Many rules and indicators need one `Num` value per index. `ForecastProjectionInd
 import org.ta4j.core.Indicator;
 import org.ta4j.core.Rule;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.numeric.BinaryOperationIndicator;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.OverIndicatorRule;
 
 ClosePriceIndicator close = new ClosePriceIndicator(series);
 Indicator<Num> medianForecast = priceForecast.median();
 Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
-Indicator<Num> forecastWidth = priceForecast.standardDeviation();
+Indicator<Num> upsideForecast = priceForecast.quantile(0.95);
+Indicator<Num> forecastWidth = BinaryOperationIndicator.difference(upsideForecast, downsideForecast);
 
 Rule forecastAboveCurrentPrice = new OverIndicatorRule(medianForecast, close);
 ```
@@ -221,7 +223,18 @@ Rule downsideAboveStop = new OverIndicatorRule(fifthPercentilePrice, plannedStop
 
 ### Forecast Width Filter
 
-Use `priceForecast.standardDeviation()` when you want to avoid forecasts that are too uncertain, or require enough spread for a volatility strategy. The result is in the same unit as the forecast summary: log-return units for return forecasts and price units for price forecasts.
+Use a price-quantile spread when you want to avoid forecasts that are too uncertain, or require enough spread for a volatility strategy.
+
+```java
+import org.ta4j.core.indicators.numeric.BinaryOperationIndicator;
+
+Indicator<Num> fifthPercentilePrice = priceForecast.quantile(0.05);
+Indicator<Num> ninetyFifthPercentilePrice = priceForecast.quantile(0.95);
+Indicator<Num> forecastWidth =
+        BinaryOperationIndicator.difference(ninetyFifthPercentilePrice, fifthPercentilePrice);
+```
+
+`standardDeviation()` is most useful on return forecasts. For price forecasts, prefer quantile spreads because the log-return-to-price reducer maps summary fields instead of recomputing dispersion from transformed price samples.
 
 ## Choosing Return or Price Space
 

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -24,15 +24,22 @@ This example builds an EWMA-volatility Monte Carlo pipeline and projects forecas
 ```java
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.forecast.ForecastPredictionIndicator;
-import org.ta4j.core.indicators.forecast.LogReturnToPriceForecastIndicator;
+import org.ta4j.core.indicators.forecast.EwmaReturnForecastStateIndicator;
+import org.ta4j.core.indicators.forecast.ForecastProjectionProvider;
+import org.ta4j.core.indicators.forecast.MonteCarloReturnProjectionIndicator;
+import org.ta4j.core.indicators.forecast.ReturnForecastProjectionProvider;
+import org.ta4j.core.indicators.forecast.ReturnForecastStateProvider;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.LogReturnIndicator;
 import org.ta4j.core.num.Num;
 
 BarSeries series = ...;
 ClosePriceIndicator close = new ClosePriceIndicator(series);
 
-ForecastPredictionIndicator priceForecast = new LogReturnToPriceForecastIndicator(close, 5);
+LogReturnIndicator returns = new LogReturnIndicator(close);
+ReturnForecastStateProvider state = new EwmaReturnForecastStateIndicator(returns);
+ReturnForecastProjectionProvider projection = new MonteCarloReturnProjectionIndicator(state, 5);
+ForecastProjectionProvider<?> priceForecast = projection.toPriceForecast(close);
 
 Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
 Indicator<Num> medianForecast = priceForecast.median();
@@ -44,9 +51,16 @@ Num median = medianForecast.getValue(index);
 Num upside = upsideForecast.getValue(index);
 ```
 
-Use `ForecastPredictionIndicator` projection methods for strategy rules, chart overlays, and other ta4j data flows. Each projection shifts the index lookup onto a normal `Indicator<Num>` and returns `NaN` while the source forecast is unstable.
+Use `ForecastProjectionProvider` projection methods for strategy rules, chart overlays, and other ta4j data flows. Each projection shifts the index lookup onto a normal `Indicator<Num>` and returns `NaN` while the source forecast is unstable.
 
-The short constructor path creates log returns internally, then uses EWMA return state with a 30-bar initialization window, `0.94` decay, zero drift, standardized empirical shocks, 1,000 simulations, a 252-return lookback, and default quantiles of `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`.
+The setup has three business decisions and one optional reducer:
+
+- `LogReturnIndicator` declares the source stream as log returns through the `ReturnIndicator` semantic contract.
+- `EwmaReturnForecastStateIndicator` provides hidden return state from that log-return stream.
+- `MonteCarloReturnProjectionIndicator` projects cumulative log returns from the state provider.
+- `projection.toPriceForecast(close)` uses `LogReturnToPriceForecastIndicator` internally to convert cumulative log returns into decision-index prices.
+
+The default EWMA state uses a 30-bar initialization window, `0.94` decay, and zero drift. The default Monte Carlo projection uses standardized empirical shocks, 1,000 simulations, a 252-return lookback, and default quantiles of `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`.
 
 The raw `PredictionSnapshot.Forecast<Num>` summary remains useful for diagnostics and metadata. At each index, it contains:
 
@@ -58,11 +72,11 @@ The raw `PredictionSnapshot.Forecast<Num>` summary remains useful for diagnostic
 - `quantiles()`: configured quantile probabilities to values.
 - `quantile(probability)`: one configured quantile value.
 
-Only request quantile projections that were configured on `MonteCarloReturnForecastIndicator.Builder`. For example, `priceForecast.quantile(0.05)` returns useful values only if `0.05` was included in `quantiles(...)`.
+Only request quantile projections that were configured on `MonteCarloReturnProjectionIndicator.Builder`. For example, `priceForecast.quantile(0.05)` returns useful values only if `0.05` was included in `quantiles(...)`.
 
 ## Point Projection Indicators
 
-Many rules and indicators need one `Num` value per index. `ForecastPredictionIndicator` exposes projection methods that return normal `Indicator<Num>` instances.
+Many rules and indicators need one `Num` value per index. `ForecastProjectionProvider` exposes projection methods that return normal `Indicator<Num>` instances.
 
 ```java
 import org.ta4j.core.Indicator;
@@ -84,18 +98,16 @@ Projection indicators return `NaN` when the source forecast is unstable or when 
 ```mermaid
 graph TD
     CP["ClosePriceIndicator or another price Indicator<Num>"] --> LR["LogReturnIndicator"]
-    LR --> MC["new MonteCarloReturnForecastIndicator(returns, horizon)"]
-    MC -. "default EWMA state" .-> STATE["new ForecastStateIndicator(...)"]
-    MC --> PRICE["LogReturnToPriceForecastIndicator"]
-    CP --> PRICE_SHORT["new LogReturnToPriceForecastIndicator(close, horizon)"]
-    PRICE_SHORT -. "default return forecast" .-> MC
+    LR --> STATE["new EwmaReturnForecastStateIndicator(returns)"]
+    STATE --> MC["new MonteCarloReturnProjectionIndicator(state, horizon)"]
+    MC --> PRICE["projection.toPriceForecast(close)"]
+    CP --> PRICE
     PRICE --> PROJECT["median(), quantile(), mean(), standardDeviation()"]
-    PRICE_SHORT --> PROJECT
 ```
 
-Use this pipeline when you need direct access to return forecasts, a custom price source, custom point projections, or intermediate state diagnostics. The API intentionally avoids a god factory so each stage remains reusable and testable while the common constructor keeps setup small.
+Use this pipeline when you need direct access to return forecasts, a custom price source, custom point projections, or intermediate state diagnostics. The API intentionally avoids a god factory so each stage remains reusable and testable.
 
-`MonteCarloReturnForecastIndicator` produces a cumulative log-return forecast over the configured horizon. `LogReturnToPriceForecastIndicator` converts it to a price forecast with:
+`MonteCarloReturnProjectionIndicator` produces a cumulative log-return forecast over the configured horizon. `LogReturnToPriceForecastIndicator` converts it to a price forecast with:
 
 ```text
 forecastPrice = priceAtDecisionIndex * exp(cumulativeLogReturn)
@@ -105,24 +117,24 @@ forecastPrice = priceAtDecisionIndex * exp(cumulativeLogReturn)
 
 ### EWMA State
 
-`new ForecastStateIndicator(...)` estimates rolling return state from a log-return source. You only need to create it yourself when you want to override the default state used by `new MonteCarloReturnForecastIndicator(returns, horizon)`.
+`new EwmaReturnForecastStateIndicator(returns)` estimates rolling return state from a log-return source. Its constructors accept `ReturnIndicator`, not arbitrary `Indicator<Num>`, and reject return streams whose `ReturnRepresentation` is not `LOG`.
 
 | Parameter | Default in examples | Meaning | Common tuning |
 | --- | --- | --- | --- |
 | `initializationBarCount` | `30` | Number of valid return observations required before state is stable. | Increase for slower, steadier estimates; decrease for faster adaptation. |
 | `decayFactor` | `0.94` | EWMA persistence in `(0, 1)`. Higher values react more slowly. | Use higher values for daily data and lower values for shorter bars only after validation. |
-| `driftMode` | `ForecastStateIndicator.DriftMode.ZERO` | Drift used in simulated paths. | Prefer `ZERO` as a conservative default; use `ROLLING_MEAN` only when the rolling mean has validated predictive value. |
+| `driftMode` | `EwmaReturnForecastStateIndicator.DriftMode.ZERO` | Drift used in simulated paths. | Prefer `ZERO` as a conservative default; use `ROLLING_MEAN` only when the rolling mean has validated predictive value. |
 
 The state output is a `ReturnForecastState` with rolling `mean`, forecast `drift`, `variance`, and `volatility`.
 
 ### Monte Carlo Forecast
 
-`new MonteCarloReturnForecastIndicator(returns, horizon)` is the standard constructor for default EWMA Monte Carlo forecasts. Use the builder only when you need to tune the simulation settings beyond horizon and EWMA state.
+`new MonteCarloReturnProjectionIndicator(state, horizon)` is the standard constructor for EWMA Monte Carlo forecasts. It accepts a `ReturnForecastStateProvider`, validates that the provider is log-return based, and uses `state.getReturnIndicator()` for historical shocks. Use the builder only when you need to tune simulation settings beyond horizon.
 
 | Constructor or builder method | Default | Meaning | Common tuning |
 | --- | --- | --- | --- |
-| `new MonteCarloReturnForecastIndicator(returns)` | `1` bar | Default one-bar forecast. | Use for next-bar forecasts. |
-| `new MonteCarloReturnForecastIndicator(returns, horizon)` | caller supplied | Number of bars ahead to forecast. | Match the holding period or evaluation label. |
+| `new MonteCarloReturnProjectionIndicator(state)` | `1` bar | Default one-bar forecast from the supplied state provider. | Use for next-bar forecasts. |
+| `new MonteCarloReturnProjectionIndicator(state, horizon)` | caller supplied | Number of bars ahead to forecast. | Match the holding period or evaluation label. |
 | `iterationCount(...)` | `1_000` | Number of simulated paths. | Increase for smoother quantiles; reduce only for latency-sensitive live loops after measuring. |
 | `lookbackBarCount(...)` | `252` | Number of historical returns used for empirical shocks. | Match the market regime window you want represented. |
 | `seed(...)` | `42L` | Base random seed. | Keep fixed for reproducible research and tests. |
@@ -135,16 +147,16 @@ The state output is a `ReturnForecastState` with rolling `mean`, forecast `drift
 
 | Shock model | Behavior | Use when |
 | --- | --- | --- |
-| `MonteCarloReturnForecastIndicator.ShockModel.HISTORICAL_BOOTSTRAP` | Samples raw historical returns from the lookback window. | You want the recent empirical return distribution without rescaling by current volatility. |
-| `MonteCarloReturnForecastIndicator.ShockModel.STANDARDIZED_EMPIRICAL` | Samples standardized residuals and scales them by the current EWMA state. | You want empirical tail shape with current volatility and drift. This is the default. |
-| `MonteCarloReturnForecastIndicator.ShockModel.NORMAL` | Draws standard normal shocks and scales them by the current EWMA state. | You want a simple parametric baseline and accept thinner tails than many markets show. |
+| `MonteCarloReturnProjectionIndicator.ShockModel.HISTORICAL_BOOTSTRAP` | Samples raw historical returns from the lookback window. | You want the recent empirical return distribution without rescaling by current volatility. |
+| `MonteCarloReturnProjectionIndicator.ShockModel.STANDARDIZED_EMPIRICAL` | Samples standardized residuals and scales them by the current EWMA state. | You want empirical tail shape with current volatility and drift. This is the default. |
+| `MonteCarloReturnProjectionIndicator.ShockModel.NORMAL` | Draws standard normal shocks and scales them by the current EWMA state. | You want a simple parametric baseline and accept thinner tails than many markets show. |
 
 ### Volatility Update Modes
 
 | Mode | Behavior | Tradeoff |
 | --- | --- | --- |
-| `MonteCarloReturnForecastIndicator.VolatilityUpdateMode.CONSTANT` | Uses the decision-index volatility for every simulated step in a path. | Simple, reproducible, and usually the first model to validate. |
-| `MonteCarloReturnForecastIndicator.VolatilityUpdateMode.EWMA` | Updates path volatility after each simulated step using `volatilityDecayFactor`. | More dynamic, but adds another assumption that must be tested. |
+| `MonteCarloReturnProjectionIndicator.VolatilityUpdateMode.CONSTANT` | Uses the decision-index volatility for every simulated step in a path. | Simple, reproducible, and usually the first model to validate. |
+| `MonteCarloReturnProjectionIndicator.VolatilityUpdateMode.EWMA` | Updates path volatility after each simulated step using `volatilityDecayFactor`. | More dynamic, but adds another assumption that must be tested. |
 
 ## Warm-Up and Unstable Values
 
@@ -154,8 +166,8 @@ Important warm-up rules:
 
 - `LogReturnIndicator` is unstable for `source.getCountOfUnstableBars() + barCount` bars.
 - `EWMAIndicator` is unstable for `source.getCountOfUnstableBars() + barCount - 1` bars.
-- `ForecastStateIndicator` is unstable until its EWMA mean and variance sources are stable.
-- `MonteCarloReturnForecastIndicator` is unstable until both the state is stable and the configured return lookback is available.
+- `EwmaReturnForecastStateIndicator` is unstable until its EWMA mean and variance sources are stable.
+- `MonteCarloReturnProjectionIndicator` is unstable until both the state is stable and the configured return lookback is available.
 - With the default one-bar log return and default `lookbackBarCount(252)`, the standard Monte Carlo return forecast first becomes eligible at index `252` when all returns are valid.
 
 Unstable values can also occur after warm-up when:
@@ -228,7 +240,7 @@ Use price forecasts when:
 - Strategy rules compare the forecast to current price, stops, targets, support, resistance, or chart overlays.
 - You want report output in user-facing price units.
 
-`LogReturnToPriceForecastIndicator` is the bridge between the two.
+`LogReturnToPriceForecastIndicator` is the reducer bridge between the two. It accepts an explicit price indicator plus an explicit `ReturnForecastProjectionProvider` and rejects non-log return projections.
 
 ## Reproducibility Notes
 
@@ -241,8 +253,9 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | Projection values are `NaN` early in the series. | Warm-up and lookback requirements are not met. | Start reading after `forecast.getCountOfUnstableBars()`. |
-| Quantile projection is `NaN` at a stable index. | The probability was not included in `quantiles(...)`. | The default constructor includes `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`; for other probabilities add that exact value with `MonteCarloReturnForecastIndicator.builder(...).quantiles(...)`. |
+| Quantile projection is `NaN` at a stable index. | The probability was not included in `quantiles(...)`. | The default quantile set includes `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`; for other probabilities add that exact value with `MonteCarloReturnProjectionIndicator.builder(state).quantiles(...)`. |
 | Point forecast is `NaN`. | The source forecast is unstable, the projection requested a missing quantile, or source data is invalid. | Check warm-up, configured quantiles, and source price/return validity. |
+| A constructor rejects the return input. | The stream declares a non-log `ReturnRepresentation`. | Use `LogReturnIndicator` or another `ReturnIndicator` that explicitly returns `ReturnRepresentation.LOG`. Decimal, percentage, and multiplicative returns need separate projection support. |
 | Price forecast is unstable while return forecast is stable. | Decision-index price is non-positive or invalid. | Check the source price indicator and data feed. |
 | Live forecasts disappear with a moving series. | The series evicted bars required by the lookback. | Increase `setMaximumBarCount` or reduce lookback after validation. |
 
@@ -251,14 +264,18 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | Type | Package | Purpose |
 | --- | --- | --- |
 | `LogReturnIndicator` | `org.ta4j.core.indicators.helpers` | Normal numeric helper indicator for `log(x[i] / x[i - n])`. |
+| `ReturnIndicator` | `org.ta4j.core.indicators` | Semantic contract for indicators that promise return-stream output in a declared `ReturnRepresentation`. |
 | `EWMAIndicator` | `org.ta4j.core.indicators.averages` | Reusable EWMA indicator with explicit decay and SMA initialization. |
-| `ForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Converts EWMA or explicit mean and variance indicators into `ReturnForecastState`. |
-| `ForecastStateIndicator.DriftMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting zero drift or rolling-mean drift. |
+| `ForecastStateProvider` | `org.ta4j.core.indicators.forecast` | Interface for hidden-state providers used by forecast projections. |
+| `ReturnForecastStateProvider` | `org.ta4j.core.indicators.forecast` | Interface for hidden-state providers derived from a `ReturnIndicator`. |
+| `EwmaReturnForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Builds `ReturnForecastState` from a log-return `ReturnIndicator` using EWMA mean and variance. |
+| `EwmaReturnForecastStateIndicator.DriftMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting zero drift or rolling-mean drift. |
 | `ReturnForecastState` | `org.ta4j.core.indicators.forecast` | State record consumed by return forecast indicators. |
-| `MonteCarloReturnForecastIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return forecast indicator with constructor defaults and a builder for advanced configuration. |
-| `MonteCarloReturnForecastIndicator.ShockModel` | `org.ta4j.core.indicators.forecast` | Nested enum selecting historical bootstrap, standardized empirical, or normal shocks. |
-| `MonteCarloReturnForecastIndicator.VolatilityUpdateMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting constant or EWMA path volatility. |
-| `ForecastPredictionIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for forecast summaries with point projection methods. |
-| `LogReturnToPriceForecastIndicator` | `org.ta4j.core.indicators.forecast` | Converts cumulative log-return forecasts to price forecasts. |
+| `ForecastProjectionProvider` | `org.ta4j.core.indicators.forecast` | Indicator interface for forecast summaries with point projection methods. |
+| `ReturnForecastProjectionProvider` | `org.ta4j.core.indicators.forecast` | Interface for return projections that declare a `ReturnRepresentation` and can convert to price forecasts. |
+| `MonteCarloReturnProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return projection provider with constructor defaults and a builder for advanced simulation settings. |
+| `MonteCarloReturnProjectionIndicator.ShockModel` | `org.ta4j.core.indicators.forecast` | Nested enum selecting historical bootstrap, standardized empirical, or normal shocks. |
+| `MonteCarloReturnProjectionIndicator.VolatilityUpdateMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting constant or EWMA path volatility. |
+| `LogReturnToPriceForecastIndicator` | `org.ta4j.core.indicators.forecast` | Reducer that converts an explicit cumulative log-return projection to a price projection. |
 | `ForwardForecastIndicator` | `org.ta4j.core.indicators.forecast` | Adapter used by point projection methods to expose one `Num` forecast. |
 | `PredictionSnapshot.Forecast` | `org.ta4j.core.walkforward` | Walk-forward prediction summary type used by forecast indicators. |

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -4,6 +4,8 @@ Forecast indicators estimate a future return or price distribution from data ava
 
 The forecast API lives mostly in `org.ta4j.core.indicators.forecast`. `LogReturnIndicator` is a normal helper indicator in `org.ta4j.core.indicators.helpers`, `EWMAIndicator` is a reusable average in `org.ta4j.core.indicators.averages`, and forecast summaries use the walk-forward prediction model via `PredictionSnapshot.Forecast`.
 
+**Release status:** These APIs are introduced by the matching ta4j feature branch for CF-289 and should be published with ta4j 0.22.9 or newer. Until that ta4j change is merged and released, use this guide with the matching ta4j branch rather than the current release artifacts.
+
 ## When to use them
 
 Use forecast indicators when you want to answer questions such as:

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -273,7 +273,7 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| Projection values are `NaN` early in the series. | Warm-up and lookback requirements are not met. | Start reading after `forecast.getCountOfUnstableBars()`. |
+| Projection values are `NaN` early in the series. | Warm-up and lookback requirements are not met. | Start reading after `priceForecast.getCountOfUnstableBars()` or set the same unstable-bar count on the strategy. |
 | Direct quantile lookup returns `null`. | The probability was valid but was not included in `quantiles(...)`. | Use `forecast.hasQuantile(probability)` before direct `forecast.quantile(probability)`, or configure that probability on the Monte Carlo builder. |
 | Quantile projection is `NaN` at a stable index. | The probability was valid but was not included in `quantiles(...)`. | The default quantile set includes `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`; for other probabilities add that exact value with `MonteCarloReturnProjectionIndicator.builder(state).quantiles(...)`. |
 | Point forecast is `NaN`. | The source forecast is unstable, the projection requested a missing quantile, or source data is invalid. | Check warm-up, configured quantiles, and source price/return validity. |

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -2,7 +2,7 @@
 
 Forecast indicators estimate a future return or price distribution from data available at a decision index. They are useful when a strategy needs a probabilistic outlook instead of a single backward-looking technical signal.
 
-The forecast API lives under `org.ta4j.core.indicators.forecast`. The root package contains the primary indicators most users instantiate, while state contracts, projection contracts, and conversion adapters live in `forecast.state`, `forecast.projection`, and `forecast.adapters`. `LogReturnIndicator` is a normal helper indicator in `org.ta4j.core.indicators.helpers`, `EWMAIndicator` is a reusable average in `org.ta4j.core.indicators.averages`, and forecast summaries use the walk-forward prediction model via `PredictionSnapshot.Forecast`.
+The forecast API lives under `org.ta4j.core.indicators.forecast`. The root package contains the primary indicators most users instantiate, while state contracts, projection contracts, the `Forecast` value model, and conversion adapters live in `forecast.state`, `forecast.projection`, and `forecast.adapters`. `LogReturnIndicator` is a normal helper indicator in `org.ta4j.core.indicators.helpers`, and `EWMAIndicator` is a reusable average in `org.ta4j.core.indicators.averages`.
 
 **Release status:** These APIs are introduced by the matching ta4j feature branch for CF-289 and should be published with ta4j 0.22.9 or newer. Until that ta4j change is merged and released, use this guide with the matching ta4j branch rather than the current release artifacts.
 
@@ -26,11 +26,11 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.forecast.EwmaReturnForecastStateIndicator;
 import org.ta4j.core.indicators.forecast.MonteCarloPriceForecastIndicator;
+import org.ta4j.core.indicators.forecast.projection.Forecast;
 import org.ta4j.core.indicators.forecast.projection.ForecastProjectionIndicator;
 import org.ta4j.core.indicators.forecast.state.ReturnForecastStateIndicator;
 import org.ta4j.core.indicators.helpers.LogReturnIndicator;
 import org.ta4j.core.num.Num;
-import org.ta4j.core.walkforward.PredictionSnapshot;
 
 BarSeries series = ...;
 LogReturnIndicator returns = new LogReturnIndicator(series);
@@ -38,7 +38,7 @@ ReturnForecastStateIndicator state = new EwmaReturnForecastStateIndicator(return
 ForecastProjectionIndicator priceForecast = new MonteCarloPriceForecastIndicator(state, 5);
 
 int index = series.getEndIndex();
-PredictionSnapshot.Forecast<Num> forecast = priceForecast.getValue(index);
+Forecast<Num> forecast = priceForecast.getValue(index);
 if (forecast.isStable()) {
     Num directDownside = forecast.quantile(0.05);
     Num directMedian = forecast.median();
@@ -70,12 +70,12 @@ The default EWMA state uses a 30-bar initialization window, `0.94` decay, and ze
 The forecasting layer is organized around three responsibilities:
 
 - **Hidden state estimators** build latent state from source indicators. `EwmaReturnForecastStateIndicator` is the initial estimator; its reusable contracts and state record live in `org.ta4j.core.indicators.forecast.state`.
-- **Projection indicators** turn hidden state into a forward `PredictionSnapshot.Forecast<Num>`. `MonteCarloReturnProjectionIndicator` projects cumulative log returns; `MonteCarloPriceForecastIndicator` is the constructor-first price forecast path for the common log-return workflow. Projection contracts and point adapters live in `org.ta4j.core.indicators.forecast.projection`.
+- **Projection indicators** turn hidden state into a forward `Forecast<Num>`. `MonteCarloReturnProjectionIndicator` projects cumulative log returns; `MonteCarloPriceForecastIndicator` is the constructor-first price forecast path for the common log-return workflow. Projection contracts, point adapters, and the forecast summary value model live in `org.ta4j.core.indicators.forecast.projection`.
 - **Adapters and glue** bridge forecast domains or API shapes. `LogReturnToPriceForecastIndicator` lives in `org.ta4j.core.indicators.forecast.adapters` because it converts an explicit log-return projection into price space rather than estimating state or simulating paths itself.
 
 The root `forecast` package intentionally stays focused on the primary indicators users choose and compose. Framework types, data records, and conversion bridges are grouped under subpackages so custom estimators and custom projection models have obvious extension points without turning the root package into a catch-all.
 
-The raw `PredictionSnapshot.Forecast<Num>` summary remains useful for diagnostics and metadata. At each index, it contains:
+The raw `Forecast<Num>` summary remains useful for diagnostics and metadata. At each index, it contains:
 
 - `decisionIndex()` / `index()`: the decision index where the forecast was made.
 - `horizon()`: the configured number of bars ahead.
@@ -211,7 +211,7 @@ Unstable values can also occur after warm-up when:
 - The historical lookback does not contain enough valid returns.
 - A price forecast cannot be converted because the decision-index price is invalid or non-positive.
 
-Prefer projection indicators for rule and indicator composition. If you intentionally inspect raw `PredictionSnapshot.Forecast` summaries in reporting or diagnostics, check `isStable()` before reading summary values. Projection indicators return `NaN` for unstable summaries, which normal ta4j rules will treat as not satisfying comparisons.
+Prefer projection indicators for rule and indicator composition. If you intentionally inspect raw `Forecast` summaries in reporting or diagnostics, check `isStable()` before reading summary values. Projection indicators return `NaN` for unstable summaries, which normal ta4j rules will treat as not satisfying comparisons.
 
 ## Avoiding Look-Ahead Bias
 
@@ -339,4 +339,4 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | `MonteCarloReturnProjectionIndicator.VolatilityUpdateMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting constant or EWMA path volatility. |
 | `LogReturnToPriceForecastIndicator` | `org.ta4j.core.indicators.forecast.adapters` | Adapter that converts an explicit cumulative log-return projection to a price projection. |
 | `ForwardForecastIndicator` | `org.ta4j.core.indicators.forecast.projection` | Adapter used by point projection methods to expose one `Num` forecast. |
-| `PredictionSnapshot.Forecast` | `org.ta4j.core.walkforward` | Walk-forward prediction summary type used by forecast indicators. |
+| `Forecast` | `org.ta4j.core.indicators.forecast.projection` | Forecast summary value model used by projection indicators. |

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -25,10 +25,10 @@ This example builds an EWMA-volatility Monte Carlo pipeline and projects forecas
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.forecast.EwmaReturnForecastStateIndicator;
-import org.ta4j.core.indicators.forecast.ForecastProjectionProvider;
+import org.ta4j.core.indicators.forecast.ForecastProjectionIndicator;
 import org.ta4j.core.indicators.forecast.MonteCarloReturnProjectionIndicator;
-import org.ta4j.core.indicators.forecast.ReturnForecastProjectionProvider;
-import org.ta4j.core.indicators.forecast.ReturnForecastStateProvider;
+import org.ta4j.core.indicators.forecast.ReturnForecastProjectionIndicator;
+import org.ta4j.core.indicators.forecast.ReturnForecastStateIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.LogReturnIndicator;
 import org.ta4j.core.num.Num;
@@ -37,9 +37,9 @@ BarSeries series = ...;
 ClosePriceIndicator close = new ClosePriceIndicator(series);
 
 LogReturnIndicator returns = new LogReturnIndicator(close);
-ReturnForecastStateProvider state = new EwmaReturnForecastStateIndicator(returns);
-ReturnForecastProjectionProvider projection = new MonteCarloReturnProjectionIndicator(state, 5);
-ForecastProjectionProvider<?> priceForecast = projection.toPriceForecast(close);
+ReturnForecastStateIndicator state = new EwmaReturnForecastStateIndicator(returns);
+ReturnForecastProjectionIndicator projection = new MonteCarloReturnProjectionIndicator(state, 5);
+ForecastProjectionIndicator priceForecast = projection.toPriceForecast(close);
 
 Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
 Indicator<Num> medianForecast = priceForecast.median();
@@ -51,13 +51,13 @@ Num median = medianForecast.getValue(index);
 Num upside = upsideForecast.getValue(index);
 ```
 
-Use `ForecastProjectionProvider` projection methods for strategy rules, chart overlays, and other ta4j data flows. Each projection shifts the index lookup onto a normal `Indicator<Num>` and returns `NaN` while the source forecast is unstable.
+Use `ForecastProjectionIndicator` projection methods for strategy rules, chart overlays, and other ta4j data flows. Each projection shifts the index lookup onto a normal `Indicator<Num>` and returns `NaN` while the source forecast is unstable.
 
 The setup has three business decisions and one optional reducer:
 
 - `LogReturnIndicator` declares the source stream as log returns through the `ReturnIndicator` semantic contract.
 - `EwmaReturnForecastStateIndicator` provides hidden return state from that log-return stream.
-- `MonteCarloReturnProjectionIndicator` projects cumulative log returns from the state provider.
+- `MonteCarloReturnProjectionIndicator` projects cumulative log returns from the state indicator.
 - `projection.toPriceForecast(close)` uses `LogReturnToPriceForecastIndicator` internally to convert cumulative log returns into decision-index prices.
 
 The default EWMA state uses a 30-bar initialization window, `0.94` decay, and zero drift. The default Monte Carlo projection uses standardized empirical shocks, 1,000 simulations, a 252-return lookback, and default quantiles of `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`.
@@ -76,7 +76,7 @@ Only request quantile projections that were configured on `MonteCarloReturnProje
 
 ## Point Projection Indicators
 
-Many rules and indicators need one `Num` value per index. `ForecastProjectionProvider` exposes projection methods that return normal `Indicator<Num>` instances.
+Many rules and indicators need one `Num` value per index. `ForecastProjectionIndicator` exposes projection methods that return normal `Indicator<Num>` instances.
 
 ```java
 import org.ta4j.core.Indicator;
@@ -129,11 +129,11 @@ The state output is a `ReturnForecastState` with rolling `mean`, forecast `drift
 
 ### Monte Carlo Forecast
 
-`new MonteCarloReturnProjectionIndicator(state, horizon)` is the standard constructor for EWMA Monte Carlo forecasts. It accepts a `ReturnForecastStateProvider`, validates that the provider is log-return based, and uses `state.getReturnIndicator()` for historical shocks. Use the builder only when you need to tune simulation settings beyond horizon.
+`new MonteCarloReturnProjectionIndicator(state, horizon)` is the standard constructor for EWMA Monte Carlo forecasts. It accepts a `ReturnForecastStateIndicator`, validates that the state indicator is log-return based, and uses `state.getReturnIndicator()` for historical shocks. Use the builder only when you need to tune simulation settings beyond horizon.
 
 | Constructor or builder method | Default | Meaning | Common tuning |
 | --- | --- | --- | --- |
-| `new MonteCarloReturnProjectionIndicator(state)` | `1` bar | Default one-bar forecast from the supplied state provider. | Use for next-bar forecasts. |
+| `new MonteCarloReturnProjectionIndicator(state)` | `1` bar | Default one-bar forecast from the supplied state indicator. | Use for next-bar forecasts. |
 | `new MonteCarloReturnProjectionIndicator(state, horizon)` | caller supplied | Number of bars ahead to forecast. | Match the holding period or evaluation label. |
 | `iterationCount(...)` | `1_000` | Number of simulated paths. | Increase for smoother quantiles; reduce only for latency-sensitive live loops after measuring. |
 | `lookbackBarCount(...)` | `252` | Number of historical returns used for empirical shocks. | Match the market regime window you want represented. |
@@ -240,7 +240,7 @@ Use price forecasts when:
 - Strategy rules compare the forecast to current price, stops, targets, support, resistance, or chart overlays.
 - You want report output in user-facing price units.
 
-`LogReturnToPriceForecastIndicator` is the reducer bridge between the two. It accepts an explicit price indicator plus an explicit `ReturnForecastProjectionProvider` and rejects non-log return projections.
+`LogReturnToPriceForecastIndicator` is the reducer bridge between the two. It accepts an explicit price indicator plus an explicit `ReturnForecastProjectionIndicator` and rejects non-log return projections.
 
 ## Reproducibility Notes
 
@@ -266,14 +266,14 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | `LogReturnIndicator` | `org.ta4j.core.indicators.helpers` | Normal numeric helper indicator for `log(x[i] / x[i - n])`. |
 | `ReturnIndicator` | `org.ta4j.core.indicators` | Semantic contract for indicators that promise return-stream output in a declared `ReturnRepresentation`. |
 | `EWMAIndicator` | `org.ta4j.core.indicators.averages` | Reusable EWMA indicator with explicit decay and SMA initialization. |
-| `ForecastStateProvider` | `org.ta4j.core.indicators.forecast` | Interface for hidden-state providers used by forecast projections. |
-| `ReturnForecastStateProvider` | `org.ta4j.core.indicators.forecast` | Interface for hidden-state providers derived from a `ReturnIndicator`. |
+| `ForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for hidden state used by forecast projections. |
+| `ReturnForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for hidden state derived from a `ReturnIndicator`. |
 | `EwmaReturnForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Builds `ReturnForecastState` from a log-return `ReturnIndicator` using EWMA mean and variance. |
 | `EwmaReturnForecastStateIndicator.DriftMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting zero drift or rolling-mean drift. |
 | `ReturnForecastState` | `org.ta4j.core.indicators.forecast` | State record consumed by return forecast indicators. |
-| `ForecastProjectionProvider` | `org.ta4j.core.indicators.forecast` | Indicator interface for forecast summaries with point projection methods. |
-| `ReturnForecastProjectionProvider` | `org.ta4j.core.indicators.forecast` | Interface for return projections that declare a `ReturnRepresentation` and can convert to price forecasts. |
-| `MonteCarloReturnProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return projection provider with constructor defaults and a builder for advanced simulation settings. |
+| `ForecastProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for forecast summaries with point projection methods. |
+| `ReturnForecastProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Interface for return projections that declare a `ReturnRepresentation` and can convert to price forecasts. |
+| `MonteCarloReturnProjectionIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return projection indicator with constructor defaults and a builder for advanced simulation settings. |
 | `MonteCarloReturnProjectionIndicator.ShockModel` | `org.ta4j.core.indicators.forecast` | Nested enum selecting historical bootstrap, standardized empirical, or normal shocks. |
 | `MonteCarloReturnProjectionIndicator.VolatilityUpdateMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting constant or EWMA path volatility. |
 | `LogReturnToPriceForecastIndicator` | `org.ta4j.core.indicators.forecast` | Reducer that converts an explicit cumulative log-return projection to a price projection. |

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -51,13 +51,13 @@ MonteCarloForecastConfig forecastConfig = MonteCarloForecastConfig.builder()
         .quantiles(0.05, 0.5, 0.95)
         .build();
 
-ForecastDistributionIndicator<Num> priceForecast =
+ForecastDistributionIndicator priceForecast =
         ForecastIndicators.ewmaVolatilityClosePriceForecast(close, stateConfig, forecastConfig);
 
 int index = series.getEndIndex();
 ForecastDistribution<Num> distribution = priceForecast.getValue(index);
 
-if (distribution.defined()) {
+if (distribution.isStable()) {
     Num downside = distribution.quantile(0.05);
     Num median = distribution.median();
     Num upside = distribution.quantile(0.95);
@@ -69,30 +69,26 @@ At each index, `ForecastDistribution<Num>` contains:
 - `index()`: the decision index where the forecast was made.
 - `horizon()`: the configured number of bars ahead.
 - `sampleCount()`: the number of simulated samples summarized.
-- `defined()`: whether the forecast is usable.
+- `isStable()`: whether the forecast is usable at this decision index.
 - `mean()`, `median()`, `standardDeviation()`: summary values.
 - `quantiles()`: configured quantile probabilities to values.
 - `quantile(probability)`: one configured quantile value.
 
 Only request quantiles that were configured in `MonteCarloForecastConfig`. For example, `distribution.quantile(0.05)` is available only if `0.05` was included in `quantiles(...)`.
 
-## Point Forecasts
+## Point Projection Indicators
 
-Many rules and indicators need one `Num` value. Use `ForwardForecastIndicator` with a reducer when you want one point from a distribution.
+Many rules and indicators need one `Num` value per index. `ForecastDistributionIndicator` exposes projection methods that return normal `Indicator<Num>` instances.
 
 ```java
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.forecast.ForecastReducers;
-import org.ta4j.core.indicators.forecast.ForwardForecastIndicator;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.OverIndicatorRule;
 import org.ta4j.core.Rule;
 
-Indicator<Num> medianForecast =
-        new ForwardForecastIndicator(priceForecast, ForecastReducers.median());
-
-Indicator<Num> downsideForecast =
-        new ForwardForecastIndicator(priceForecast, ForecastReducers.quantile(0.05));
+Indicator<Num> medianForecast = priceForecast.median();
+Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
+Indicator<Num> forecastWidth = priceForecast.standardDeviation();
 
 Rule forecastAboveCurrentPrice = new OverIndicatorRule(medianForecast, close);
 ```
@@ -104,7 +100,7 @@ Indicator<Num> medianPriceForecast =
         ForecastIndicators.ewmaVolatilityMedianClosePriceForecast(close, stateConfig, forecastConfig);
 ```
 
-Reducers return `NaN` when the source distribution is undefined or when the requested quantile is missing. That makes reduced forecasts safe to compose with normal ta4j rules and indicators.
+Projection indicators return `NaN` when the source distribution is unstable or when the requested quantile is missing. That makes projected forecasts safe to compose with normal ta4j rules and indicators, including `UnaryOperationIndicator` and `BinaryOperationIndicator`.
 
 ## Manual Pipeline
 
@@ -117,10 +113,10 @@ graph TD
     LR --> MC["MonteCarloReturnForecastIndicator"]
     EWMA --> MC
     MC --> PRICE["LogReturnToPriceForecastIndicator"]
-    PRICE --> REDUCE["ForwardForecastIndicator (optional)"]
+    PRICE --> PROJECT["median(), quantile(), mean(), standardDeviation()"]
 ```
 
-Use the manual pipeline when you need direct access to return forecasts, a custom price source, a custom reducer, or intermediate state diagnostics.
+Use the manual pipeline when you need direct access to return forecasts, a custom price source, custom point projections, or intermediate state diagnostics.
 
 ```java
 import org.ta4j.core.indicators.forecast.EwmaReturnForecastStateIndicator;
@@ -134,10 +130,10 @@ LogReturnIndicator returns = new LogReturnIndicator(close);
 EwmaReturnForecastStateIndicator state =
         new EwmaReturnForecastStateIndicator(returns, stateConfig);
 
-ForecastDistributionIndicator<Num> returnForecast =
+ForecastDistributionIndicator returnForecast =
         new MonteCarloReturnForecastIndicator(returns, state, forecastConfig);
 
-ForecastDistributionIndicator<Num> priceForecast =
+ForecastDistributionIndicator priceForecast =
         new LogReturnToPriceForecastIndicator(close, returnForecast);
 ```
 
@@ -155,7 +151,7 @@ forecastPrice = priceAtDecisionIndex * exp(cumulativeLogReturn)
 
 | Setting | Default | Meaning | Common tuning |
 | --- | --- | --- | --- |
-| `initializationBarCount` | `30` | Number of valid return observations required before state is defined. | Increase for slower, steadier estimates; decrease for faster adaptation. |
+| `initializationBarCount` | `30` | Number of valid return observations required before state is stable. | Increase for slower, steadier estimates; decrease for faster adaptation. |
 | `decayFactor` | `0.94` | EWMA persistence in `(0, 1)`. Higher values react more slowly. | Use higher values for daily data and lower values for shorter bars only after validation. |
 | `driftMode` | `DriftMode.ZERO` | Drift used in simulated paths. | Prefer `ZERO` as a conservative default; use `ROLLING_MEAN` only when the rolling mean has validated predictive value. |
 
@@ -191,9 +187,9 @@ The state output is a `ReturnForecastState` with rolling `mean`, forecast `drift
 | `CONSTANT` | Uses the decision-index volatility for every simulated step in a path. | Simple, reproducible, and usually the first model to validate. |
 | `EWMA` | Updates path volatility after each simulated step using `volatilityDecayFactor`. | More dynamic, but adds another assumption that must be tested. |
 
-## Warm-Up and Undefined Values
+## Warm-Up and Unstable Values
 
-Forecast indicators deliberately return undefined distributions until enough valid data is available.
+Forecast indicators deliberately return unstable distributions until enough valid data is available.
 
 Important warm-up rules:
 
@@ -202,14 +198,14 @@ Important warm-up rules:
 - `MonteCarloReturnForecastIndicator` is unstable until both the state is stable and the configured return lookback is available.
 - With the default one-bar log return and default `lookbackBarCount(252)`, the standard Monte Carlo return forecast first becomes eligible at index `252` when all returns are valid.
 
-Undefined values can also occur after warm-up when:
+Unstable values can also occur after warm-up when:
 
 - A source price is zero, negative, `NaN`, or infinite.
 - A return in the required initialization window is invalid.
 - The historical lookback does not contain enough valid returns.
 - A price forecast cannot be converted because the decision-index price is invalid or non-positive.
 
-Always check `distribution.defined()` before reading summary values in reporting code. Point-forecast reducers return `NaN` for undefined distributions, which normal ta4j rules will treat as not satisfying comparisons.
+Always check `distribution.isStable()` before reading summary values in reporting code. Projection indicators return `NaN` for unstable distributions, which normal ta4j rules will treat as not satisfying comparisons.
 
 ## Avoiding Look-Ahead Bias
 
@@ -249,7 +245,7 @@ Use a low quantile to avoid entries when the downside tail is too close.
 
 ```java
 Indicator<Num> fifthPercentilePrice =
-        new ForwardForecastIndicator(priceForecast, ForecastReducers.quantile(0.05));
+        priceForecast.quantile(0.05);
 
 Rule downsideAboveStop = new OverIndicatorRule(fifthPercentilePrice, plannedStopPrice);
 ```
@@ -258,7 +254,7 @@ Rule downsideAboveStop = new OverIndicatorRule(fifthPercentilePrice, plannedStop
 
 ### Distribution Width Filter
 
-Use `ForecastReducers.standardDeviation()` when you want to avoid forecasts that are too uncertain, or require enough spread for a volatility strategy. The result is in the same unit as the distribution: log-return units for return forecasts and price units for price forecasts.
+Use `priceForecast.standardDeviation()` when you want to avoid forecasts that are too uncertain, or require enough spread for a volatility strategy. The result is in the same unit as the distribution: log-return units for return forecasts and price units for price forecasts.
 
 ## Choosing Return or Price Space
 
@@ -279,16 +275,16 @@ Use price forecasts when:
 
 The Monte Carlo indicator mixes the configured seed with the decision index and horizon. That means the same seed, index, horizon, inputs, and configuration produce the same distribution independent of call order. This is important for cached indicators, tests, and chart rendering.
 
-Do not rely on a seed to make an invalid forecast defined. Reproducibility only applies once the data and warm-up requirements are satisfied.
+Do not rely on a seed to make an invalid forecast stable. Reproducibility only applies once the data and warm-up requirements are satisfied.
 
 ## Common Problems
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| `distribution.defined()` is false early in the series. | Warm-up and lookback requirements are not met. | Start reading after `forecast.getCountOfUnstableBars()`. |
+| `distribution.isStable()` is false early in the series. | Warm-up and lookback requirements are not met. | Start reading after `forecast.getCountOfUnstableBars()`. |
 | A configured quantile throws when requested. | The probability was not included in `quantiles(...)`. | Add that exact probability to `MonteCarloForecastConfig`. |
-| Point forecast is `NaN`. | The source distribution is undefined or the reducer requested a missing quantile. | Check `defined()` on the distribution source and config. |
-| Price forecast is undefined while return forecast is defined. | Decision-index price is non-positive or invalid. | Check the source price indicator and data feed. |
+| Point forecast is `NaN`. | The source distribution is unstable or the projection requested a missing quantile. | Check `isStable()` on the distribution source and config. |
+| Price forecast is unstable while return forecast is stable. | Decision-index price is non-positive or invalid. | Check the source price indicator and data feed. |
 | Live forecasts disappear with a moving series. | The series evicted bars required by the lookback. | Increase `setMaximumBarCount` or reduce lookback after validation. |
 
 ## API Map
@@ -302,8 +298,7 @@ Do not rely on a seed to make an invalid forecast defined. Reproducibility only 
 | `MonteCarloForecastConfig` | `org.ta4j.core.indicators.forecast` | Monte Carlo horizon, iteration, seed, shock, volatility, and quantile settings. |
 | `MonteCarloReturnForecastIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return forecast distribution indicator. |
 | `ForecastDistribution` | `org.ta4j.core.indicators.forecast` | Immutable distribution summary record. |
-| `ForecastDistributionIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for distribution-valued forecasts. |
+| `ForecastDistributionIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for distribution-valued forecasts with point projection methods. |
 | `LogReturnToPriceForecastIndicator` | `org.ta4j.core.indicators.forecast` | Converts cumulative log-return distributions to price distributions. |
-| `ForwardForecastIndicator` | `org.ta4j.core.indicators.forecast` | Reduces a distribution to one `Num` point forecast. |
-| `ForecastReducers` | `org.ta4j.core.indicators.forecast` | Built-in reducers for mean, median, standard deviation, and quantiles. |
+| `ForwardForecastIndicator` | `org.ta4j.core.indicators.forecast` | Adapter used by point projection methods to expose one `Num` forecast. |
 | `ForecastIndicators` | `org.ta4j.core.indicators.forecast` | Convenience factories for standard forecast pipelines. |

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -25,36 +25,14 @@ This example builds an EWMA-volatility Monte Carlo pipeline and projects forecas
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.forecast.ForecastPredictionIndicator;
-import org.ta4j.core.indicators.forecast.ForecastStateIndicator;
 import org.ta4j.core.indicators.forecast.LogReturnToPriceForecastIndicator;
-import org.ta4j.core.indicators.forecast.MonteCarloReturnForecastIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
-import org.ta4j.core.indicators.helpers.LogReturnIndicator;
 import org.ta4j.core.num.Num;
 
 BarSeries series = ...;
 ClosePriceIndicator close = new ClosePriceIndicator(series);
-LogReturnIndicator returns = new LogReturnIndicator(close);
 
-ForecastStateIndicator state = ForecastStateIndicator.ofEwma(
-        returns,
-        30,
-        0.94,
-        ForecastStateIndicator.DriftMode.ZERO);
-
-ForecastPredictionIndicator returnForecast =
-        MonteCarloReturnForecastIndicator.builder(returns, state)
-                .horizon(5)
-                .iterationCount(2_000)
-                .lookbackBarCount(252)
-                .seed(42L)
-                .shockModel(MonteCarloReturnForecastIndicator.ShockModel.STANDARDIZED_EMPIRICAL)
-                .volatilityUpdateMode(MonteCarloReturnForecastIndicator.VolatilityUpdateMode.CONSTANT)
-                .quantiles(0.05, 0.5, 0.95)
-                .build();
-
-ForecastPredictionIndicator priceForecast =
-        new LogReturnToPriceForecastIndicator(close, returnForecast);
+ForecastPredictionIndicator priceForecast = new LogReturnToPriceForecastIndicator(close, 5);
 
 Indicator<Num> downsideForecast = priceForecast.quantile(0.05);
 Indicator<Num> medianForecast = priceForecast.median();
@@ -67,6 +45,8 @@ Num upside = upsideForecast.getValue(index);
 ```
 
 Use `ForecastPredictionIndicator` projection methods for strategy rules, chart overlays, and other ta4j data flows. Each projection shifts the index lookup onto a normal `Indicator<Num>` and returns `NaN` while the source forecast is unstable.
+
+The short constructor path creates log returns internally, then uses EWMA return state with a 30-bar initialization window, `0.94` decay, zero drift, standardized empirical shocks, 1,000 simulations, a 252-return lookback, and default quantiles of `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`.
 
 The raw `PredictionSnapshot.Forecast<Num>` summary remains useful for diagnostics and metadata. At each index, it contains:
 
@@ -104,14 +84,16 @@ Projection indicators return `NaN` when the source forecast is unstable or when 
 ```mermaid
 graph TD
     CP["ClosePriceIndicator or another price Indicator<Num>"] --> LR["LogReturnIndicator"]
-    LR --> STATE["ForecastStateIndicator.ofEwma(...)"]
-    LR --> MC["MonteCarloReturnForecastIndicator.builder(...).build()"]
-    STATE --> MC
+    LR --> MC["new MonteCarloReturnForecastIndicator(returns, horizon)"]
+    MC -. "default EWMA state" .-> STATE["new ForecastStateIndicator(...)"]
     MC --> PRICE["LogReturnToPriceForecastIndicator"]
+    CP --> PRICE_SHORT["new LogReturnToPriceForecastIndicator(close, horizon)"]
+    PRICE_SHORT -. "default return forecast" .-> MC
     PRICE --> PROJECT["median(), quantile(), mean(), standardDeviation()"]
+    PRICE_SHORT --> PROJECT
 ```
 
-Use this explicit pipeline when you need direct access to return forecasts, a custom price source, custom point projections, or intermediate state diagnostics. The API intentionally avoids a god factory so each stage remains reusable and testable.
+Use this pipeline when you need direct access to return forecasts, a custom price source, custom point projections, or intermediate state diagnostics. The API intentionally avoids a god factory so each stage remains reusable and testable while the common constructor keeps setup small.
 
 `MonteCarloReturnForecastIndicator` produces a cumulative log-return forecast over the configured horizon. `LogReturnToPriceForecastIndicator` converts it to a price forecast with:
 
@@ -123,7 +105,7 @@ forecastPrice = priceAtDecisionIndex * exp(cumulativeLogReturn)
 
 ### EWMA State
 
-`ForecastStateIndicator.ofEwma(...)` estimates rolling return state from a log-return source.
+`new ForecastStateIndicator(...)` estimates rolling return state from a log-return source. You only need to create it yourself when you want to override the default state used by `new MonteCarloReturnForecastIndicator(returns, horizon)`.
 
 | Parameter | Default in examples | Meaning | Common tuning |
 | --- | --- | --- | --- |
@@ -135,11 +117,12 @@ The state output is a `ReturnForecastState` with rolling `mean`, forecast `drift
 
 ### Monte Carlo Forecast
 
-`MonteCarloReturnForecastIndicator.builder(...)` controls horizon, samples, shock model, and returned quantiles.
+`new MonteCarloReturnForecastIndicator(returns, horizon)` is the standard constructor for default EWMA Monte Carlo forecasts. Use the builder only when you need to tune the simulation settings beyond horizon and EWMA state.
 
-| Builder method | Default | Meaning | Common tuning |
+| Constructor or builder method | Default | Meaning | Common tuning |
 | --- | --- | --- | --- |
-| `horizon(...)` | `1` | Number of bars ahead to forecast. | Match the holding period or evaluation label. |
+| `new MonteCarloReturnForecastIndicator(returns)` | `1` bar | Default one-bar forecast. | Use for next-bar forecasts. |
+| `new MonteCarloReturnForecastIndicator(returns, horizon)` | caller supplied | Number of bars ahead to forecast. | Match the holding period or evaluation label. |
 | `iterationCount(...)` | `1_000` | Number of simulated paths. | Increase for smoother quantiles; reduce only for latency-sensitive live loops after measuring. |
 | `lookbackBarCount(...)` | `252` | Number of historical returns used for empirical shocks. | Match the market regime window you want represented. |
 | `seed(...)` | `42L` | Base random seed. | Keep fixed for reproducible research and tests. |
@@ -171,7 +154,7 @@ Important warm-up rules:
 
 - `LogReturnIndicator` is unstable for `source.getCountOfUnstableBars() + barCount` bars.
 - `EWMAIndicator` is unstable for `source.getCountOfUnstableBars() + barCount - 1` bars.
-- `ForecastStateIndicator.ofEwma(...)` is unstable until its EWMA mean and variance sources are stable.
+- `ForecastStateIndicator` is unstable until its EWMA mean and variance sources are stable.
 - `MonteCarloReturnForecastIndicator` is unstable until both the state is stable and the configured return lookback is available.
 - With the default one-bar log return and default `lookbackBarCount(252)`, the standard Monte Carlo return forecast first becomes eligible at index `252` when all returns are valid.
 
@@ -258,7 +241,7 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | Projection values are `NaN` early in the series. | Warm-up and lookback requirements are not met. | Start reading after `forecast.getCountOfUnstableBars()`. |
-| Quantile projection is `NaN` at a stable index. | The probability was not included in `quantiles(...)`. | Add that exact probability to `MonteCarloReturnForecastIndicator.builder(...).quantiles(...)`. |
+| Quantile projection is `NaN` at a stable index. | The probability was not included in `quantiles(...)`. | The default constructor includes `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`; for other probabilities add that exact value with `MonteCarloReturnForecastIndicator.builder(...).quantiles(...)`. |
 | Point forecast is `NaN`. | The source forecast is unstable, the projection requested a missing quantile, or source data is invalid. | Check warm-up, configured quantiles, and source price/return validity. |
 | Price forecast is unstable while return forecast is stable. | Decision-index price is non-positive or invalid. | Check the source price indicator and data feed. |
 | Live forecasts disappear with a moving series. | The series evicted bars required by the lookback. | Increase `setMaximumBarCount` or reduce lookback after validation. |
@@ -269,10 +252,10 @@ Do not rely on a seed to make an invalid forecast stable. Reproducibility only a
 | --- | --- | --- |
 | `LogReturnIndicator` | `org.ta4j.core.indicators.helpers` | Normal numeric helper indicator for `log(x[i] / x[i - n])`. |
 | `EWMAIndicator` | `org.ta4j.core.indicators.averages` | Reusable EWMA indicator with explicit decay and SMA initialization. |
-| `ForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Converts mean and variance indicators into `ReturnForecastState`, with `ofEwma(...)` for the standard state pipeline. |
+| `ForecastStateIndicator` | `org.ta4j.core.indicators.forecast` | Converts EWMA or explicit mean and variance indicators into `ReturnForecastState`. |
 | `ForecastStateIndicator.DriftMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting zero drift or rolling-mean drift. |
 | `ReturnForecastState` | `org.ta4j.core.indicators.forecast` | State record consumed by return forecast indicators. |
-| `MonteCarloReturnForecastIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return forecast indicator with builder-owned configuration. |
+| `MonteCarloReturnForecastIndicator` | `org.ta4j.core.indicators.forecast` | Cumulative log-return forecast indicator with constructor defaults and a builder for advanced configuration. |
 | `MonteCarloReturnForecastIndicator.ShockModel` | `org.ta4j.core.indicators.forecast` | Nested enum selecting historical bootstrap, standardized empirical, or normal shocks. |
 | `MonteCarloReturnForecastIndicator.VolatilityUpdateMode` | `org.ta4j.core.indicators.forecast` | Nested enum selecting constant or EWMA path volatility. |
 | `ForecastPredictionIndicator` | `org.ta4j.core.indicators.forecast` | Indicator interface for forecast summaries with point projection methods. |

--- a/Home.md
+++ b/Home.md
@@ -42,7 +42,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Data Sources](Data-Sources.md)** - Loading bars or trades from files and HTTP providers
 - **[Num](Num.md)** - Precision-aware numeric types such as `DoubleNum` and `DecimalNum`
 - **[Technical Indicators](Technical-indicators.md)** - Indicator composition and caching
-- **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, reducers, and strategy filters
+- **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, point projections, and strategy filters
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts
 

--- a/Home.md
+++ b/Home.md
@@ -42,6 +42,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Data Sources](Data-Sources.md)** - Loading bars or trades from files and HTTP providers
 - **[Num](Num.md)** - Precision-aware numeric types such as `DoubleNum` and `DecimalNum`
 - **[Technical Indicators](Technical-indicators.md)** - Indicator composition and caching
+- **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, reducers, and strategy filters
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts
 

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -539,7 +539,8 @@ Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They pr
 | `org.ta4j.core.indicators.forecast` | **ReturnForecastStateIndicator** | Indicator interface for hidden state derived from a `ReturnIndicator`. |
 | `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateIndicator** | Builds return forecast state from a log-return `ReturnIndicator` using EWMA mean and variance. |
 | `org.ta4j.core.indicators.forecast` | **ReturnForecastState** | Record containing return-state index, observation count, stable flag, mean, drift, variance, and volatility. |
-| `org.ta4j.core.indicators.forecast` | **ReturnForecastProjectionIndicator** | Interface for return projections that declare their return representation and can convert to price forecasts. |
+| `org.ta4j.core.indicators.forecast` | **ReturnForecastProjectionIndicator** | Interface for return projections that declare their return representation. |
+| `org.ta4j.core.indicators.forecast` | **MonteCarloPriceForecastIndicator** | Constructor-first Monte Carlo price forecast indicator that infers the price source from `LogReturnIndicator`. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloReturnProjectionIndicator** | Monte Carlo cumulative log-return projection indicator with standard constructors and a builder for advanced configuration. |
 | `org.ta4j.core.indicators.forecast` | **LogReturnToPriceForecastIndicator** | Reducer that converts an explicit cumulative log-return projection to price forecasts. |
 | `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast projection indicator into a point forecast indicator. |
@@ -547,7 +548,7 @@ Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They pr
 
 **Short usage**
 - **What it is:** A forecasting layer that estimates future return or price distributions from historical returns and rolling volatility state.
-- **Theory:** The standard pipeline converts prices to log returns, estimates EWMA return state, simulates horizon returns with Monte Carlo shocks, and optionally converts cumulative log returns back to prices.
+- **Theory:** The standard pipeline converts prices to log returns, estimates EWMA return state, and projects horizon prices with Monte Carlo shocks; explicit return projections remain available for advanced tuning.
 - **When to use:** Probabilistic research labels, forecast-aware filters, risk bounds, tail checks, and point projections exposed as regular ta4j indicators.
 - **When not to use:** As a guaranteed target, without warm-up checks, or as a replacement for realistic execution and out-of-sample validation.
 - See also: [Forecast Indicators](Forecast-Indicators.md).

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -534,7 +534,7 @@ Forecast types live under `org.ta4j.core.indicators.forecast`. The root package 
 | `org.ta4j.core.indicators.helpers` | **LogReturnIndicator** | Numeric helper indicator for `log(x[i] / x[i - barCount])`, often used as the input to return forecasts. |
 | `org.ta4j.core.indicators` | **ReturnIndicator** | Semantic contract for indicators that declare their return representation. |
 | `org.ta4j.core.indicators.averages` | **EWMAIndicator** | Reusable exponentially weighted moving average indicator with explicit decay and SMA initialization. |
-| `org.ta4j.core.indicators.forecast.projection` | **ForecastProjectionIndicator** | `Indicator<PredictionSnapshot.Forecast<Num>>` interface with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
+| `org.ta4j.core.indicators.forecast.projection` | **ForecastProjectionIndicator** | `Indicator<Forecast<Num>>` interface with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
 | `org.ta4j.core.indicators.forecast.state` | **ForecastStateIndicator** | Indicator interface for hidden state used by forecast projections. |
 | `org.ta4j.core.indicators.forecast.state` | **ReturnForecastStateIndicator** | Indicator interface for hidden state derived from a `ReturnIndicator`. |
 | `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateIndicator** | Builds return forecast state from a log-return `ReturnIndicator` using EWMA mean and variance. |
@@ -544,7 +544,7 @@ Forecast types live under `org.ta4j.core.indicators.forecast`. The root package 
 | `org.ta4j.core.indicators.forecast` | **MonteCarloReturnProjectionIndicator** | Monte Carlo cumulative log-return projection indicator with standard constructors and a builder for advanced configuration. |
 | `org.ta4j.core.indicators.forecast.adapters` | **LogReturnToPriceForecastIndicator** | Adapter that converts an explicit cumulative log-return projection to price forecasts. |
 | `org.ta4j.core.indicators.forecast.projection` | **ForwardForecastIndicator** | Adapts a forecast projection indicator into a point forecast indicator. |
-| `org.ta4j.core.walkforward` | **PredictionSnapshot.Forecast** | Walk-forward prediction summary type used by forecast indicators, with mean, median, standard deviation, quantiles, sample count, horizon, and stable state. |
+| `org.ta4j.core.indicators.forecast.projection` | **Forecast** | Forecast summary value model used by projection indicators, with mean, median, standard deviation, quantiles, sample count, horizon, and stable state. |
 
 **Short usage**
 - **What it is:** A forecasting layer that estimates future return or price distributions from historical returns and rolling volatility state.

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -22,7 +22,8 @@ For an overview of indicator categories and composition patterns, see [Technical
 12. [Renko](#12-renko)
 13. [Analysis (PnL, returns, cash flow)](#13-analysis-pnl-returns-cash-flow)
 14. [Charting (ta4j-examples)](#14-charting-ta4j-examples)
-15. [Supporting public types (facades, enums, records)](#15-supporting-public-types-facades-enums-records)
+15. [Forecasting](#15-forecasting)
+16. [Supporting public types (facades, enums, records)](#16-supporting-public-types-facades-enums-records)
 
 ---
 
@@ -69,6 +70,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.helpers` | **NumIndicator** | Wraps a Num value as an indicator. |
 | `org.ta4j.core.indicators.helpers` | **TradeCountIndicator** | Number of trades in the bar (when available). |
 | `org.ta4j.core.indicators.helpers` | **UnstableIndicator** | Returns NaN for indices within the unstable period; used for warm-up. |
+| `org.ta4j.core.indicators.helpers` | **LogReturnIndicator** | Log return of a numeric source: `log(x[i] / x[i - barCount])`; returns NaN for warm-up, invalid, or non-positive inputs. |
 
 **Short usage (per-indicator expansion)**  
 - **What it is:** As in the table (e.g. close price, true range, running sum).  
@@ -523,7 +525,39 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 ---
 
-## 15. Supporting public types (facades, enums, records)
+## 15. Forecasting
+
+Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They produce distribution-valued forecasts at a decision index using only data available at or before that index. For tutorial guidance, see [Forecast Indicators](Forecast-Indicators.md).
+
+| FQN | Class | Description (from codebase) |
+|-----|-------|-----------------------------|
+| `org.ta4j.core.indicators.helpers` | **LogReturnIndicator** | Numeric helper indicator for `log(x[i] / x[i - barCount])`, often used as the input to return forecasts. |
+| `org.ta4j.core.indicators.forecast` | **ForecastDistributionIndicator** | `Indicator<ForecastDistribution<T>>` marker interface for distribution-valued forecast indicators. |
+| `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateIndicator** | Recursive EWMA estimator for return mean, drift, variance, and volatility state. |
+| `org.ta4j.core.indicators.forecast` | **MonteCarloReturnForecastIndicator** | Monte Carlo cumulative log-return forecast distribution indicator. |
+| `org.ta4j.core.indicators.forecast` | **LogReturnToPriceForecastIndicator** | Converts cumulative log-return forecast distributions to price forecast distributions. |
+| `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast distribution indicator into a point forecast indicator with a reducer. |
+| `org.ta4j.core.indicators.forecast` | **ForecastIndicators** | Convenience factories for standard forecast pipelines such as EWMA-volatility close-price forecasts. |
+| `org.ta4j.core.indicators.forecast` | **ForecastDistribution** | Immutable distribution summary with mean, median, standard deviation, quantiles, sample count, horizon, and defined state. |
+| `org.ta4j.core.indicators.forecast` | **ForecastReducer** | Functional interface that reduces a numeric forecast distribution to one `Num` value. |
+| `org.ta4j.core.indicators.forecast` | **ForecastReducers** | Built-in reducers for mean, median, standard deviation, and configured quantiles. |
+| `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateConfig** | Builder-backed EWMA state configuration with initialization count, decay factor, and drift mode. |
+| `org.ta4j.core.indicators.forecast` | **ReturnForecastState** | Record containing return-state index, observation count, defined flag, mean, drift, variance, and volatility. |
+| `org.ta4j.core.indicators.forecast` | **MonteCarloForecastConfig** | Builder-backed Monte Carlo configuration for horizon, iterations, lookback, seed, shock model, volatility mode, and quantiles. |
+| `org.ta4j.core.indicators.forecast` | **DriftMode** | Enum selecting zero drift or rolling-mean drift for return forecasts. |
+| `org.ta4j.core.indicators.forecast` | **ShockModel** | Enum selecting historical bootstrap, standardized empirical, or normal shocks. |
+| `org.ta4j.core.indicators.forecast` | **VolatilityUpdateMode** | Enum selecting constant or EWMA-updated volatility inside simulated paths. |
+
+**Short usage**
+- **What it is:** A forecasting layer that estimates future return or price distributions from historical returns and rolling volatility state.
+- **Theory:** The standard pipeline converts prices to log returns, estimates EWMA return state, simulates horizon returns with Monte Carlo shocks, and optionally converts cumulative log returns back to prices.
+- **When to use:** Probabilistic research labels, forecast-aware filters, risk bounds, tail checks, and point forecasts reduced to regular ta4j indicators.
+- **When not to use:** As a guaranteed target, without warm-up checks, or as a replacement for realistic execution and out-of-sample validation.
+- See also: [Forecast Indicators](Forecast-Indicators.md).
+
+---
+
+## 16. Supporting public types (facades, enums, records)
 
 These types live in `org.ta4j.core.indicators` and its subpackages and are part of the public indicator API surface, even though they are not all `*Indicator` classes.
 
@@ -595,7 +629,7 @@ These types live in `org.ta4j.core.indicators` and its subpackages and are part 
 
 ## Summary
 
-- **ta4j-core** currently provides indicator classes across helpers, averages, volatility, momentum, trend, volume, candles, pivots, swing, Elliott, statistics, renko, and analysis.
+- **ta4j-core** currently provides indicator classes across helpers, averages, volatility, momentum, trend, volume, candles, pivots, swing, Elliott, statistics, renko, analysis, and forecasting.
 - The inventory also tracks supporting public types (facades, enums, records, interfaces) in indicator packages that are required for complete API coverage.
 - **ta4j-examples** adds charting-oriented indicators (labels, channel boundary).  
 - All entries above use the **fully qualified name** and **class name** and a **short description as in the ta4j codebase**.  

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -534,10 +534,10 @@ Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They pr
 | `org.ta4j.core.indicators.helpers` | **LogReturnIndicator** | Numeric helper indicator for `log(x[i] / x[i - barCount])`, often used as the input to return forecasts. |
 | `org.ta4j.core.indicators.averages` | **EWMAIndicator** | Reusable exponentially weighted moving average indicator with explicit decay and SMA initialization. |
 | `org.ta4j.core.indicators.forecast` | **ForecastPredictionIndicator** | `Indicator<PredictionSnapshot.Forecast<Num>>` interface with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
-| `org.ta4j.core.indicators.forecast` | **ForecastStateIndicator** | Builds return forecast state from mean and variance indicators, with `ofEwma(...)` for the standard EWMA state pipeline. |
+| `org.ta4j.core.indicators.forecast` | **ForecastStateIndicator** | Builds return forecast state from EWMA defaults or explicit mean and variance indicators. |
 | `org.ta4j.core.indicators.forecast` | **ReturnForecastState** | Record containing return-state index, observation count, stable flag, mean, drift, variance, and volatility. |
-| `org.ta4j.core.indicators.forecast` | **MonteCarloReturnForecastIndicator** | Monte Carlo cumulative log-return forecast indicator with builder-owned configuration. |
-| `org.ta4j.core.indicators.forecast` | **LogReturnToPriceForecastIndicator** | Converts cumulative log-return forecasts to price forecasts. |
+| `org.ta4j.core.indicators.forecast` | **MonteCarloReturnForecastIndicator** | Monte Carlo cumulative log-return forecast indicator with constructor defaults and a builder for advanced configuration. |
+| `org.ta4j.core.indicators.forecast` | **LogReturnToPriceForecastIndicator** | Converts cumulative log-return forecasts to price forecasts, with constructor defaults for close-price forecasts. |
 | `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast prediction indicator into a point forecast indicator. |
 | `org.ta4j.core.walkforward` | **PredictionSnapshot.Forecast** | Walk-forward prediction summary type used by forecast indicators, with mean, median, standard deviation, quantiles, sample count, horizon, and stable state. |
 

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -70,7 +70,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.helpers` | **NumIndicator** | Wraps a Num value as an indicator. |
 | `org.ta4j.core.indicators.helpers` | **TradeCountIndicator** | Number of trades in the bar (when available). |
 | `org.ta4j.core.indicators.helpers` | **UnstableIndicator** | Returns NaN for indices within the unstable period; used for warm-up. |
-| `org.ta4j.core.indicators.helpers` | **LogReturnIndicator** | Log return of a numeric source: `log(x[i] / x[i - barCount])`; returns NaN for warm-up, invalid, or non-positive inputs. |
+| `org.ta4j.core.indicators.helpers` | **LogReturnIndicator** | CF-289 branch-only until ta4j 0.22.9: log return of a numeric source, `log(x[i] / x[i - barCount])`; returns NaN for warm-up, invalid, or non-positive inputs. |
 
 **Short usage (per-indicator expansion)**  
 - **What it is:** As in the table (e.g. close price, true range, running sum).  

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -527,23 +527,23 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 ## 15. Forecasting
 
-Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They produce forecast summaries at a decision index using only data available at or before that index. These entries are introduced by the matching CF-289 ta4j feature branch and should be treated as branch-only until the ta4j 0.22.9 release includes them. For tutorial guidance, see [Forecast Indicators](Forecast-Indicators.md).
+Forecast types live under `org.ta4j.core.indicators.forecast`. The root package holds the primary indicators, while `forecast.state`, `forecast.projection`, and `forecast.adapters` group state contracts, projection contracts, and conversion bridges. They produce forecast summaries at a decision index using only data available at or before that index. These entries are introduced by the matching CF-289 ta4j feature branch and should be treated as branch-only until the ta4j 0.22.9 release includes them. For tutorial guidance, see [Forecast Indicators](Forecast-Indicators.md).
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.helpers` | **LogReturnIndicator** | Numeric helper indicator for `log(x[i] / x[i - barCount])`, often used as the input to return forecasts. |
 | `org.ta4j.core.indicators` | **ReturnIndicator** | Semantic contract for indicators that declare their return representation. |
 | `org.ta4j.core.indicators.averages` | **EWMAIndicator** | Reusable exponentially weighted moving average indicator with explicit decay and SMA initialization. |
-| `org.ta4j.core.indicators.forecast` | **ForecastProjectionIndicator** | `Indicator<PredictionSnapshot.Forecast<Num>>` interface with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
-| `org.ta4j.core.indicators.forecast` | **ForecastStateIndicator** | Indicator interface for hidden state used by forecast projections. |
-| `org.ta4j.core.indicators.forecast` | **ReturnForecastStateIndicator** | Indicator interface for hidden state derived from a `ReturnIndicator`. |
+| `org.ta4j.core.indicators.forecast.projection` | **ForecastProjectionIndicator** | `Indicator<PredictionSnapshot.Forecast<Num>>` interface with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
+| `org.ta4j.core.indicators.forecast.state` | **ForecastStateIndicator** | Indicator interface for hidden state used by forecast projections. |
+| `org.ta4j.core.indicators.forecast.state` | **ReturnForecastStateIndicator** | Indicator interface for hidden state derived from a `ReturnIndicator`. |
 | `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateIndicator** | Builds return forecast state from a log-return `ReturnIndicator` using EWMA mean and variance. |
-| `org.ta4j.core.indicators.forecast` | **ReturnForecastState** | Record containing return-state index, observation count, stable flag, mean, drift, variance, and volatility. |
-| `org.ta4j.core.indicators.forecast` | **ReturnForecastProjectionIndicator** | Interface for return projections that declare their return representation. |
+| `org.ta4j.core.indicators.forecast.state` | **ReturnForecastState** | Record containing return-state index, observation count, stable flag, mean, drift, variance, and volatility. |
+| `org.ta4j.core.indicators.forecast.projection` | **ReturnForecastProjectionIndicator** | Interface for return projections that declare their return representation. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloPriceForecastIndicator** | Constructor-first Monte Carlo price forecast indicator that infers the price source from `LogReturnIndicator`. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloReturnProjectionIndicator** | Monte Carlo cumulative log-return projection indicator with standard constructors and a builder for advanced configuration. |
-| `org.ta4j.core.indicators.forecast` | **LogReturnToPriceForecastIndicator** | Reducer that converts an explicit cumulative log-return projection to price forecasts. |
-| `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast projection indicator into a point forecast indicator. |
+| `org.ta4j.core.indicators.forecast.adapters` | **LogReturnToPriceForecastIndicator** | Adapter that converts an explicit cumulative log-return projection to price forecasts. |
+| `org.ta4j.core.indicators.forecast.projection` | **ForwardForecastIndicator** | Adapts a forecast projection indicator into a point forecast indicator. |
 | `org.ta4j.core.walkforward` | **PredictionSnapshot.Forecast** | Walk-forward prediction summary type used by forecast indicators, with mean, median, standard deviation, quantiles, sample count, horizon, and stable state. |
 
 **Short usage**

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -532,17 +532,15 @@ Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They pr
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.helpers` | **LogReturnIndicator** | Numeric helper indicator for `log(x[i] / x[i - barCount])`, often used as the input to return forecasts. |
-| `org.ta4j.core.indicators.forecast` | **ForecastDistributionIndicator** | `Indicator<ForecastDistribution<T>>` marker interface for distribution-valued forecast indicators. |
+| `org.ta4j.core.indicators.forecast` | **ForecastDistributionIndicator** | `Indicator<ForecastDistribution<Num>>` interface for distribution-valued forecast indicators, with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
 | `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateIndicator** | Recursive EWMA estimator for return mean, drift, variance, and volatility state. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloReturnForecastIndicator** | Monte Carlo cumulative log-return forecast distribution indicator. |
 | `org.ta4j.core.indicators.forecast` | **LogReturnToPriceForecastIndicator** | Converts cumulative log-return forecast distributions to price forecast distributions. |
-| `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast distribution indicator into a point forecast indicator with a reducer. |
+| `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast distribution indicator into a point forecast indicator. |
 | `org.ta4j.core.indicators.forecast` | **ForecastIndicators** | Convenience factories for standard forecast pipelines such as EWMA-volatility close-price forecasts. |
-| `org.ta4j.core.indicators.forecast` | **ForecastDistribution** | Immutable distribution summary with mean, median, standard deviation, quantiles, sample count, horizon, and defined state. |
-| `org.ta4j.core.indicators.forecast` | **ForecastReducer** | Functional interface that reduces a numeric forecast distribution to one `Num` value. |
-| `org.ta4j.core.indicators.forecast` | **ForecastReducers** | Built-in reducers for mean, median, standard deviation, and configured quantiles. |
+| `org.ta4j.core.indicators.forecast` | **ForecastDistribution** | Immutable distribution summary with mean, median, standard deviation, quantiles, sample count, horizon, and stable state. |
 | `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateConfig** | Builder-backed EWMA state configuration with initialization count, decay factor, and drift mode. |
-| `org.ta4j.core.indicators.forecast` | **ReturnForecastState** | Record containing return-state index, observation count, defined flag, mean, drift, variance, and volatility. |
+| `org.ta4j.core.indicators.forecast` | **ReturnForecastState** | Record containing return-state index, observation count, stable flag, mean, drift, variance, and volatility. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloForecastConfig** | Builder-backed Monte Carlo configuration for horizon, iterations, lookback, seed, shock model, volatility mode, and quantiles. |
 | `org.ta4j.core.indicators.forecast` | **DriftMode** | Enum selecting zero drift or rolling-mean drift for return forecasts. |
 | `org.ta4j.core.indicators.forecast` | **ShockModel** | Enum selecting historical bootstrap, standardized empirical, or normal shocks. |
@@ -551,7 +549,7 @@ Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They pr
 **Short usage**
 - **What it is:** A forecasting layer that estimates future return or price distributions from historical returns and rolling volatility state.
 - **Theory:** The standard pipeline converts prices to log returns, estimates EWMA return state, simulates horizon returns with Monte Carlo shocks, and optionally converts cumulative log returns back to prices.
-- **When to use:** Probabilistic research labels, forecast-aware filters, risk bounds, tail checks, and point forecasts reduced to regular ta4j indicators.
+- **When to use:** Probabilistic research labels, forecast-aware filters, risk bounds, tail checks, and point projections exposed as regular ta4j indicators.
 - **When not to use:** As a guaranteed target, without warm-up checks, or as a replacement for realistic execution and out-of-sample validation.
 - See also: [Forecast Indicators](Forecast-Indicators.md).
 

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -527,24 +527,19 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 ## 15. Forecasting
 
-Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They produce distribution-valued forecasts at a decision index using only data available at or before that index. For tutorial guidance, see [Forecast Indicators](Forecast-Indicators.md).
+Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They produce forecast summaries at a decision index using only data available at or before that index. For tutorial guidance, see [Forecast Indicators](Forecast-Indicators.md).
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.helpers` | **LogReturnIndicator** | Numeric helper indicator for `log(x[i] / x[i - barCount])`, often used as the input to return forecasts. |
-| `org.ta4j.core.indicators.forecast` | **ForecastDistributionIndicator** | `Indicator<ForecastDistribution<Num>>` interface for distribution-valued forecast indicators, with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
-| `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateIndicator** | Recursive EWMA estimator for return mean, drift, variance, and volatility state. |
-| `org.ta4j.core.indicators.forecast` | **MonteCarloReturnForecastIndicator** | Monte Carlo cumulative log-return forecast distribution indicator. |
-| `org.ta4j.core.indicators.forecast` | **LogReturnToPriceForecastIndicator** | Converts cumulative log-return forecast distributions to price forecast distributions. |
-| `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast distribution indicator into a point forecast indicator. |
-| `org.ta4j.core.indicators.forecast` | **ForecastIndicators** | Convenience factories for standard forecast pipelines such as EWMA-volatility close-price forecasts. |
-| `org.ta4j.core.indicators.forecast` | **ForecastDistribution** | Immutable distribution summary with mean, median, standard deviation, quantiles, sample count, horizon, and stable state. |
-| `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateConfig** | Builder-backed EWMA state configuration with initialization count, decay factor, and drift mode. |
+| `org.ta4j.core.indicators.averages` | **EWMAIndicator** | Reusable exponentially weighted moving average indicator with explicit decay and SMA initialization. |
+| `org.ta4j.core.indicators.forecast` | **ForecastPredictionIndicator** | `Indicator<PredictionSnapshot.Forecast<Num>>` interface with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
+| `org.ta4j.core.indicators.forecast` | **ForecastStateIndicator** | Builds return forecast state from mean and variance indicators, with `ofEwma(...)` for the standard EWMA state pipeline. |
 | `org.ta4j.core.indicators.forecast` | **ReturnForecastState** | Record containing return-state index, observation count, stable flag, mean, drift, variance, and volatility. |
-| `org.ta4j.core.indicators.forecast` | **MonteCarloForecastConfig** | Builder-backed Monte Carlo configuration for horizon, iterations, lookback, seed, shock model, volatility mode, and quantiles. |
-| `org.ta4j.core.indicators.forecast` | **DriftMode** | Enum selecting zero drift or rolling-mean drift for return forecasts. |
-| `org.ta4j.core.indicators.forecast` | **ShockModel** | Enum selecting historical bootstrap, standardized empirical, or normal shocks. |
-| `org.ta4j.core.indicators.forecast` | **VolatilityUpdateMode** | Enum selecting constant or EWMA-updated volatility inside simulated paths. |
+| `org.ta4j.core.indicators.forecast` | **MonteCarloReturnForecastIndicator** | Monte Carlo cumulative log-return forecast indicator with builder-owned configuration. |
+| `org.ta4j.core.indicators.forecast` | **LogReturnToPriceForecastIndicator** | Converts cumulative log-return forecasts to price forecasts. |
+| `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast prediction indicator into a point forecast indicator. |
+| `org.ta4j.core.walkforward` | **PredictionSnapshot.Forecast** | Walk-forward prediction summary type used by forecast indicators, with mean, median, standard deviation, quantiles, sample count, horizon, and stable state. |
 
 **Short usage**
 - **What it is:** A forecasting layer that estimates future return or price distributions from historical returns and rolling volatility state.

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -527,7 +527,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 ## 15. Forecasting
 
-Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They produce forecast summaries at a decision index using only data available at or before that index. For tutorial guidance, see [Forecast Indicators](Forecast-Indicators.md).
+Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They produce forecast summaries at a decision index using only data available at or before that index. These entries are introduced by the matching CF-289 ta4j feature branch and should be treated as branch-only until the ta4j 0.22.9 release includes them. For tutorial guidance, see [Forecast Indicators](Forecast-Indicators.md).
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
@@ -626,7 +626,7 @@ These types live in `org.ta4j.core.indicators` and its subpackages and are part 
 
 ## Summary
 
-- **ta4j-core** currently provides indicator classes across helpers, averages, volatility, momentum, trend, volume, candles, pivots, swing, Elliott, statistics, renko, analysis, and forecasting.
+- **ta4j-core** currently provides indicator classes across helpers, averages, volatility, momentum, trend, volume, candles, pivots, swing, Elliott, statistics, renko, and analysis. Forecasting entries above are CF-289 branch-only until the matching ta4j release includes them.
 - The inventory also tracks supporting public types (facades, enums, records, interfaces) in indicator packages that are required for complete API coverage.
 - **ta4j-examples** adds charting-oriented indicators (labels, channel boundary).  
 - All entries above use the **fully qualified name** and **class name** and a **short description as in the ta4j codebase**.  

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -532,13 +532,17 @@ Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They pr
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.helpers` | **LogReturnIndicator** | Numeric helper indicator for `log(x[i] / x[i - barCount])`, often used as the input to return forecasts. |
+| `org.ta4j.core.indicators` | **ReturnIndicator** | Semantic contract for indicators that declare their return representation. |
 | `org.ta4j.core.indicators.averages` | **EWMAIndicator** | Reusable exponentially weighted moving average indicator with explicit decay and SMA initialization. |
-| `org.ta4j.core.indicators.forecast` | **ForecastPredictionIndicator** | `Indicator<PredictionSnapshot.Forecast<Num>>` interface with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
-| `org.ta4j.core.indicators.forecast` | **ForecastStateIndicator** | Builds return forecast state from EWMA defaults or explicit mean and variance indicators. |
+| `org.ta4j.core.indicators.forecast` | **ForecastProjectionProvider** | `Indicator<PredictionSnapshot.Forecast<Num>>` interface with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
+| `org.ta4j.core.indicators.forecast` | **ForecastStateProvider** | Interface for hidden-state providers used by forecast projections. |
+| `org.ta4j.core.indicators.forecast` | **ReturnForecastStateProvider** | Interface for hidden-state providers derived from a `ReturnIndicator`. |
+| `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateIndicator** | Builds return forecast state from a log-return `ReturnIndicator` using EWMA mean and variance. |
 | `org.ta4j.core.indicators.forecast` | **ReturnForecastState** | Record containing return-state index, observation count, stable flag, mean, drift, variance, and volatility. |
-| `org.ta4j.core.indicators.forecast` | **MonteCarloReturnForecastIndicator** | Monte Carlo cumulative log-return forecast indicator with constructor defaults and a builder for advanced configuration. |
-| `org.ta4j.core.indicators.forecast` | **LogReturnToPriceForecastIndicator** | Converts cumulative log-return forecasts to price forecasts, with constructor defaults for close-price forecasts. |
-| `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast prediction indicator into a point forecast indicator. |
+| `org.ta4j.core.indicators.forecast` | **ReturnForecastProjectionProvider** | Interface for return projections that declare their return representation and can convert to price forecasts. |
+| `org.ta4j.core.indicators.forecast` | **MonteCarloReturnProjectionIndicator** | Monte Carlo cumulative log-return projection provider with standard constructors and a builder for advanced configuration. |
+| `org.ta4j.core.indicators.forecast` | **LogReturnToPriceForecastIndicator** | Reducer that converts an explicit cumulative log-return projection to price forecasts. |
+| `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast projection provider into a point forecast indicator. |
 | `org.ta4j.core.walkforward` | **PredictionSnapshot.Forecast** | Walk-forward prediction summary type used by forecast indicators, with mean, median, standard deviation, quantiles, sample count, horizon, and stable state. |
 
 **Short usage**

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -534,15 +534,15 @@ Forecast types live in `org.ta4j.core.indicators.forecast` unless noted. They pr
 | `org.ta4j.core.indicators.helpers` | **LogReturnIndicator** | Numeric helper indicator for `log(x[i] / x[i - barCount])`, often used as the input to return forecasts. |
 | `org.ta4j.core.indicators` | **ReturnIndicator** | Semantic contract for indicators that declare their return representation. |
 | `org.ta4j.core.indicators.averages` | **EWMAIndicator** | Reusable exponentially weighted moving average indicator with explicit decay and SMA initialization. |
-| `org.ta4j.core.indicators.forecast` | **ForecastProjectionProvider** | `Indicator<PredictionSnapshot.Forecast<Num>>` interface with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
-| `org.ta4j.core.indicators.forecast` | **ForecastStateProvider** | Interface for hidden-state providers used by forecast projections. |
-| `org.ta4j.core.indicators.forecast` | **ReturnForecastStateProvider** | Interface for hidden-state providers derived from a `ReturnIndicator`. |
+| `org.ta4j.core.indicators.forecast` | **ForecastProjectionIndicator** | `Indicator<PredictionSnapshot.Forecast<Num>>` interface with mean/median/std-dev/quantile projection methods returning `Indicator<Num>`. |
+| `org.ta4j.core.indicators.forecast` | **ForecastStateIndicator** | Indicator interface for hidden state used by forecast projections. |
+| `org.ta4j.core.indicators.forecast` | **ReturnForecastStateIndicator** | Indicator interface for hidden state derived from a `ReturnIndicator`. |
 | `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateIndicator** | Builds return forecast state from a log-return `ReturnIndicator` using EWMA mean and variance. |
 | `org.ta4j.core.indicators.forecast` | **ReturnForecastState** | Record containing return-state index, observation count, stable flag, mean, drift, variance, and volatility. |
-| `org.ta4j.core.indicators.forecast` | **ReturnForecastProjectionProvider** | Interface for return projections that declare their return representation and can convert to price forecasts. |
-| `org.ta4j.core.indicators.forecast` | **MonteCarloReturnProjectionIndicator** | Monte Carlo cumulative log-return projection provider with standard constructors and a builder for advanced configuration. |
+| `org.ta4j.core.indicators.forecast` | **ReturnForecastProjectionIndicator** | Interface for return projections that declare their return representation and can convert to price forecasts. |
+| `org.ta4j.core.indicators.forecast` | **MonteCarloReturnProjectionIndicator** | Monte Carlo cumulative log-return projection indicator with standard constructors and a builder for advanced configuration. |
 | `org.ta4j.core.indicators.forecast` | **LogReturnToPriceForecastIndicator** | Reducer that converts an explicit cumulative log-return projection to price forecasts. |
-| `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast projection provider into a point forecast indicator. |
+| `org.ta4j.core.indicators.forecast` | **ForwardForecastIndicator** | Adapts a forecast projection indicator into a point forecast indicator. |
 | `org.ta4j.core.walkforward` | **PredictionSnapshot.Forecast** | Walk-forward prediction summary type used by forecast indicators, with mean, median, standard deviation, quantiles, sample count, horizon, and stable state. |
 
 **Short usage**

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Data Sources](Data-Sources.md)** - Loading bars or trades from files and HTTP providers
 - **[Num](Num.md)** - Precision-aware numeric types such as `DoubleNum` and `DecimalNum`
 - **[Technical Indicators](Technical-indicators.md)** - Indicator composition and caching
+- **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, point projections, and strategy filters
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts
 

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -10,7 +10,7 @@ Technical indicators (a.k.a. *technicals*) transform price/volume data into stru
 | Momentum & Oscillators | RSI family, NetMomentum, MACD/MACDV, MACD-V momentum states, KST, Stochastics, CMO, ROC. | This page |
 | Regime & signal quality | TrendScore, TrendConclusion, Compression, EntryEdge, EdgeDecaySlope, StretchZScore. | This page |
 | Advanced correlation | Kendall tau, Spearman, lagged/distance/regime-segmented correlation, mutual information. | [Indicators Inventory §11](Indicators-Inventory.md#11-statistics--numeric) |
-| Forecasting | Log returns, EWMA return state, Monte Carlo return distributions, price forecast adapters, distribution reducers. | [Forecast Indicators](Forecast-Indicators.md) |
+| Forecasting | Log returns, EWMA return state, Monte Carlo return distributions, price forecast adapters, point projection indicators. | [Forecast Indicators](Forecast-Indicators.md) |
 | Volatility & Bands | ATR, Donchian, Bollinger, Keltner, Average True Range trailing stops. | [Bar Series & Bars](Bar-series-and-bars.md) (for ATR-based stops) |
 | Volume & Breadth | OBV, VWAP/VWMA, Accumulation/Distribution, Chaikin, Force Index, Ease of Movement, Klinger Volume Oscillator. | Indicators package |
 | Market Structure (VWAP/SR/Wyckoff) | Anchored VWAP, VWAP bands/z-score, price clusters, bounce counts, KDE volume profile, Wyckoff phase/cycle detection. | [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md) |
@@ -103,7 +103,7 @@ ta4j's forecast package adds distribution-valued indicators for forward-looking 
 - `EwmaReturnForecastStateIndicator` estimates rolling return mean, drift, variance, and volatility.
 - `MonteCarloReturnForecastIndicator` simulates cumulative log-return distributions over a configured horizon.
 - `LogReturnToPriceForecastIndicator` converts return distributions to price distributions at the decision index.
-- `ForwardForecastIndicator` and `ForecastReducers` reduce a distribution to one `Num` value for normal ta4j rule composition.
+- `ForecastDistributionIndicator` exposes `mean()`, `median()`, `standardDeviation()`, and `quantile(...)` point projections for normal ta4j rule composition.
 - `ForecastIndicators` provides convenience factories for the standard EWMA-volatility close-price forecast pipeline.
 
 Forecast indicators do not read future bars while producing `getValue(i)`. Use the configured horizon only when evaluating the forecast against later realized outcomes. See [Forecast Indicators](Forecast-Indicators.md) for setup, tuning, warm-up behavior, and strategy examples.
@@ -139,7 +139,7 @@ Indicators should be evaluated the same way strategies are—prefer realistic da
 
 - Every indicator extends `CachedIndicator`, so once a value is computed (except for the most recent bar) it is reused.
 - Mutating the latest bar (common with streaming data) invalidates just that slot; the rest stays cached.
-- Use `indicator.getCountOfUnstableBars()` / `indicator.isStable(index)` to understand when the values become reliable (and pass that number to `strategy.setUnstableBars(...)`).
+- Use `indicator.getCountOfUnstableBars()` / `indicator.isStable()` to understand when the values become reliable (and pass that number to `strategy.setUnstableBars(...)`).
 - When using moving `BarSeries` via `setMaximumBarCount`, cached entries older than the oldest remaining bar disappear. Always guard against `NaN` if you try to access evicted indexes.
 
 ## Creating custom indicators
@@ -148,7 +148,7 @@ Sub-class `CachedIndicator<Num>` or compose existing indicators with operations.
 
 - Accept dependencies via constructor injections (`Indicator<Num> base`) rather than pulling directly from a `BarSeries`.
 - Respect the `Num` abstraction: use `Num` arithmetic (`plus`, `minus`, etc.) and produce values via the series `NumFactory`.
-- Override `getUnstableBars()` / `isStable()` when your indicator requires warm-up bars (e.g., multi-stage EMAs).
+- Override `getCountOfUnstableBars()` when your indicator requires warm-up bars (e.g., multi-stage EMAs).
 - If you need state across indices, store it in the indicator (ta4j handles thread safety by design if you limit state to the calculation path).
 
 ## Tips

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -103,7 +103,7 @@ ta4j's forecast package adds prediction-valued indicators for forward-looking re
 - `EWMAIndicator` provides reusable explicit-decay smoothing for forecast and non-forecast workflows.
 - `ForecastStateIndicator` estimates rolling return mean, drift, variance, and volatility from mean and variance indicators.
 - `MonteCarloReturnForecastIndicator` simulates cumulative log-return distributions over a configured horizon.
-- `LogReturnToPriceForecastIndicator` converts return distributions to price distributions at the decision index.
+- `LogReturnToPriceForecastIndicator` converts return distributions to price distributions at the decision index, and can build the default close-price forecast directly from a price indicator and horizon.
 - `ForecastPredictionIndicator` exposes `mean()`, `median()`, `standardDeviation()`, and `quantile(...)` point projections for normal ta4j rule composition.
 
 Forecast indicators do not read future bars while producing `getValue(i)`. Use the configured horizon only when evaluating the forecast against later realized outcomes. See [Forecast Indicators](Forecast-Indicators.md) for setup, tuning, warm-up behavior, and strategy examples.

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -10,6 +10,7 @@ Technical indicators (a.k.a. *technicals*) transform price/volume data into stru
 | Momentum & Oscillators | RSI family, NetMomentum, MACD/MACDV, MACD-V momentum states, KST, Stochastics, CMO, ROC. | This page |
 | Regime & signal quality | TrendScore, TrendConclusion, Compression, EntryEdge, EdgeDecaySlope, StretchZScore. | This page |
 | Advanced correlation | Kendall tau, Spearman, lagged/distance/regime-segmented correlation, mutual information. | [Indicators Inventory §11](Indicators-Inventory.md#11-statistics--numeric) |
+| Forecasting | Log returns, EWMA return state, Monte Carlo return distributions, price forecast adapters, distribution reducers. | [Forecast Indicators](Forecast-Indicators.md) |
 | Volatility & Bands | ATR, Donchian, Bollinger, Keltner, Average True Range trailing stops. | [Bar Series & Bars](Bar-series-and-bars.md) (for ATR-based stops) |
 | Volume & Breadth | OBV, VWAP/VWMA, Accumulation/Distribution, Chaikin, Force Index, Ease of Movement, Klinger Volume Oscillator. | Indicators package |
 | Market Structure (VWAP/SR/Wyckoff) | Anchored VWAP, VWAP bands/z-score, price clusters, bounce counts, KDE volume profile, Wyckoff phase/cycle detection. | [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md) |
@@ -93,6 +94,19 @@ ta4j 0.22.7 adds composite regime and edge-scoring indicators for strategy gatin
 - **Stretch:** `StretchZScoreIndicator` normalizes deviation between any source/reference pair (close vs SMA, price vs VWAP, etc.).
 
 Pair edge indicators with `EdgeHealthyRule` and loss hygiene with `LossTriggeredCooldownRule` (see [Trading Strategies](Trading-strategies.md) and [Stop Loss & Stop Gain Rules](Stop-Loss-and-Stop-Gain-Rules.md)).
+
+## Forecast workflow (0.22.9)
+
+ta4j's forecast package adds distribution-valued indicators for forward-looking research and strategy filters:
+
+- `LogReturnIndicator` creates reusable log-return inputs from close prices or any numeric source indicator.
+- `EwmaReturnForecastStateIndicator` estimates rolling return mean, drift, variance, and volatility.
+- `MonteCarloReturnForecastIndicator` simulates cumulative log-return distributions over a configured horizon.
+- `LogReturnToPriceForecastIndicator` converts return distributions to price distributions at the decision index.
+- `ForwardForecastIndicator` and `ForecastReducers` reduce a distribution to one `Num` value for normal ta4j rule composition.
+- `ForecastIndicators` provides convenience factories for the standard EWMA-volatility close-price forecast pipeline.
+
+Forecast indicators do not read future bars while producing `getValue(i)`. Use the configured horizon only when evaluating the forecast against later realized outcomes. See [Forecast Indicators](Forecast-Indicators.md) for setup, tuning, warm-up behavior, and strategy examples.
 
 ## Advanced correlation workflow (0.22.7)
 

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -10,7 +10,7 @@ Technical indicators (a.k.a. *technicals*) transform price/volume data into stru
 | Momentum & Oscillators | RSI family, NetMomentum, MACD/MACDV, MACD-V momentum states, KST, Stochastics, CMO, ROC. | This page |
 | Regime & signal quality | TrendScore, TrendConclusion, Compression, EntryEdge, EdgeDecaySlope, StretchZScore. | This page |
 | Advanced correlation | Kendall tau, Spearman, lagged/distance/regime-segmented correlation, mutual information. | [Indicators Inventory §11](Indicators-Inventory.md#11-statistics--numeric) |
-| Forecasting | Log returns, EWMA return state, Monte Carlo return distributions, price forecast adapters, point projection indicators. | [Forecast Indicators](Forecast-Indicators.md) |
+| Forecasting | CF-289 branch-only until ta4j 0.22.9: log returns, EWMA return state, Monte Carlo return distributions, price forecast adapters, point projection indicators. | [Forecast Indicators](Forecast-Indicators.md) |
 | Volatility & Bands | ATR, Donchian, Bollinger, Keltner, Average True Range trailing stops. | [Bar Series & Bars](Bar-series-and-bars.md) (for ATR-based stops) |
 | Volume & Breadth | OBV, VWAP/VWMA, Accumulation/Distribution, Chaikin, Force Index, Ease of Movement, Klinger Volume Oscillator. | Indicators package |
 | Market Structure (VWAP/SR/Wyckoff) | Anchored VWAP, VWAP bands/z-score, price clusters, bounce counts, KDE volume profile, Wyckoff phase/cycle detection. | [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md) |

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -103,9 +103,9 @@ ta4j's forecast package adds prediction-valued indicators for forward-looking re
 - `ReturnIndicator` marks indicators that semantically produce returns in a declared representation.
 - `EWMAIndicator` provides reusable explicit-decay smoothing for forecast and non-forecast workflows.
 - `EwmaReturnForecastStateIndicator` estimates rolling return mean, drift, variance, and volatility from a log-return `ReturnIndicator`.
-- `MonteCarloReturnProjectionIndicator` simulates cumulative log-return distributions from a `ReturnForecastStateProvider` over a configured horizon.
+- `MonteCarloReturnProjectionIndicator` simulates cumulative log-return distributions from a `ReturnForecastStateIndicator` over a configured horizon.
 - `LogReturnToPriceForecastIndicator` converts explicit log-return projections to price distributions at the decision index.
-- `ForecastProjectionProvider` exposes `mean()`, `median()`, `standardDeviation()`, and `quantile(...)` point projections for normal ta4j rule composition.
+- `ForecastProjectionIndicator` exposes `mean()`, `median()`, `standardDeviation()`, and `quantile(...)` point projections for normal ta4j rule composition.
 
 Forecast indicators do not read future bars while producing `getValue(i)`. Use the configured horizon only when evaluating the forecast against later realized outcomes. See [Forecast Indicators](Forecast-Indicators.md) for setup, tuning, warm-up behavior, and strategy examples.
 

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -100,11 +100,12 @@ Pair edge indicators with `EdgeHealthyRule` and loss hygiene with `LossTriggered
 ta4j's forecast package adds prediction-valued indicators for forward-looking research and strategy filters:
 
 - `LogReturnIndicator` creates reusable log-return inputs from close prices or any numeric source indicator.
+- `ReturnIndicator` marks indicators that semantically produce returns in a declared representation.
 - `EWMAIndicator` provides reusable explicit-decay smoothing for forecast and non-forecast workflows.
-- `ForecastStateIndicator` estimates rolling return mean, drift, variance, and volatility from mean and variance indicators.
-- `MonteCarloReturnForecastIndicator` simulates cumulative log-return distributions over a configured horizon.
-- `LogReturnToPriceForecastIndicator` converts return distributions to price distributions at the decision index, and can build the default close-price forecast directly from a price indicator and horizon.
-- `ForecastPredictionIndicator` exposes `mean()`, `median()`, `standardDeviation()`, and `quantile(...)` point projections for normal ta4j rule composition.
+- `EwmaReturnForecastStateIndicator` estimates rolling return mean, drift, variance, and volatility from a log-return `ReturnIndicator`.
+- `MonteCarloReturnProjectionIndicator` simulates cumulative log-return distributions from a `ReturnForecastStateProvider` over a configured horizon.
+- `LogReturnToPriceForecastIndicator` converts explicit log-return projections to price distributions at the decision index.
+- `ForecastProjectionProvider` exposes `mean()`, `median()`, `standardDeviation()`, and `quantile(...)` point projections for normal ta4j rule composition.
 
 Forecast indicators do not read future bars while producing `getValue(i)`. Use the configured horizon only when evaluating the forecast against later realized outcomes. See [Forecast Indicators](Forecast-Indicators.md) for setup, tuning, warm-up behavior, and strategy examples.
 

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -97,14 +97,14 @@ Pair edge indicators with `EdgeHealthyRule` and loss hygiene with `LossTriggered
 
 ## Forecast workflow (0.22.9)
 
-ta4j's forecast package adds distribution-valued indicators for forward-looking research and strategy filters:
+ta4j's forecast package adds prediction-valued indicators for forward-looking research and strategy filters:
 
 - `LogReturnIndicator` creates reusable log-return inputs from close prices or any numeric source indicator.
-- `EwmaReturnForecastStateIndicator` estimates rolling return mean, drift, variance, and volatility.
+- `EWMAIndicator` provides reusable explicit-decay smoothing for forecast and non-forecast workflows.
+- `ForecastStateIndicator` estimates rolling return mean, drift, variance, and volatility from mean and variance indicators.
 - `MonteCarloReturnForecastIndicator` simulates cumulative log-return distributions over a configured horizon.
 - `LogReturnToPriceForecastIndicator` converts return distributions to price distributions at the decision index.
-- `ForecastDistributionIndicator` exposes `mean()`, `median()`, `standardDeviation()`, and `quantile(...)` point projections for normal ta4j rule composition.
-- `ForecastIndicators` provides convenience factories for the standard EWMA-volatility close-price forecast pipeline.
+- `ForecastPredictionIndicator` exposes `mean()`, `median()`, `standardDeviation()`, and `quantile(...)` point projections for normal ta4j rule composition.
 
 Forecast indicators do not read future bars while producing `getValue(i)`. Use the configured horizon only when evaluating the forecast against later realized outcomes. See [Forecast Indicators](Forecast-Indicators.md) for setup, tuning, warm-up behavior, and strategy examples.
 

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -105,8 +105,9 @@ ta4j's forecast package adds prediction-valued indicators for forward-looking re
 - `ReturnIndicator` marks indicators that semantically produce returns in a declared representation.
 - `EWMAIndicator` provides reusable explicit-decay smoothing for forecast and non-forecast workflows.
 - `EwmaReturnForecastStateIndicator` estimates rolling return mean, drift, variance, and volatility from a log-return `ReturnIndicator`.
-- `MonteCarloReturnProjectionIndicator` simulates cumulative log-return distributions from a `ReturnForecastStateIndicator` over a configured horizon.
-- `LogReturnToPriceForecastIndicator` converts explicit log-return projections to price distributions at the decision index.
+- `MonteCarloPriceForecastIndicator` is the standard constructor-first price forecast path when state comes from `LogReturnIndicator`.
+- `MonteCarloReturnProjectionIndicator` simulates cumulative log-return distributions for return-space workflows or advanced tuning.
+- `LogReturnToPriceForecastIndicator` converts explicit log-return projections to price distributions when the price source must be supplied directly.
 - `ForecastProjectionIndicator` exposes `mean()`, `median()`, `standardDeviation()`, and `quantile(...)` point projections for normal ta4j rule composition.
 
 Forecast indicators do not read future bars while producing `getValue(i)`. Use the configured horizon only when evaluating the forecast against later realized outcomes. See [Forecast Indicators](Forecast-Indicators.md) for setup, tuning, warm-up behavior, and strategy examples.

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -139,7 +139,7 @@ Indicators should be evaluated the same way strategies are—prefer realistic da
 
 - Every indicator extends `CachedIndicator`, so once a value is computed (except for the most recent bar) it is reused.
 - Mutating the latest bar (common with streaming data) invalidates just that slot; the rest stays cached.
-- Use `indicator.getCountOfUnstableBars()` / `indicator.isStable()` to understand when the values become reliable (and pass that number to `strategy.setUnstableBars(...)`).
+- Compare the current index with `indicator.getCountOfUnstableBars()` before trusting early values, or pass that number to `strategy.setUnstableBars(...)`.
 - When using moving `BarSeries` via `setMaximumBarCount`, cached entries older than the oldest remaining bar disappear. Always guard against `NaN` if you try to access evicted indexes.
 
 ## Creating custom indicators

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -97,6 +97,8 @@ Pair edge indicators with `EdgeHealthyRule` and loss hygiene with `LossTriggered
 
 ## Forecast workflow (0.22.9)
 
+This workflow is documented from the CF-289 feature branch and is branch-only until the ta4j 0.22.9 release includes these APIs.
+
 ta4j's forecast package adds prediction-valued indicators for forward-looking research and strategy filters:
 
 - `LogReturnIndicator` creates reusable log-return inputs from close prices or any numeric source indicator.

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -107,8 +107,8 @@ ta4j's forecast package adds prediction-valued indicators for forward-looking re
 - `EwmaReturnForecastStateIndicator` estimates rolling return mean, drift, variance, and volatility from a log-return `ReturnIndicator`.
 - `MonteCarloPriceForecastIndicator` is the standard constructor-first price forecast path when state comes from `LogReturnIndicator`.
 - `MonteCarloReturnProjectionIndicator` simulates cumulative log-return distributions for return-space workflows or advanced tuning.
-- `LogReturnToPriceForecastIndicator` converts explicit log-return projections to price distributions when the price source must be supplied directly.
-- `ForecastProjectionIndicator` exposes `mean()`, `median()`, `standardDeviation()`, and `quantile(...)` point projections for normal ta4j rule composition.
+- `LogReturnToPriceForecastIndicator` in `forecast.adapters` converts explicit log-return projections to price distributions when the price source must be supplied directly.
+- `ForecastProjectionIndicator` in `forecast.projection` exposes `mean()`, `median()`, `standardDeviation()`, and `quantile(...)` point projections for normal ta4j rule composition.
 
 Forecast indicators do not read future bars while producing `getValue(i)`. Use the configured horizon only when evaluating the forecast against later realized outcomes. See [Forecast Indicators](Forecast-Indicators.md) for setup, tuning, warm-up behavior, and strategy examples.
 

--- a/Usage-examples.md
+++ b/Usage-examples.md
@@ -26,6 +26,7 @@ For verification signals and common failure patterns, see [Examples Expected Out
 - **[IndicatorsToCsv](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToCsv.java)** - Export indicator values for spreadsheet analysis
 - **[IndicatorsToChart](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java)** - Plot price plus indicator overlays
 - **[CandlestickChart](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java)** - Candlestick chart overlays
+- **[Forecast Indicators](Forecast-Indicators.md)** - Build forward-looking return and price distributions, then reduce them to rule-friendly point forecasts
 - **[Charting](Charting.md)** - Full `ChartWorkflow` guide
 - **[ElliottWaveIndicatorSuiteDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/ElliottWaveIndicatorSuiteDemo.java)** - Full Elliott Wave indicator-suite run with charts and scenario analysis
 - **[ElliottWavePresetDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/ElliottWavePresetDemo.java)** - Preset Elliott Wave launcher for ossified BTC/ETH/SP500 datasets or live datasource arguments

--- a/Usage-examples.md
+++ b/Usage-examples.md
@@ -26,7 +26,7 @@ For verification signals and common failure patterns, see [Examples Expected Out
 - **[IndicatorsToCsv](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToCsv.java)** - Export indicator values for spreadsheet analysis
 - **[IndicatorsToChart](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java)** - Plot price plus indicator overlays
 - **[CandlestickChart](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java)** - Candlestick chart overlays
-- **[Forecast Indicators](Forecast-Indicators.md)** - Build forward-looking return and price distributions, then reduce them to rule-friendly point forecasts
+- **[Forecast Indicators](Forecast-Indicators.md)** - Build forward-looking return and price distributions, then project them to rule-friendly point forecasts
 - **[Charting](Charting.md)** - Full `ChartWorkflow` guide
 - **[ElliottWaveIndicatorSuiteDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/ElliottWaveIndicatorSuiteDemo.java)** - Full Elliott Wave indicator-suite run with charts and scenario analysis
 - **[ElliottWavePresetDemo](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/ElliottWavePresetDemo.java)** - Preset Elliott Wave launcher for ossified BTC/ETH/SP500 datasets or live datasource arguments

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -21,6 +21,7 @@
 - [Num](Num.md)
 - [Technical Indicators](Technical-indicators.md)
 - [Indicators Inventory](Indicators-Inventory.md)
+- [Forecast Indicators](Forecast-Indicators.md)
 - [Moving Average Indicators](Moving-Average-Indicators.md)
 - [Bill Williams Indicators](Bill-Williams-Indicators.md)
 - [Trendlines & Swing Points](Trendlines-and-Swing-Points.md)


### PR DESCRIPTION
## Summary
- Add a Forecast Indicators user guide covering the EWMA-volatility Monte Carlo pipeline, point reducers, tuning, warm-up behavior, undefined values, look-ahead avoidance, and strategy patterns.
- Link the guide from Home, Usage Examples, Sidebar, Technical Indicators, and Indicators Inventory.
- Add the new forecast API surface to the indicator inventory, including LogReturnIndicator in helpers and forecast distribution/configuration types.

## Validation
- `git diff --check`
- Local Markdown file/anchor link check across touched docs
- Verified forecast class and enum names against the ta4j CF-289 implementation branch

Not run: Jekyll site build and markdownlint; neither `jekyll` nor `markdownlint` is installed in this checkout environment.