### PR TITLE
Document analog and rolling conformal forecasts

### DIFF
--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -6,6 +6,8 @@ Use them for probabilistic filters, sizing, risk limits, chart overlays, and out
 
 For reusable state contracts and feature schemas, see [Forecast State Estimation](Forecast-State-Estimation.md). Applications upgrading from 0.23.0 should read [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
+For detailed analog and rolling calibration tuning, see [Forecast Projection Models](Forecast-Projection-Models.md).
+
 ## Quick Start: Exact Monte Carlo Prices
 
 ```java
@@ -31,6 +33,24 @@ Indicator<Num> downsideSeries = prices.quantile(0.05);
 `MonteCarloPriceForecastIndicator` infers the price source when the state uses `LogReturnIndicator`. It converts every simulated cumulative return to a terminal price before calculating any moment or quantile. Mean, median, standard deviation, and quantiles therefore describe the same empirical price paths.
 
 The shortest constructor uses a 30-observation EWMA state, one or five bars as requested, 1,000 paths, a 252-return lookback, seed `42`, standardized empirical shocks, constant path volatility, and quantiles `0.05`, `0.25`, `0.5`, `0.75`, and `0.95`.
+
+## Quick Start: Analog Returns With Rolling Calibration
+
+```java
+LogReturnIndicator returns = new LogReturnIndicator(series);
+ReturnForecastStateIndicator<ReturnForecastState> states =
+        new EwmaReturnForecastStateIndicator(returns);
+AnalogReturnProjectionIndicator<ReturnForecastState> analog =
+        new AnalogReturnProjectionIndicator<>(states, 5);
+RollingConformalForecastProjectionIndicator calibrated =
+        RollingConformalForecastProjectionIndicator
+                .cumulativeLogReturnBuilder(analog, returns)
+                .build();
+
+Forecast result = calibrated.getValue(series.getEndIndex());
+```
+
+Analog projection uses only candidates whose complete five-bar outcomes have matured, fits feature standardization from historical candidates only, and reports selected neighbors as empirical support. The conformal wrapper remains unavailable until 30 valid historical forecasts mature, then widens lower and upper quantiles while preserving the analog mean, median, standard deviation, and support.
 
 ## Forecast Semantics
 
@@ -161,6 +181,8 @@ Common unavailable causes:
 - Factory coercion is non-finite, overflows primitive representation, or underflows a nonzero value to primitive zero.
 - Any configured Monte Carlo terminal path is non-finite. The whole empirical projection is unavailable; paths are never silently dropped.
 - The central fields of a lognormal approximation require an exponent magnitude above `700`. An overflowing optional tail is omitted while usable central fields remain.
+- Analog history has too few fully matured neighbors, its schema differs from log-return state representation, or a feature cannot be represented as a finite primitive value.
+- Rolling conformal history has fewer than the configured minimum valid scores, base forecast metadata is inconsistent, or positive widening would contradict a zero-dispersion base summary.
 
 Always check `isStable()` when inspecting a raw summary. Point adapters are safer for normal ta4j rule composition because unavailable values become `NaN.NaN`.
 
@@ -174,6 +196,8 @@ Always check `isStable()` when inspecting a raw summary. Point adapters are safe
 | --- | --- | --- |
 | Exact simulated price distribution | `MonteCarloPriceForecastIndicator` | Transforming summary moments after simulation. |
 | Cumulative log-return distribution | `MonteCarloReturnProjectionIndicator` | Treating returns as prices. |
+| State-conditioned empirical log returns | `AnalogReturnProjectionIndicator` | Letting current features influence training standardization. |
+| Rolling tail calibration | `RollingConformalForecastProjectionIndicator` | Counting calibration rows as forecast support. |
 | Price approximation from moments only | `LognormalApproximationPriceForecastIndicator` | Calling it empirical support. |
 | Point value in a rule | `projection.median()`, `.mean()`, or `.quantile(p)` | Reimplementing unstable checks. |
 | Empirical custom model output | `Forecast.ofSamples(...)` | Claiming analytic support. |
@@ -185,6 +209,8 @@ Always check `isStable()` when inspecting a raw summary. Point adapters are safe
 | --- | --- | --- |
 | `EwmaReturnForecastStateIndicator` | `forecast` | Default return-moment state estimator. |
 | `MonteCarloReturnProjectionIndicator` | `forecast` | Exact empirical cumulative log-return projection. |
+| `AnalogReturnProjectionIndicator` | `forecast` | State-conditioned weighted empirical log-return projection. |
+| `RollingConformalForecastProjectionIndicator` | `forecast` | Matured-error tail calibration that preserves base support. |
 | `MonteCarloPriceForecastIndicator` | `forecast` | Exact empirical terminal-price projection. |
 | `Forecast` / `ForecastSupport` | `forecast.projection` | Numeric distribution summary and provenance. |
 | `ForecastProjectionIndicator` | `forecast.projection` | Horizon-aware forecast indicator with point adapters. |
@@ -196,6 +222,7 @@ Always check `isStable()` when inspecting a raw summary. Point adapters are safe
 ## Related Guides
 
 - [Forecast State Estimation](Forecast-State-Estimation.md)
+- [Forecast Projection Models](Forecast-Projection-Models.md)
 - [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231)
 - [Indicators Inventory](Indicators-Inventory.md)
 - [Walk-Forward Research](Walk-Forward-Research.md)

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -50,7 +50,7 @@ RollingConformalForecastProjectionIndicator calibrated =
 Forecast result = calibrated.getValue(series.getEndIndex());
 ```
 
-Analog projection uses only candidates whose complete five-bar outcomes have matured, fits feature standardization from historical candidates only, and reports selected neighbors as empirical support. The conformal wrapper remains unavailable until 30 valid historical forecasts mature, then widens lower and upper quantiles while preserving the analog mean, median, standard deviation, and support.
+Analog projection uses only post-warm-up candidates whose complete five-bar outcomes have matured, fits feature standardization from historical candidates only, and reports selected neighbors as empirical support. The conformal wrapper remains unavailable until at least 30 valid historical forecasts mature and the finite-sample coverage rank is attainable, then widens lower and upper quantiles while preserving the analog mean, median, standard deviation, and support.
 
 ## Forecast Semantics
 

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -42,7 +42,7 @@ ReturnForecastStateIndicator<ReturnForecastState> states =
         new EwmaReturnForecastStateIndicator(returns);
 AnalogReturnProjectionIndicator<ReturnForecastState> analog =
         new AnalogReturnProjectionIndicator<>(states, 5);
-RollingConformalForecastProjectionIndicator calibrated =
+ReturnForecastProjectionIndicator calibrated =
         RollingConformalForecastProjectionIndicator
                 .cumulativeLogReturnBuilder(analog, returns)
                 .build();
@@ -50,7 +50,7 @@ RollingConformalForecastProjectionIndicator calibrated =
 Forecast result = calibrated.getValue(series.getEndIndex());
 ```
 
-Analog projection uses only post-warm-up candidates whose complete five-bar outcomes have matured, fits feature standardization from historical candidates only, and reports selected neighbors as empirical support. The conformal wrapper remains unavailable until at least 30 valid historical forecasts mature and the finite-sample coverage rank is attainable, then widens lower and upper quantiles while preserving the analog mean, median, standard deviation, and support.
+Analog projection uses only post-warm-up candidates whose complete five-bar outcomes have matured, fits feature standardization from historical candidates only, and reports selected neighbors as empirical support. The conformal wrapper remains unavailable until at least 30 valid historical forecasts mature and the finite-sample coverage rank is attainable, then widens lower and upper quantiles while preserving the analog mean, median, standard deviation, support, and semantic return-projection contract.
 
 ## Forecast Semantics
 
@@ -182,7 +182,7 @@ Common unavailable causes:
 - Any configured Monte Carlo terminal path is non-finite. The whole empirical projection is unavailable; paths are never silently dropped.
 - The central fields of a lognormal approximation require an exponent magnitude above `700`. An overflowing optional tail is omitted while usable central fields remain.
 - Analog history has too few fully matured neighbors, its schema differs from log-return state representation, or a feature cannot be represented as a finite primitive value.
-- Rolling conformal history has fewer than the configured minimum valid scores, base forecast metadata is inconsistent, or positive widening would contradict a zero-dispersion base summary.
+- Rolling conformal history has fewer than the configured minimum valid scores, base forecast metadata is inconsistent, no non-median tail quantile is configured, or positive widening would contradict a zero-dispersion base summary.
 
 Always check `isStable()` when inspecting a raw summary. Point adapters are safer for normal ta4j rule composition because unavailable values become `NaN.NaN`.
 

--- a/Forecast-Projection-Models.md
+++ b/Forecast-Projection-Models.md
@@ -36,6 +36,18 @@ AnalogReturnProjectionIndicator<ReturnForecastState> analog =
 
 Use `builder(ForecastStateIndicator<S>, ReturnIndicator)` only when a custom state source cannot expose its return stream through `ReturnForecastStateIndicator<S>`.
 
+```java
+ForecastStateIndicator<RegimeReturnState> regimeStates = ...;
+ReturnIndicator logReturns = ...;
+AnalogReturnProjectionIndicator<RegimeReturnState> analog =
+        AnalogReturnProjectionIndicator.builder(regimeStates, logReturns)
+                .featureExtractor(ForecastFeatureExtractors
+                        .meanVolatility(ReturnRepresentation.LOG))
+                .build();
+```
+
+`RegimeReturnState` implements `ReturnMomentState`; the explicit return stream supplies the matured forward labels while the state remains free to carry model-specific fields.
+
 | Setting | Default | Operator intent |
 | --- | --- | --- |
 | `horizon(...)` | `1` | Match the forward-return label to the holding period. |
@@ -52,7 +64,7 @@ Use analog projection when state similarity has an interpretable historical mean
 
 ## Rolling Conformal Calibration
 
-`RollingConformalForecastProjectionIndicator` wraps any numeric forecast and widens its configured tails using recent absolute median errors. It preserves the base mean, median, standard deviation, horizon, decision index, and support. Calibration rows are not samples and never replace base provenance.
+`RollingConformalForecastProjectionIndicator` wraps a numeric forecast with at least one configured non-median quantile and widens its tails using recent absolute median errors. It preserves the base mean, median, standard deviation, horizon, decision index, and support. Calibration rows are not samples and never replace base provenance.
 
 ### Generic realized values
 
@@ -66,7 +78,7 @@ The realized value for a decision is `closePrice.getValue(decision + horizon)`.
 ### Cumulative log returns
 
 ```java
-RollingConformalForecastProjectionIndicator calibrated =
+ReturnForecastProjectionIndicator calibrated =
         RollingConformalForecastProjectionIndicator
                 .cumulativeLogReturnBuilder(analog, returns)
                 .targetCoverage(0.95)
@@ -75,7 +87,7 @@ RollingConformalForecastProjectionIndicator calibrated =
                 .build();
 ```
 
-This path validates that both the base forecast and realized stream use `ReturnRepresentation.LOG`, then sums returns from `decision + 1` through `decision + horizon`.
+This path validates that both the base forecast and realized stream use `ReturnRepresentation.LOG`, sums returns from `decision + 1` through `decision + horizon`, and preserves `ReturnForecastProjectionIndicator` so downstream composition remains representation-aware.
 
 | Setting | Default | Operator intent |
 | --- | --- | --- |
@@ -101,6 +113,7 @@ Unavailable results include:
 - too few analog neighbors or calibration scores remain after validation;
 - the calibration window cannot attain the requested finite-sample rank;
 - weighted numeric normalization cannot be represented by the owning `NumFactory`;
+- the current base forecast has no configured non-median quantile to widen;
 - a positive conformal radius would widen a zero-dispersion base forecast.
 
 Always branch on `forecast.isStable()` when reading a raw summary. Point adapters such as `projection.quantile(0.05)` emit `NaN.NaN` for unavailable forecasts.

--- a/Forecast-Projection-Models.md
+++ b/Forecast-Projection-Models.md
@@ -46,7 +46,7 @@ Use `builder(ForecastStateIndicator<S>, ReturnIndicator)` only when a custom sta
 | `standardizeFeatures(...)` | `true` | Fit per-feature scale from eligible candidates only. |
 | `quantiles(...)` | `0.05, 0.25, 0.5, 0.75, 0.95` | Request only probabilities consumed downstream. |
 
-For decision `i`, candidate `j` is eligible only when `j + horizon <= i`. Its feature vector and complete forward return must be usable. Standardization is fit without the current state, so the query never influences training scale. Euclidean distances sort by distance and then source index. Normalized `exp(-distance)` weights drive the mean, population variance, and weighted empirical quantiles.
+For decision `i`, candidate `j` is eligible only when `j + horizon <= i`. Its feature vector and complete forward return must be usable and outside both upstream indicators' unstable windows. The lookback counts matured candidate decision rows regardless of horizon. Standardization is fit without the current state, so the query never influences training scale. Euclidean distances sort by distance and then source index. Normalized `exp(-distance)` weights drive the mean, population variance, and weighted empirical quantiles; scaled moment arithmetic avoids avoidable overflow for finite extreme returns.
 
 Use analog projection when state similarity has an interpretable historical meaning and an empirical neighbor distribution is useful. Do not use it when the history has too few comparable regimes, the schema mixes representations, or standardizing the chosen raw features cannot make their distances meaningful.
 
@@ -81,15 +81,15 @@ This path validates that both the base forecast and realized stream use `ReturnR
 | --- | --- | --- |
 | `targetCoverage(...)` | `0.90` | Select the finite-sample absolute-error rank. |
 | `calibrationWindow(...)` | `252` | Inspect this many recent matured decision rows. |
-| `minimumCalibrationCount(...)` | `30` | Stay unavailable until enough valid scores mature. |
+| `minimumCalibrationCount(...)` | `30` | Set the lower bound on valid scores; the requested rank may require more. |
 
-With `n` valid scores, the calibration radius is order statistic `ceil((n + 1) * coverage)`, capped at `n`. Lower quantiles subtract that radius, upper quantiles add it, and the median remains unchanged. This is intentionally called rolling conformal calibration, not Adaptive Conformal Inference: no online coverage-rate update is claimed.
+With `n` valid scores, the calibration radius is order statistic `ceil((n + 1) * coverage)`. The wrapper stays unavailable until that rank is attainable, even when the configured minimum is smaller, and rejects a calibration window that can never attain it. Lower quantiles subtract that radius, upper quantiles add it, and the median remains unchanged. This is intentionally called rolling conformal calibration, not Adaptive Conformal Inference: no online coverage-rate update is claimed.
 
 Use the wrapper when recent, matured residuals are relevant to operational tail width and preserving the base model is important. Do not use it as a cure for a biased or semantically mismatched base model, and do not interpret target coverage as a guarantee under arbitrary distribution shift.
 
 ## Warm-Up and Failure Modes
 
-Analog output stays unavailable until the current state and enough fully matured candidates are usable. Rolling conformal output stays unavailable until its base forecast is stable and the minimum valid calibration count has matured. Both can recover at later indexes.
+Analog output stays unavailable until the current state and enough fully matured, post-warm-up candidates are usable. Rolling conformal output stays unavailable until its base forecast is stable and enough valid scores exist for both the configured minimum and requested finite-sample rank. Both can recover at later indexes.
 
 Unavailable results include:
 
@@ -99,6 +99,7 @@ Unavailable results include:
 - indicators do not share the same underlying `BarSeries`;
 - primitive feature conversion overflows or a nonzero value underflows to zero;
 - too few analog neighbors or calibration scores remain after validation;
+- the calibration window cannot attain the requested finite-sample rank;
 - weighted numeric normalization cannot be represented by the owning `NumFactory`;
 - a positive conformal radius would widen a zero-dispersion base forecast.
 

--- a/Forecast-Projection-Models.md
+++ b/Forecast-Projection-Models.md
@@ -1,0 +1,121 @@
+# Forecast Projection Models
+
+ta4j 0.23.1 adds two complementary projection tools: analog forecasting creates an empirical return distribution from similar historical states, and rolling conformal calibration adjusts an existing forecast's tails using matured forecast errors. Both are causal `Indicator<Forecast>` implementations and return `ForecastSupport.Unavailable` rather than inventing a partial distribution.
+
+## Analog Return Projection
+
+`AnalogReturnProjectionIndicator<S extends ReturnMomentState>` answers: “What happened after historical states that looked like this one?” It projects cumulative log returns and reports `ForecastSupport.empirical(selectedNeighborCount)`.
+
+### Default construction
+
+```java
+LogReturnIndicator returns = new LogReturnIndicator(series);
+ReturnForecastStateIndicator<ReturnForecastState> states =
+        new EwmaReturnForecastStateIndicator(returns);
+AnalogReturnProjectionIndicator<ReturnForecastState> analog =
+        new AnalogReturnProjectionIndicator<>(states);
+```
+
+The return-specific state contract is the joyful path: the projection infers the source return indicator, validates shared-series and log-return semantics, and uses the representation-bound `[mean, volatility]` schema.
+
+### Advanced construction
+
+```java
+AnalogReturnProjectionIndicator<ReturnForecastState> analog =
+        AnalogReturnProjectionIndicator.builder(states)
+                .horizon(5)
+                .lookbackBarCount(504)
+                .neighborCount(40)
+                .minimumNeighborCount(15)
+                .featureExtractor(ForecastFeatureExtractors
+                        .driftVolatility(ReturnRepresentation.LOG))
+                .standardizeFeatures(true)
+                .quantiles(0.01, 0.05, 0.5, 0.95, 0.99)
+                .build();
+```
+
+Use `builder(ForecastStateIndicator<S>, ReturnIndicator)` only when a custom state source cannot expose its return stream through `ReturnForecastStateIndicator<S>`.
+
+| Setting | Default | Operator intent |
+| --- | --- | --- |
+| `horizon(...)` | `1` | Match the forward-return label to the holding period. |
+| `lookbackBarCount(...)` | `252` | Bound historical candidate decisions. |
+| `neighborCount(...)` | `30` | Cap the empirical states represented by the forecast. |
+| `minimumNeighborCount(...)` | `5` | Refuse forecasts that rely on too little comparable history. |
+| `featureExtractor(...)` | log `[mean, volatility]` | Choose a fixed schema whose representation and units match the model. |
+| `standardizeFeatures(...)` | `true` | Fit per-feature scale from eligible candidates only. |
+| `quantiles(...)` | `0.05, 0.25, 0.5, 0.75, 0.95` | Request only probabilities consumed downstream. |
+
+For decision `i`, candidate `j` is eligible only when `j + horizon <= i`. Its feature vector and complete forward return must be usable. Standardization is fit without the current state, so the query never influences training scale. Euclidean distances sort by distance and then source index. Normalized `exp(-distance)` weights drive the mean, population variance, and weighted empirical quantiles.
+
+Use analog projection when state similarity has an interpretable historical meaning and an empirical neighbor distribution is useful. Do not use it when the history has too few comparable regimes, the schema mixes representations, or standardizing the chosen raw features cannot make their distances meaningful.
+
+## Rolling Conformal Calibration
+
+`RollingConformalForecastProjectionIndicator` wraps any numeric forecast and widens its configured tails using recent absolute median errors. It preserves the base mean, median, standard deviation, horizon, decision index, and support. Calibration rows are not samples and never replace base provenance.
+
+### Generic realized values
+
+```java
+RollingConformalForecastProjectionIndicator calibrated =
+        new RollingConformalForecastProjectionIndicator(priceForecast, closePrice);
+```
+
+The realized value for a decision is `closePrice.getValue(decision + horizon)`.
+
+### Cumulative log returns
+
+```java
+RollingConformalForecastProjectionIndicator calibrated =
+        RollingConformalForecastProjectionIndicator
+                .cumulativeLogReturnBuilder(analog, returns)
+                .targetCoverage(0.95)
+                .calibrationWindow(504)
+                .minimumCalibrationCount(60)
+                .build();
+```
+
+This path validates that both the base forecast and realized stream use `ReturnRepresentation.LOG`, then sums returns from `decision + 1` through `decision + horizon`.
+
+| Setting | Default | Operator intent |
+| --- | --- | --- |
+| `targetCoverage(...)` | `0.90` | Select the finite-sample absolute-error rank. |
+| `calibrationWindow(...)` | `252` | Inspect this many recent matured decision rows. |
+| `minimumCalibrationCount(...)` | `30` | Stay unavailable until enough valid scores mature. |
+
+With `n` valid scores, the calibration radius is order statistic `ceil((n + 1) * coverage)`, capped at `n`. Lower quantiles subtract that radius, upper quantiles add it, and the median remains unchanged. This is intentionally called rolling conformal calibration, not Adaptive Conformal Inference: no online coverage-rate update is claimed.
+
+Use the wrapper when recent, matured residuals are relevant to operational tail width and preserving the base model is important. Do not use it as a cure for a biased or semantically mismatched base model, and do not interpret target coverage as a guarantee under arbitrary distribution shift.
+
+## Warm-Up and Failure Modes
+
+Analog output stays unavailable until the current state and enough fully matured candidates are usable. Rolling conformal output stays unavailable until its base forecast is stable and the minimum valid calibration count has matured. Both can recover at later indexes.
+
+Unavailable results include:
+
+- state, forecast, or horizon metadata does not match the queried decision;
+- state moments, feature extraction, realized values, or cumulative returns are null or non-finite;
+- schema and return representation differ;
+- indicators do not share the same underlying `BarSeries`;
+- primitive feature conversion overflows or a nonzero value underflows to zero;
+- too few analog neighbors or calibration scores remain after validation;
+- weighted numeric normalization cannot be represented by the owning `NumFactory`;
+- a positive conformal radius would widen a zero-dispersion base forecast.
+
+Always branch on `forecast.isStable()` when reading a raw summary. Point adapters such as `projection.quantile(0.05)` emit `NaN.NaN` for unavailable forecasts.
+
+## Runnable Example
+
+`ta4jexamples.analysis.forecast.RollingConformalForecastExample` loads the committed Coinbase BTC-USD daily resource, builds a five-day analog return forecast, and calibrates it with matured five-day cumulative log returns.
+
+```bash
+./mvnw -pl ta4j-examples -am install
+./mvnw -pl ta4j-examples exec:java \
+  -Dexec.mainClass=ta4jexamples.analysis.forecast.RollingConformalForecastExample
+```
+
+## Related Guides
+
+- [Forecast Indicators](Forecast-Indicators.md)
+- [Forecast State Estimation](Forecast-State-Estimation.md)
+- [Walk-Forward Research](Walk-Forward-Research.md)

--- a/Forecast-State-Estimation.md
+++ b/Forecast-State-Estimation.md
@@ -93,6 +93,8 @@ extractor.extractInto(state.getValue(index), row, 4);
 
 Feature values remain in raw declared units. Consumers such as analog-distance models own training-window standardization; the extractor does not hide scaling assumptions.
 
+`AnalogReturnProjectionIndicator` validates the schema representation against each candidate's `ReturnMoments`, rejects inconsistent feature dimensions or non-finite primitive values, and fits optional standardization from matured historical candidates only. The current query state is never part of that fit. See [Forecast Projection Models](Forecast-Projection-Models.md) for construction and tuning.
+
 ## Forecast Construction and Provenance
 
 State observation counts are training metadata. Forecast support describes the output distribution:

--- a/Home.md
+++ b/Home.md
@@ -25,6 +25,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **Broader analysis surface**: Recent current-master additions include `SharpeRatioCriterion`, `SortinoRatioCriterion`, `CalmarRatioCriterion`, `OmegaRatioCriterion`, and volume pressure indicators such as `ForceIndexIndicator`, `EaseOfMovementIndicator`, and `KlingerVolumeOscillatorIndicator`.
 - **Forecast foundation targeting 0.23.1**: Num-only summaries now declare empirical or analytic support, return estimators compose canonical `ReturnMoments`, and feature vectors publish representation-bound schemas.
 - **Exact and explicit price models**: `MonteCarloPriceForecastIndicator` summarizes transformed terminal-price paths exactly; `LognormalApproximationPriceForecastIndicator` is the clearly named analytic alternative when paths are unavailable.
+- **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here
@@ -47,6 +48,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Technical Indicators](Technical-indicators.md)** - Indicator composition and caching
 - **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, point projections, and strategy filters
 - **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical return moments, representation-bound schemas, and provenance-aware summaries
