### PR TITLE
Document improved swing detection

### DIFF
--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -810,7 +810,7 @@ SwingDetector consensus = SwingDetectors.consensus(
     2, 2, fractal, adaptive, filteredSlope);
 ```
 
-Choose by turn shape rather than treating one detector as universally superior: ZigZag is strongest for sharp price-distance reversals, fractals provide deterministic fixed-window extrema, and slope-change detection captures gradual turns. Tolerant consensus trades earlier confirmation for more stable pivots when detectors disagree by a few bars. Every built-in detector is causal at the requested index.
+Choose by turn shape rather than treating one detector as universally superior: ZigZag is strongest for sharp price-distance reversals, fractals provide deterministic fixed-window extrema, and slope-change detection captures gradual turns. Tolerant consensus trades earliest confirmation for more stable pivots when detectors disagree by a few bars. Every built-in detector is causal at the requested index.
 
 ### SwingFilter and MinMagnitudeSwingFilter
 

--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -124,7 +124,7 @@ ElliottSwingIndicator (alternating swings)
 ├─────────────────────────────────────────────────────────┤
 │ • ElliottWaveAnalysisRunner (one-shot analysis)         │
 │ • SwingDetector             (pluggable swing detection)  │
-│ • Fractal / ZigZag / SlopeChange / multi-scale consensus│
+│ • Fractal / ZigZag; SlopeChange / multi-scale (0.22.9+)  │
 │ • ConfidenceModel / ConfidenceProfile (pluggable weights)│
 └─────────────────────────────────────────────────────────┘
 ```

--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -124,7 +124,7 @@ ElliottSwingIndicator (alternating swings)
 ├─────────────────────────────────────────────────────────┤
 │ • ElliottWaveAnalysisRunner (one-shot analysis)         │
 │ • SwingDetector             (pluggable swing detection)  │
-│ • FractalSwingDetector / ZigZag / AdaptiveZigZag        │
+│ • Fractal / ZigZag / SlopeChange / multi-scale consensus│
 │ • ConfidenceModel / ConfidenceProfile (pluggable weights)│
 └─────────────────────────────────────────────────────────┘
 ```
@@ -782,7 +782,8 @@ Elliott Wave analysis can use different swing detection backends via the **Swing
 | **FractalSwingDetector** | Fixed lookback/lookforward window (fractal-style pivots). |
 | **ZigZagSwingDetector** | ZigZag state with fixed or ATR-based reversal threshold. |
 | **AdaptiveZigZagSwingDetector** | ZigZag with volatility-adaptive threshold (ATR period, multiplier, min/max clamp). |
-| **CompositeSwingDetector** | Combines multiple detectors with AND/OR pivot agreement. |
+| **SlopeChangeSwingDetector** | Causal rolling-regression slope reversal with persistence and ATR magnitude filters; suited to rounded turns. |
+| **CompositeSwingDetector** | Combines detectors with exact AND/OR agreement or tolerant same-type pivot clustering and a configurable quorum. |
 
 Use **SwingDetectors** for factory methods:
 
@@ -797,10 +798,16 @@ SwingDetector fractal = SwingDetectors.fractal(3, 5, 1);
 AdaptiveZigZagConfig config = new AdaptiveZigZagConfig(14, 2.0, 0, 0, 1);
 SwingDetector adaptive = SwingDetectors.adaptiveZigZag(config);
 
-// Composite: require both fractal and ZigZag to agree on pivots
-SwingDetector composite = SwingDetectors.composite(
-    CompositeSwingDetector.Policy.AND, fractal, zigzag);
+// Rounded turns: rolling slopes must reverse and persist for two windows
+SwingDetector slope = SwingDetectors.slopeChange(
+    new SlopeChangeConfig(5, 2, 14, 0.0, 0.5));
+
+// Multi-scale consensus: require two votes within a two-bar cluster
+SwingDetector consensus = SwingDetectors.multiScale(
+    2, 2, fractal, adaptive, slope);
 ```
+
+Choose by turn shape rather than treating one detector as universally superior: ZigZag is strongest for sharp price-distance reversals, fractals provide deterministic fixed-window extrema, and slope-change detection captures gradual turns. Multi-scale consensus trades earlier confirmation for more stable pivots when detectors disagree by a few bars. Every built-in detector is causal at the requested index.
 
 ### SwingFilter and MinMagnitudeSwingFilter
 