+- **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts
 

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -552,7 +552,7 @@ Forecast types live under `org.ta4j.core.indicators.forecast`. The root package 
 | `org.ta4j.core.indicators.forecast` | **MonteCarloPriceForecastIndicator** | Exact terminal-path price simulation with inferred or explicit price source and advanced builder. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloReturnProjectionIndicator** | Monte Carlo cumulative log-return projection indicator with standard constructors and a builder for advanced configuration. |
 | `org.ta4j.core.indicators.forecast` | **AnalogReturnProjectionIndicator&lt;S&gt;** | Weighted empirical cumulative log-return projection from matured, schema-compatible historical states. |
-| `org.ta4j.core.indicators.forecast` | **RollingConformalForecastProjectionIndicator** | Rolling finite-sample tail calibration over matured realized values while preserving base support and central fields. |
+| `org.ta4j.core.indicators.forecast` | **RollingConformalForecastProjectionIndicator** | Rolling finite-sample tail calibration over matured realized values; cumulative log-return calibration preserves semantic return typing and tail-less inputs remain unavailable. |
 | `org.ta4j.core.indicators.forecast.adapters` | **LognormalApproximationPriceForecastIndicator** | Explicit analytic lognormal moment-match from a cumulative log-return summary. |
 | `org.ta4j.core.indicators.forecast.projection` | **ForwardForecastIndicator** | Adapts a forecast projection indicator into a point forecast indicator. |
 | `org.ta4j.core.indicators.forecast.projection` | **Forecast** | Num-only immutable distribution summary with empirical samples, validated builder, affine transforms, and provenance. |

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -529,7 +529,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 ## 15. Forecasting
 
-Forecast types live under `org.ta4j.core.indicators.forecast`. The root package holds primary indicators, while `forecast.state`, `forecast.projection`, and `forecast.adapters` hold composition contracts and the explicitly analytic bridge. The 0.23.1 foundation corrects the initial 0.23.0 API with Num-only summaries, support provenance, exact terminal-price simulation, minimal state, return-moment composition, and representation-bound feature schemas. For tutorial and migration guidance, see [Forecast Indicators](Forecast-Indicators.md).
+Forecast types live under `org.ta4j.core.indicators.forecast`. The root package holds primary indicators, while `forecast.state`, `forecast.projection`, and `forecast.adapters` hold composition contracts and the explicitly analytic bridge. The 0.23.1 surface includes Num-only summaries, support provenance, exact terminal-price simulation, minimal state, return-moment composition, representation-bound feature schemas, state-conditioned analog projection, and rolling conformal calibration. For tutorial and migration guidance, see [Forecast Indicators](Forecast-Indicators.md).
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
@@ -551,16 +551,18 @@ Forecast types live under `org.ta4j.core.indicators.forecast`. The root package 
 | `org.ta4j.core.indicators.forecast.projection` | **ReturnForecastProjectionIndicator** | Interface for return projections that declare their return representation. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloPriceForecastIndicator** | Exact terminal-path price simulation with inferred or explicit price source and advanced builder. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloReturnProjectionIndicator** | Monte Carlo cumulative log-return projection indicator with standard constructors and a builder for advanced configuration. |