@@ -820,6 +827,7 @@ ElliottWaveAnalysisRunner runner = ElliottWaveAnalysisRunner.builder()
 - **SwingDetectorResult**: Pivots and derived swings for a bar index.
 - **SwingPivot** / **SwingPivotType**: Single pivot (index, price, high/low).
 - **AdaptiveZigZagConfig**: ATR period, multiplier, min/max threshold, smoothing for adaptive ZigZag.
+- **SlopeChangeConfig**: regression window, persistence count, ATR period, minimum slope change, and minimum ATR reversal.
 
 See [Indicators Inventory](Indicators-Inventory.md#102-elliott-confidence-orgta4jcoreindicatorselliottconfidence) for the full list of swing and confidence types.
 

--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -782,7 +782,7 @@ Elliott Wave analysis can use different swing detection backends via the **Swing
 | **FractalSwingDetector** | Fixed lookback/lookforward window (fractal-style pivots). |
 | **ZigZagSwingDetector** | ZigZag state with fixed or ATR-based reversal threshold. |
 | **AdaptiveZigZagSwingDetector** | ZigZag with volatility-adaptive threshold (ATR period, multiplier, min/max clamp). |
-| **SlopeChangeSwingDetector** | Causal rolling-regression slope reversal with persistence and ATR magnitude filters; suited to rounded turns. |
+| **SlopeChangeSwingDetector** | Causal rolling-regression slope reversal suited to rounded turns. Its window-only constructor supplies conservative persistence and filter defaults; `SlopeChangeConfig` enables full control. |
 | **CompositeSwingDetector** | Combines detectors with exact AND/OR agreement or tolerant same-type pivot clustering and a configurable quorum. |
 
 Use **SwingDetectors** for factory methods:
@@ -798,13 +798,16 @@ SwingDetector fractal = SwingDetectors.fractal(3, 5, 1);
 AdaptiveZigZagConfig config = new AdaptiveZigZagConfig(14, 2.0, 0, 0, 1);
 SwingDetector adaptive = SwingDetectors.adaptiveZigZag(config);
 
-// Rounded turns: rolling slopes must reverse and persist for two windows
-SwingDetector slope = SwingDetectors.slopeChange(
+// Rounded turns with defaults: one confirmation window, ATR(14), filters off
+SwingDetector slope = new SlopeChangeSwingDetector(5);
+
+// Full control over persistence and magnitude filtering
+SwingDetector filteredSlope = SwingDetectors.slopeChange(
     new SlopeChangeConfig(5, 2, 14, 0.0, 0.5));
 
 // Multi-scale consensus: require two votes within a two-bar cluster
 SwingDetector consensus = SwingDetectors.multiScale(
-    2, 2, fractal, adaptive, slope);
+    2, 2, fractal, adaptive, filteredSlope);
 ```
 
 Choose by turn shape rather than treating one detector as universally superior: ZigZag is strongest for sharp price-distance reversals, fractals provide deterministic fixed-window extrema, and slope-change detection captures gradual turns. Multi-scale consensus trades earlier confirmation for more stable pivots when detectors disagree by a few bars. Every built-in detector is causal at the requested index.

--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -782,7 +782,7 @@ Elliott Wave analysis can use different swing detection backends via the **Swing
 | **FractalSwingDetector** | Fixed lookback/lookforward window (fractal-style pivots). |
 | **ZigZagSwingDetector** | ZigZag state with fixed or ATR-based reversal threshold. |
 | **AdaptiveZigZagSwingDetector** | ZigZag with volatility-adaptive threshold (ATR period, multiplier, min/max clamp). |
-| **SlopeChangeSwingDetector** | Causal rolling-regression slope reversal suited to rounded turns. Its window-only constructor supplies conservative persistence and filter defaults; `SlopeChangeConfig` enables full control. |
+| **SlopeChangeSwingDetector** | Causal rolling-regression slope reversal suited to rounded turns. Its window-only constructor supplies balanced two-window persistence and half-ATR filtering; `SlopeChangeConfig` enables full control. |
 | **CompositeSwingDetector** | Combines detectors with exact AND/OR agreement or tolerant same-type pivot clustering and a configurable quorum. |
 
 Use **SwingDetectors** for factory methods:
@@ -798,19 +798,19 @@ SwingDetector fractal = SwingDetectors.fractal(3, 5, 1);
 AdaptiveZigZagConfig config = new AdaptiveZigZagConfig(14, 2.0, 0, 0, 1);
 SwingDetector adaptive = SwingDetectors.adaptiveZigZag(config);
 
-// Rounded turns with defaults: one confirmation window, ATR(14), filters off
-SwingDetector slope = new SlopeChangeSwingDetector(5);
+// Rounded turns with balanced two-window and half-ATR defaults
+SwingDetector slope = SwingDetectors.slopeChange(5);
 
 // Full control over persistence and magnitude filtering
 SwingDetector filteredSlope = SwingDetectors.slopeChange(
     new SlopeChangeConfig(5, 2, 14, 0.0, 0.5));
 
-// Multi-scale consensus: require two votes within a two-bar cluster
-SwingDetector consensus = SwingDetectors.multiScale(
+// Tolerant consensus: require two votes within a two-bar cluster
+SwingDetector consensus = SwingDetectors.consensus(
     2, 2, fractal, adaptive, filteredSlope);
 ```
 
-Choose by turn shape rather than treating one detector as universally superior: ZigZag is strongest for sharp price-distance reversals, fractals provide deterministic fixed-window extrema, and slope-change detection captures gradual turns. Multi-scale consensus trades earlier confirmation for more stable pivots when detectors disagree by a few bars. Every built-in detector is causal at the requested index.
+Choose by turn shape rather than treating one detector as universally superior: ZigZag is strongest for sharp price-distance reversals, fractals provide deterministic fixed-window extrema, and slope-change detection captures gradual turns. Tolerant consensus trades earlier confirmation for more stable pivots when detectors disagree by a few bars. Every built-in detector is causal at the requested index.
 
 ### SwingFilter and MinMagnitudeSwingFilter
 
@@ -830,7 +830,7 @@ ElliottWaveAnalysisRunner runner = ElliottWaveAnalysisRunner.builder()
 - **SwingDetectorResult**: Pivots and derived swings for a bar index.
 - **SwingPivot** / **SwingPivotType**: Single pivot (index, price, high/low).
 - **AdaptiveZigZagConfig**: ATR period, multiplier, min/max threshold, smoothing for adaptive ZigZag.
-- **SlopeChangeConfig**: regression window, persistence count, ATR period, minimum slope change, and minimum ATR reversal.
+- **SlopeChangeConfig**: regression window, persistence count, ATR period, minimum slope change, and minimum ATR reversal. `defaults(window)` returns the balanced profile used by `SwingDetectors.slopeChange(window)`.
 
 See [Indicators Inventory](Indicators-Inventory.md#102-elliott-confidence-orgta4jcoreindicatorselliottconfidence) for the full list of swing and confidence types.
 

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -398,12 +398,14 @@ For an overview of indicator categories and composition patterns, see [Technical
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.elliott.swing` | **SwingDetector** | Interface: detects swing pivots and constructs swing sequences for a bar index. |
 | `org.ta4j.core.indicators.elliott.swing` | **SwingDetectorResult** | Record: detected pivots and derived swings for a given index. |
-| `org.ta4j.core.indicators.elliott.swing` | **SwingDetectors** | Factory helpers for fractal, adaptive ZigZag, and composite swing detectors. |
+| `org.ta4j.core.indicators.elliott.swing` | **SwingDetectors** | Factory helpers for fractal, adaptive ZigZag, slope-change, composite, and tolerant multi-scale swing detectors. |
 | `org.ta4j.core.indicators.elliott.swing` | **FractalSwingDetector** | Swing detector backed by fractal swing high/low (fixed lookback/lookforward window). |
 | `org.ta4j.core.indicators.elliott.swing` | **ZigZagSwingDetector** | Swing detector backed by ZigZag state (reversal threshold or ATR-based). |
 | `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagSwingDetector** | ZigZag swing detector that adapts reversal threshold to volatility (ATR-based). |
 | `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagConfig** | Record: ATR period, multiplier, min/max threshold, smoothing for adaptive ZigZag. |
-| `org.ta4j.core.indicators.elliott.swing` | **CompositeSwingDetector** | Combines multiple swing detectors with AND/OR pivot agreement policy. |
+| `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeSwingDetector** | Detects rounded turns from sustained causal changes in rolling regression slope. |
+| `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeConfig** | Record: slope window, confirmation persistence, ATR period, and magnitude filters. |
+| `org.ta4j.core.indicators.elliott.swing` | **CompositeSwingDetector** | Combines detectors with exact AND/OR agreement or tolerant clustered quorum voting. |
 | `org.ta4j.core.indicators.elliott.swing` | **MinMagnitudeSwingFilter** | SwingFilter that drops swings below a relative magnitude of the largest swing. |
 | `org.ta4j.core.indicators.elliott.swing` | **SwingFilter** | Interface: post-processes swing lists (e.g. remove noise, apply constraints). |
 | `org.ta4j.core.indicators.elliott.swing` | **SwingPivot** | Record: confirmed swing pivot (index, price, type high/low). |

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -403,7 +403,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.elliott.swing` | **ZigZagSwingDetector** | Swing detector backed by ZigZag state (reversal threshold or ATR-based). |
 | `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagSwingDetector** | ZigZag swing detector that adapts reversal threshold to volatility (ATR-based). |
 | `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagConfig** | Record: ATR period, multiplier, min/max threshold, smoothing for adaptive ZigZag. |
-| `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeSwingDetector** | Detects rounded turns from sustained causal changes in rolling regression slope; supports a window-only constructor with conservative defaults. |
+| `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeSwingDetector** | Detects rounded turns from sustained causal changes in rolling regression slope; supports balanced window-only construction. |
 | `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeConfig** | Record: slope window, confirmation persistence, ATR period, and magnitude filters. |
 | `org.ta4j.core.indicators.elliott.swing` | **CompositeSwingDetector** | Combines detectors with exact AND/OR agreement or tolerant clustered quorum voting. |
 | `org.ta4j.core.indicators.elliott.swing` | **MinMagnitudeSwingFilter** | SwingFilter that drops swings below a relative magnitude of the largest swing. |

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -403,7 +403,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.elliott.swing` | **ZigZagSwingDetector** | Swing detector backed by ZigZag state (reversal threshold or ATR-based). |
 | `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagSwingDetector** | ZigZag swing detector that adapts reversal threshold to volatility (ATR-based). |
 | `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagConfig** | Record: ATR period, multiplier, min/max threshold, smoothing for adaptive ZigZag. |
-| `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeSwingDetector** | Detects rounded turns from sustained causal changes in rolling regression slope. |
+| `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeSwingDetector** | Detects rounded turns from sustained causal changes in rolling regression slope; supports a window-only constructor with conservative defaults. |
 | `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeConfig** | Record: slope window, confirmation persistence, ATR period, and magnitude filters. |
 | `org.ta4j.core.indicators.elliott.swing` | **CompositeSwingDetector** | Combines detectors with exact AND/OR agreement or tolerant clustered quorum voting. |
 | `org.ta4j.core.indicators.elliott.swing` | **MinMagnitudeSwingFilter** | SwingFilter that drops swings below a relative magnitude of the largest swing. |

--- a/Trendlines-and-Swing-Points.md
+++ b/Trendlines-and-Swing-Points.md
@@ -94,7 +94,11 @@ No single formula is best for every turn shape:
 | `SwingDetectors.multiScale(...)` | Noisy data where consistent pivots matter more than the earliest signal | Requires a quorum of same-type pivots within an index tolerance. |
 
 ```java
-SwingDetector roundedTurns = SwingDetectors.slopeChange(
+// Window-only constructor: one confirmation window, ATR(14), filters disabled
+SwingDetector roundedTurns = new SlopeChangeSwingDetector(5);
+
+// Use the config overload when persistence or magnitude filters are required
+SwingDetector filteredRoundedTurns = SwingDetectors.slopeChange(
         new SlopeChangeConfig(5, 2, 14, 0.0, 0.5));
 
 SwingDetector consensus = SwingDetectors.multiScale(
@@ -102,7 +106,7 @@ SwingDetector consensus = SwingDetectors.multiScale(
         2, // require two detector votes
         SwingDetectors.fractal(3),
         SwingDetectors.adaptiveZigZag(new AdaptiveZigZagConfig(14, 1.5, 0, 0, 1)),
-        roundedTurns);
+        filteredRoundedTurns);
 ```
 
 All detector results are causal at the requested evaluation index: they use only bars available at that index, while the reported pivot can refer to the earlier bar where the confirmed extreme occurred.

--- a/Trendlines-and-Swing-Points.md
+++ b/Trendlines-and-Swing-Points.md
@@ -61,6 +61,8 @@ int latestHighIndex = majorHighs.getLatestSwingHighIndex(series.getEndIndex());
 ### ZigZag swings (reversal-threshold based)
 `RecentZigZagSwingHighIndicator` / `RecentZigZagSwingLowIndicator` track swings confirmed when price reverses by at least a configured threshold—no fixed lookahead window.
 
+The OHLC-aware state constructors and state-only recent-swing constructors below are available in ta4j 0.22.9 and later. On 0.22.8, use the released single-price `ZigZagStateIndicator(price, reversalAmount)` and explicit-price recent-swing constructors.
+
 - Driven by `ZigZagStateIndicator(high, low, confirmationPrice, reversalAmount)`; the older single-price constructor remains available.
 - **Extreme sources**: use highs to extend upward legs and lows to extend downward legs. Confirmation commonly uses the close so an intrabar wick can set an extreme without confirming its own reversal.
 - **Reversal threshold** (`reversalAmount`): indicator in price units. Defaults to `ATR(14)` in the convenience constructor; pass `ConstantIndicator` for fixed-point thresholds or any indicator for adaptive ones.

--- a/Trendlines-and-Swing-Points.md
+++ b/Trendlines-and-Swing-Points.md
@@ -5,8 +5,6 @@ Trendlines and swing points are the core building blocks behind support/resistan
 ## What you get
 - **Fractal swing detectors**: window-based swing highs/lows with configurable symmetry and tolerance for flat tops/bottoms.
 - **ZigZag swing detectors**: OHLC-aware ATR/price-threshold reversals for adaptive swing confirmation without fixed lookahead windows.
-- **Slope-change detector**: sustained rolling-regression slope reversals for slower, rounded turns.
-- **Multi-scale consensus**: tolerant pivot clustering with a configurable detector quorum.
 - **Swing markers**: `SwingPointMarkerIndicator` converts swing indexes into chart-friendly markers (values only on swing bars, `NaN` elsewhere).
 - **Trendlines**: `TrendLineSupportIndicator` / `TrendLineResistanceIndicator` that score every valid line in the lookback window and pick the best candidate with tunable weights and touch tolerance.
 - **Chart-ready metadata**: `getSwingPointIndexes()` and `getCurrentSegment()` expose anchors, slope/intercept, and scoring so you can debug or annotate charts.
@@ -86,7 +84,7 @@ The state-only recent-swing constructors automatically reuse the matching low or
 high source. Use the explicit-source overloads only when custom pivot pricing is
 intentional.
 
-### Choosing a detector
+### Choosing a trendline swing source
 
 No single formula is best for every turn shape:
 
@@ -94,30 +92,10 @@ No single formula is best for every turn shape:
 |----------|----------|------------------------|
 | Fractal | Distinct local extrema and fixed timing requirements | Waits for the configured right-side window. |
 | ZigZag | Sharp reversals whose importance is defined by price distance or volatility | Confirms after the reversal threshold is crossed. |
-| `SlopeChangeSwingDetector` | Rounded tops/bottoms where direction changes gradually | Waits for adjacent regression slopes to reverse and persist. |
-| `SwingDetectors.consensus(...)` | Noisy data where consistent pivots matter more than the earliest signal | Requires a quorum of same-type pivots within an index tolerance. |
 
-```java
-// Balanced defaults: two confirmation windows and a half-ATR reversal filter
-SwingDetector roundedTurns = SwingDetectors.slopeChange(5);
+These two sources implement `RecentSwingIndicator` and plug directly into trendline and marker indicators. Elliott analysis also supports slope-change and tolerant consensus backends through its separate `SwingDetector` contract; see [Pluggable Swing Detection](Elliott-Wave-Indicators.md#pluggable-swing-detection) for those runner-specific APIs.
 
-// Use the config overload when persistence or magnitude filters are required
-SwingDetector filteredRoundedTurns = SwingDetectors.slopeChange(
-        new SlopeChangeConfig(5, 2, 14, 0.0, 0.5));
-
-SwingDetector consensus = SwingDetectors.consensus(
-        2, // cluster same-type pivots within two bars
-        2, // require two detector votes
-        SwingDetectors.fractal(3),
-        SwingDetectors.adaptiveZigZag(new AdaptiveZigZagConfig(14, 1.5, 0, 0, 1)),
-        filteredRoundedTurns);
-```
-
-`SlopeChangeConfig.defaults(window)` returns the same balanced profile used by
-the window-only detector and factory overload. Construct the record directly
-when you deliberately need different persistence or magnitude filters.
-
-All detector results are causal at the requested evaluation index: they use only bars available at that index, while the reported pivot can refer to the earlier bar where the confirmed extreme occurred.
+Both trendline swing sources are causal at the requested evaluation index: they use only bars available at that index, while the reported pivot can refer to the earlier bar where the confirmed extreme occurred.
 
 ### Showing swings on charts
 `SwingPointMarkerIndicator` outputs prices only at swing indexes (`NaN` elsewhere) so chart overlays become discrete markers instead of lines.

--- a/Trendlines-and-Swing-Points.md
+++ b/Trendlines-and-Swing-Points.md
@@ -78,9 +78,13 @@ ATRIndicator atr = new ATRIndicator(series, 14);
 Indicator<Num> atrThreshold = BinaryOperationIndicator.product(atr, 1.5);
 ZigZagStateIndicator zigzagState = new ZigZagStateIndicator(high, low, close, atrThreshold);
 
-RecentZigZagSwingLowIndicator zigzagLows = new RecentZigZagSwingLowIndicator(zigzagState, low);
-RecentZigZagSwingHighIndicator zigzagHighs = new RecentZigZagSwingHighIndicator(zigzagState, high);
+RecentZigZagSwingLowIndicator zigzagLows = new RecentZigZagSwingLowIndicator(zigzagState);
+RecentZigZagSwingHighIndicator zigzagHighs = new RecentZigZagSwingHighIndicator(zigzagState);
 ```
+
+The state-only recent-swing constructors automatically reuse the matching low or
+high source. Use the explicit-source overloads only when custom pivot pricing is
+intentional.
 
 ### Choosing a detector
 
@@ -91,23 +95,27 @@ No single formula is best for every turn shape:
 | Fractal | Distinct local extrema and fixed timing requirements | Waits for the configured right-side window. |
 | ZigZag | Sharp reversals whose importance is defined by price distance or volatility | Confirms after the reversal threshold is crossed. |
 | `SlopeChangeSwingDetector` | Rounded tops/bottoms where direction changes gradually | Waits for adjacent regression slopes to reverse and persist. |
-| `SwingDetectors.multiScale(...)` | Noisy data where consistent pivots matter more than the earliest signal | Requires a quorum of same-type pivots within an index tolerance. |
+| `SwingDetectors.consensus(...)` | Noisy data where consistent pivots matter more than the earliest signal | Requires a quorum of same-type pivots within an index tolerance. |
 
 ```java
-// Window-only constructor: one confirmation window, ATR(14), filters disabled
-SwingDetector roundedTurns = new SlopeChangeSwingDetector(5);
+// Balanced defaults: two confirmation windows and a half-ATR reversal filter
+SwingDetector roundedTurns = SwingDetectors.slopeChange(5);
 
 // Use the config overload when persistence or magnitude filters are required
 SwingDetector filteredRoundedTurns = SwingDetectors.slopeChange(
         new SlopeChangeConfig(5, 2, 14, 0.0, 0.5));
 
-SwingDetector consensus = SwingDetectors.multiScale(
+SwingDetector consensus = SwingDetectors.consensus(
         2, // cluster same-type pivots within two bars
         2, // require two detector votes
         SwingDetectors.fractal(3),
         SwingDetectors.adaptiveZigZag(new AdaptiveZigZagConfig(14, 1.5, 0, 0, 1)),
         filteredRoundedTurns);
 ```
+
+`SlopeChangeConfig.defaults(window)` returns the same balanced profile used by
+the window-only detector and factory overload. Construct the record directly
+when you deliberately need different persistence or magnitude filters.
 
 All detector results are causal at the requested evaluation index: they use only bars available at that index, while the reported pivot can refer to the earlier bar where the confirmed extreme occurred.
 

--- a/Trendlines-and-Swing-Points.md
+++ b/Trendlines-and-Swing-Points.md
@@ -4,7 +4,9 @@ Trendlines and swing points are the core building blocks behind support/resistan
 
 ## What you get
 - **Fractal swing detectors**: window-based swing highs/lows with configurable symmetry and tolerance for flat tops/bottoms.
-- **ZigZag swing detectors**: ATR/price-threshold reversals for adaptive swing confirmation without fixed lookahead windows.
+- **ZigZag swing detectors**: OHLC-aware ATR/price-threshold reversals for adaptive swing confirmation without fixed lookahead windows.
+- **Slope-change detector**: sustained rolling-regression slope reversals for slower, rounded turns.
+- **Multi-scale consensus**: tolerant pivot clustering with a configurable detector quorum.
 - **Swing markers**: `SwingPointMarkerIndicator` converts swing indexes into chart-friendly markers (values only on swing bars, `NaN` elsewhere).
 - **Trendlines**: `TrendLineSupportIndicator` / `TrendLineResistanceIndicator` that score every valid line in the lookback window and pick the best candidate with tunable weights and touch tolerance.
 - **Chart-ready metadata**: `getSwingPointIndexes()` and `getCurrentSegment()` expose anchors, slope/intercept, and scoring so you can debug or annotate charts.
@@ -47,7 +49,7 @@ charts.display(plan);
 
 - `precedingHigherBars` / `precedingLowerBars`: how many bars immediately before must be strictly above/below the candidate. Must be ≥ 1 (default convenience constructor uses 3).
 - `followingHigherBars` / `followingLowerBars`: how many bars after must be strictly above/below the candidate. Needs future bars, so swings confirm only after this window elapses.
-- `allowedEqualBars`: how many bars on each side may equal the candidate value (helps catch rounded tops/bottoms instead of rejecting plateaus).
+- `allowedEqualBars`: maximum additional equal bars allowed in the candidate plateau. A plateau is emitted once at its canonical extreme instead of producing duplicate pivots.
 - Defaults: `new RecentFractalSwingLowIndicator(series)` → 3/3/0 on lows (highs mirror the parameters).
 
 Use fractals when you want visually obvious turning points and don’t mind waiting a few bars for confirmation.
@@ -61,21 +63,49 @@ int latestHighIndex = majorHighs.getLatestSwingHighIndex(series.getEndIndex());
 ### ZigZag swings (reversal-threshold based)
 `RecentZigZagSwingHighIndicator` / `RecentZigZagSwingLowIndicator` track swings confirmed when price reverses by at least a configured threshold—no fixed lookahead window.
 
-- Driven by `ZigZagStateIndicator(price, reversalAmount)`.
-- **Price indicator**: typically `HighPriceIndicator`, `LowPriceIndicator`, or `ClosePriceIndicator`.
+- Driven by `ZigZagStateIndicator(high, low, confirmationPrice, reversalAmount)`; the older single-price constructor remains available.
+- **Extreme sources**: use highs to extend upward legs and lows to extend downward legs. Confirmation commonly uses the close so an intrabar wick can set an extreme without confirming its own reversal.
 - **Reversal threshold** (`reversalAmount`): indicator in price units. Defaults to `ATR(14)` in the convenience constructor; pass `ConstantIndicator` for fixed-point thresholds or any indicator for adaptive ones.
+- Dynamic thresholds are anchored when the candidate extreme is established. Later volatility changes therefore cannot move the confirmation boundary for that candidate.
 - Returns `NaN` until a reversal large enough to confirm the prior extreme.
 
 ```java
+HighPriceIndicator high = new HighPriceIndicator(series);
+LowPriceIndicator low = new LowPriceIndicator(series);
 ClosePriceIndicator close = new ClosePriceIndicator(series);
 // Confirm swings after a 1.5 * ATR move
 ATRIndicator atr = new ATRIndicator(series, 14);
 Indicator<Num> atrThreshold = BinaryOperationIndicator.product(atr, 1.5);
-ZigZagStateIndicator zigzagState = new ZigZagStateIndicator(close, atrThreshold);
+ZigZagStateIndicator zigzagState = new ZigZagStateIndicator(high, low, close, atrThreshold);
 
-RecentZigZagSwingLowIndicator zigzagLows = new RecentZigZagSwingLowIndicator(zigzagState, close);
-RecentZigZagSwingHighIndicator zigzagHighs = new RecentZigZagSwingHighIndicator(zigzagState, close);
+RecentZigZagSwingLowIndicator zigzagLows = new RecentZigZagSwingLowIndicator(zigzagState, low);
+RecentZigZagSwingHighIndicator zigzagHighs = new RecentZigZagSwingHighIndicator(zigzagState, high);
 ```
+
+### Choosing a detector
+
+No single formula is best for every turn shape:
+
+| Detector | Best fit | Confirmation trade-off |
+|----------|----------|------------------------|
+| Fractal | Distinct local extrema and fixed timing requirements | Waits for the configured right-side window. |
+| ZigZag | Sharp reversals whose importance is defined by price distance or volatility | Confirms after the reversal threshold is crossed. |
+| `SlopeChangeSwingDetector` | Rounded tops/bottoms where direction changes gradually | Waits for adjacent regression slopes to reverse and persist. |
+| `SwingDetectors.multiScale(...)` | Noisy data where consistent pivots matter more than the earliest signal | Requires a quorum of same-type pivots within an index tolerance. |
+
+```java
+SwingDetector roundedTurns = SwingDetectors.slopeChange(
+        new SlopeChangeConfig(5, 2, 14, 0.0, 0.5));
+
+SwingDetector consensus = SwingDetectors.multiScale(
+        2, // cluster same-type pivots within two bars
+        2, // require two detector votes
+        SwingDetectors.fractal(3),
+        SwingDetectors.adaptiveZigZag(new AdaptiveZigZagConfig(14, 1.5, 0, 0, 1)),
+        roundedTurns);
+```
+
+All detector results are causal at the requested evaluation index: they use only bars available at that index, while the reported pivot can refer to the earlier bar where the confirmed extreme occurred.
 
 ### Showing swings on charts
 `SwingPointMarkerIndicator` outputs prices only at swing indexes (`NaN` elsewhere) so chart overlays become discrete markers instead of lines.
@@ -210,7 +240,7 @@ Strategy trendlineStrategy = new BaseStrategy("Trendline break/bounce", breakout
 ## Best practices & pitfalls
 - Swings need future bars: fractals confirm only after the `following*` window; ZigZag confirms after price moves by the threshold. Guard against `NaN` when rules fire.
 - Align parameters with timeframe: wide windows on low-timeframe data will feel sluggish; on daily/weekly charts they remove noise.
-- Keep price inputs consistent: if your ZigZag tracks highs/lows, feed the same price indicator into `RecentZigZagSwing*` and the trendline.
+- Keep price inputs consistent: pair `RecentZigZagSwingHighIndicator` with the ZigZag state's high source and `RecentZigZagSwingLowIndicator` with its low source.
 - Match lookback to data retention: if you set `series.setMaximumBarCount(250)`, keep trendline `barCount <= 250` or earlier anchors will be evicted.
 - Tune tolerance to the instrument: use absolute/tick-size tolerance for low-priced or fixed-tick assets; percentage works well for equities.
 - Watch performance with dense swing series: if you detect thousands of swings, lower `maxSwingPointsForTrendline` or raise the reversal/plateau thresholds to avoid combinatorial explosions.

--- a/Trendlines-and-Swing-Points.md
+++ b/Trendlines-and-Swing-Points.md
@@ -55,7 +55,7 @@ charts.display(plan);
 Use fractals when you want visually obvious turning points and don’t mind waiting a few bars for confirmation.
 
 ```java
-// 7-bar symmetric window that tolerates one equal neighbor on each side
+// 7-bar symmetric window that tolerates one additional equal bar in the plateau
 RecentFractalSwingHighIndicator majorHighs = new RecentFractalSwingHighIndicator(high, 7, 7, 1);
 int latestHighIndex = majorHighs.getLatestSwingHighIndex(series.getEndIndex());
 ```


### PR DESCRIPTION
## Summary

- document OHLC-aware ZigZag confirmation and candidate-anchored dynamic thresholds
- clarify fractal plateau handling and detector selection trade-offs
- add slope-change and tolerant multi-scale consensus APIs to the Elliott guide and inventory

Companion documentation for ta4j/ta4j#1560.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Elliott Wave swing-detection guidance with slope-change and multi-scale consensus options.
  * Added examples for configuring slope-change detectors and combining detector results.
  * Updated detector inventory descriptions, including tolerant quorum-based consensus.
  * Clarified fractal equal-bar handling and ZigZag inputs, confirmation behavior, reversal thresholds, and causal results.
  * Added guidance for selecting matching price sources and documented the new slope-change configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->