+| `org.ta4j.core.indicators.forecast` | **AnalogReturnProjectionIndicator&lt;S&gt;** | Weighted empirical cumulative log-return projection from matured, schema-compatible historical states. |
+| `org.ta4j.core.indicators.forecast` | **RollingConformalForecastProjectionIndicator** | Rolling finite-sample tail calibration over matured realized values while preserving base support and central fields. |
 | `org.ta4j.core.indicators.forecast.adapters` | **LognormalApproximationPriceForecastIndicator** | Explicit analytic lognormal moment-match from a cumulative log-return summary. |
 | `org.ta4j.core.indicators.forecast.projection` | **ForwardForecastIndicator** | Adapts a forecast projection indicator into a point forecast indicator. |
 | `org.ta4j.core.indicators.forecast.projection` | **Forecast** | Num-only immutable distribution summary with empirical samples, validated builder, affine transforms, and provenance. |
 
 **Short usage**
 - **What it is:** A forecasting layer that estimates future return or price distributions from historical returns and rolling volatility state.
-- **Theory:** The standard pipeline converts prices to log returns, estimates canonical EWMA return moments, simulates terminal paths, and summarizes transformed price samples exactly.
+- **Theory:** Pipelines convert prices to semantic returns, estimate canonical state, then choose exact simulation, state-conditioned analogs, or explicit analytic projection; rolling conformal calibration can widen an existing model's tails from matured errors.
 - **When to use:** Probabilistic research labels, forecast-aware filters, risk bounds, tail checks, and point projections exposed as regular ta4j indicators.
 - **When not to use:** As a guaranteed target, without warm-up checks, or as a replacement for realistic execution and out-of-sample validation.
-- See also: [Forecast Indicators](Forecast-Indicators.md).
+- See also: [Forecast Indicators](Forecast-Indicators.md) and [Forecast Projection Models](Forecast-Projection-Models.md).
 
 ---
 

--- a/Migration-and-Version-Compatibility.md
+++ b/Migration-and-Version-Compatibility.md
@@ -42,7 +42,7 @@ Migration order:
 4. Compose return state around `ReturnMoments` and bind feature extractors to the correct `ReturnRepresentation`.
 5. Assert `ForecastProjectionIndicator.getHorizon()` and forecast metadata in custom projections.
 
-Training and calibration row counts belong to model-specific state or diagnostics, not `Forecast.sampleCount()`. Conformal wrappers preserve base support; later analog projections use empirical neighbor support.
+Training and calibration row counts belong to model-specific state or diagnostics, not `Forecast.sampleCount()`. `RollingConformalForecastProjectionIndicator` preserves base support; `AnalogReturnProjectionIndicator` reports selected neighbors as empirical support.
 
 ## Migration lane
 
@@ -67,3 +67,4 @@ Training and calibration row counts belong to model-specific state or diagnostic
 - [Usage Examples](Usage-examples.md)
 - [Forecast Indicators](Forecast-Indicators.md)
 - [Forecast State Estimation](Forecast-State-Estimation.md)
+- [Forecast Projection Models](Forecast-Projection-Models.md)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **Broader analysis surface**: Recent current-master additions include `SharpeRatioCriterion`, `SortinoRatioCriterion`, `CalmarRatioCriterion`, `OmegaRatioCriterion`, and volume pressure indicators such as `ForceIndexIndicator`, `EaseOfMovementIndicator`, and `KlingerVolumeOscillatorIndicator`.
 - **Forecast foundation targeting 0.23.1**: Num-only summaries now declare empirical or analytic support, return estimators compose canonical `ReturnMoments`, and feature vectors publish representation-bound schemas.
 - **Exact and explicit price models**: `MonteCarloPriceForecastIndicator` summarizes transformed terminal-price paths exactly; `LognormalApproximationPriceForecastIndicator` is the clearly named analytic alternative when paths are unavailable.
+- **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here
@@ -47,6 +48,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Technical Indicators](Technical-indicators.md)** - Indicator composition and caching
 - **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, point projections, and strategy filters
 - **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical return moments, representation-bound schemas, and provenance-aware summaries
+- **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts
 

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -10,7 +10,7 @@ Technical indicators (a.k.a. *technicals*) transform price/volume data into stru
 | Momentum & Oscillators | RSI family, NetMomentum, MACD/MACDV, MACD-V momentum states, KST, Stochastics, CMO, ROC. | This page |
 | Regime & signal quality | TrendScore, TrendConclusion, Compression, EntryEdge, EdgeDecaySlope, StretchZScore. | This page |
 | Advanced correlation | Kendall tau, Spearman, lagged/distance/regime-segmented correlation, mutual information. | [Indicators Inventory §11](Indicators-Inventory.md#11-statistics--numeric) |
-| Forecasting | 0.23.1 foundation: provenance-aware Num forecasts, canonical return moments, exact Monte Carlo return/price paths, schemas, point projections, and an explicit analytic lognormal approximation. | [Forecast Indicators](Forecast-Indicators.md) |
+| Forecasting | Provenance-aware Num forecasts, canonical return moments, exact Monte Carlo paths, state-conditioned analogs, rolling conformal calibration, schemas, point projections, and an explicit analytic lognormal approximation. | [Forecast Indicators](Forecast-Indicators.md), [Forecast Projection Models](Forecast-Projection-Models.md) |
 | Volatility & Bands | ATR, Donchian, Bollinger, Keltner, Average True Range trailing stops. | [Bar Series & Bars](Bar-series-and-bars.md) (for ATR-based stops) |
 | Volume & Breadth | OBV, VWAP/VWMA, Accumulation/Distribution, Chaikin, Force Index, Ease of Movement, Klinger Volume Oscillator. | Indicators package |
 | Market Structure (VWAP/SR/Wyckoff) | Anchored VWAP, VWAP bands/z-score, price clusters, bounce counts, KDE volume profile, Wyckoff phase/cycle detection. | [VWAP, Support/Resistance, and Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md) |

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -23,6 +23,7 @@
 - [Indicators Inventory](Indicators-Inventory.md)
 - [Forecast Indicators](Forecast-Indicators.md)
 - [Forecast State Estimation](Forecast-State-Estimation.md)
+- [Forecast Projection Models](Forecast-Projection-Models.md)
 - [Forecast 0.23.1 Migration](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231)
 - [Moving Average Indicators](Moving-Average-Indicators.md)
 - [Bill Williams Indicators](Bill-Williams-Indicators.md)


### PR DESCRIPTION
Adds the paired Phase 2 operator documentation for ta4j/ta4j#1568.

- makes `Forecast-Indicators.md` the projection quick-start hub
- documents default and advanced analog/conformal composition, tuning, warm-up, and failure modes
- adds inventory, navigation, migration, and runnable BTC example guidance