### PR TITLE
Document rough volatility forecast state

### DIFF
--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -168,6 +168,18 @@ EwmaReturnForecastStateIndicator state =
 
 Prefer zero drift unless a rolling drift assumption has earned its place in out-of-sample testing.
 
+## Rough-Volatility State
+
+`RoughVolatilityForecastStateIndicator` is the constructor-first rich-state path:
+
+```java
+RoughVolatilityForecastStateIndicator rough =
+        new RoughVolatilityForecastStateIndicator(returns);
+RoughVolatilityForecastState state = rough.getValue(index);
+```
+
+It reuses canonical EWMA moments and adds bounded log-variogram Hurst, population dispersion of the logarithmic volatility proxy, and five cumulative horizon variances by default. The representation-bound `ForecastFeatureExtractors.roughVolatility()` schema exposes `[mean, volatility, roughness_hurst, vol_of_vol]` for models that intentionally use those diagnostics. See [Forecast State Estimation](Forecast-State-Estimation.md#rough-volatility-state) for advanced tuning, exact field semantics, warm-up, recovery, and when to prefer the smaller EWMA state.
+
 ## Warm-Up, Recovery, and Numeric Failures
 
 A built-in projection returns `ForecastSupport.Unavailable` with `NaN.NaN` summary values until all prerequisites are valid. It can recover at a later index after invalid inputs leave the required window.
@@ -175,6 +187,7 @@ A built-in projection returns `ForecastSupport.Unavailable` with `NaN.NaN` summa
 Common unavailable causes:
 
 - EWMA initialization or historical shock lookback is incomplete.
+- Rough-volatility EWMA, roughness, or vol-of-vol windows are incomplete or contain a non-finite return.
 - State index, return representation, stability, or `ReturnMoments` metadata does not match the query.
 - The price and return indicators do not share the same `BarSeries`.
 - A required return, state value, or decision price is non-finite; price is non-positive.

--- a/Forecast-Projection-Models.md
+++ b/Forecast-Projection-Models.md
@@ -48,6 +48,19 @@ AnalogReturnProjectionIndicator<RegimeReturnState> analog =
 
 `RegimeReturnState` implements `ReturnMomentState`; the explicit return stream supplies the matured forward labels while the state remains free to carry model-specific fields.
 
+Built-in rich return estimators keep the shorter return-specific builder path. For example, rough-volatility similarity is an explicit schema choice rather than a hidden change to analog defaults:
+
+```java
+RoughVolatilityForecastStateIndicator roughStates =
+        new RoughVolatilityForecastStateIndicator(returns);
+AnalogReturnProjectionIndicator<RoughVolatilityForecastState> roughAnalog =
+        AnalogReturnProjectionIndicator.builder(roughStates)
+                .featureExtractor(ForecastFeatureExtractors.roughVolatility())
+                .build();
+```
+
+The ordered raw features are `[mean, volatility, roughness_hurst, vol_of_vol]`. Candidate-only standardization remains owned by the analog model. Prefer the default `[mean, volatility]` schema unless roughness and vol-of-vol are intentional, tested similarity dimensions.
+
 | Setting | Default | Operator intent |
 | --- | --- | --- |
 | `horizon(...)` | `1` | Match the forward-return label to the holding period. |

--- a/Forecast-State-Estimation.md
+++ b/Forecast-State-Estimation.md
@@ -62,6 +62,58 @@ final class RegimeStateIndicator
 
 This preserves typed specialized fields while allowing existing return projections to consume the shared moments. A stable custom state must report the queried index, the indicator's return representation, at least one observation, finite moments, and non-negative variance.
 
+## Rough-Volatility State
+
+`RoughVolatilityForecastStateIndicator` is the built-in rich-state example for operators who need more than current return location and scale. It composes the same `ReturnMoments` used by EWMA with a bounded roughness estimate, log-volatility variability, and a cumulative variance term structure.
+
+```java
+LogReturnIndicator returns = new LogReturnIndicator(series);
+RoughVolatilityForecastStateIndicator states =
+        new RoughVolatilityForecastStateIndicator(returns);
+
+RoughVolatilityForecastState state = states.getValue(series.getEndIndex());
+if (state.isStable()) {
+    Num oneBarVariance = state.horizonVarianceForecasts().get(0);
+    Num fiveBarVariance = state.horizonVarianceForecasts().get(4);
+}
+```
+
+Advanced construction keeps the same semantic return source and changes only explicit model assumptions:
+
+```java
+RoughVolatilityForecastStateIndicator states =
+        RoughVolatilityForecastStateIndicator.builder(returns)
+                .initializationBarCount(90)
+                .decayFactor(0.97)
+                .driftMode(EwmaReturnForecastStateIndicator.DriftMode.ZERO)
+                .roughnessWindow(180)
+                .volOfVolWindow(90)
+                .horizon(10)
+                .build();
+```
+
+| Setting | Default | Operator intent |
+| --- | --- | --- |
+| `initializationBarCount(...)` | `60` | Valid returns required by the shared EWMA moments. |
+| `decayFactor(...)` | `0.94` | Persistence of current mean and canonical variance. |
+| `driftMode(...)` | `ZERO` | Forward drift assumption carried by the common moments. |
+| `roughnessWindow(...)` | `120` | History used by the log-variogram regression. |
+| `volOfVolWindow(...)` | `60` | Population dispersion window for the log-volatility proxy. |
+| `horizon(...)` | `5` | Number of cumulative variance horizons emitted. |
+
+| State field | Meaning |
+| --- | --- |
+| `moments()` | Stable log-return mean, drift, canonical variance, and observation provenance. |
+| `roughnessHurst()` | OLS log-variogram slope divided by two and clamped to `[0.01, 0.49]`. |
+| `volOfVol()` | Population standard deviation of `log(abs(return) + 1e-8)` over its configured window. |
+| `horizonVarianceForecasts()` | Immutable cumulative variances; entry `h - 1` is `currentVariance * h^(2H)`. |
+
+The first horizon variance is factory-coherent with the current canonical variance. The estimator uses lags one through ten, or all available lags for shorter configured windows, and floors each variogram at `1e-12` before taking its logarithm. These are deterministic state diagnostics, not a claim that returns follow a complete rough-volatility pricing model.
+
+The state remains unstable until EWMA initialization, the roughness window, and the vol-of-vol window are all complete and finite. A non-finite return resets availability for every affected rolling window; later indices recover automatically. Unstable state preserves the known observation count, uses `NaN.NaN` for specialized scalars, and exposes an empty variance list.
+
+Use rough-volatility state when changing volatility persistence or multi-horizon risk shape is part of the model. Prefer `EwmaReturnForecastStateIndicator` when current mean and variance are sufficient, the available history is short, or the extra dimensions have not earned their place in out-of-sample testing.
+
 ## Feature Schemas
 
 Feature vectors are representation-bound and self-describing. Choose a schema by modeling intent:
@@ -79,6 +131,7 @@ double[] values = extractor.features(state.getValue(index));
 | `meanVolatility(rep)` | `return-moments/mean-volatility` | `[mean, volatility]` | return, return | Similarity needs level and scale. |
 | `driftVolatility(rep)` | `return-moments/drift-volatility` | `[drift, volatility]` | return, return | The model intentionally uses forward drift. |
 | `meanDriftVariance(rep)` | `return-moments/mean-drift-variance` | `[mean, drift, variance]` | return, return, return squared | A model needs separate location assumptions and canonical variance. |
+| `roughVolatility()` | `rough-volatility/default` | `[mean, volatility, roughness_hurst, vol_of_vol]` | log-return, log-return, dimensionless, dimensionless | Similarity should include roughness and volatility variability. |
 
 Every schema has version `1`, its required return representation, a defensive ordered descriptor list, and `dimension()`. Unit names are `log-return`, `decimal-return`, `percentage-points`, or `multiplicative-return`; variance appends `^2`.
 

--- a/Home.md
+++ b/Home.md
@@ -26,6 +26,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **Forecast foundation targeting 0.23.1**: Num-only summaries now declare empirical or analytic support, return estimators compose canonical `ReturnMoments`, and feature vectors publish representation-bound schemas.
 - **Exact and explicit price models**: `MonteCarloPriceForecastIndicator` summarizes transformed terminal-price paths exactly; `LognormalApproximationPriceForecastIndicator` is the clearly named analytic alternative when paths are unavailable.
 - **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
+- **Composable rough-volatility state**: `RoughVolatilityForecastStateIndicator` keeps canonical return moments while adding bounded roughness, vol-of-vol, cumulative horizon variance, and an explicit analog feature schema.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here
@@ -47,7 +48,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Num](Num.md)** - Precision-aware numeric types such as `DoubleNum` and `DecimalNum`
 - **[Technical Indicators](Technical-indicators.md)** - Indicator composition and caching
 - **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, point projections, and strategy filters
-- **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical return moments, representation-bound schemas, and provenance-aware summaries
+- **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical and rough-volatility moments, representation-bound schemas, and provenance-aware summaries
 - **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -529,7 +529,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 ## 15. Forecasting
 
-Forecast types live under `org.ta4j.core.indicators.forecast`. The root package holds primary indicators, while `forecast.state`, `forecast.projection`, and `forecast.adapters` hold composition contracts and the explicitly analytic bridge. The 0.23.1 surface includes Num-only summaries, support provenance, exact terminal-price simulation, minimal state, return-moment composition, representation-bound feature schemas, state-conditioned analog projection, and rolling conformal calibration. For tutorial and migration guidance, see [Forecast Indicators](Forecast-Indicators.md).
+Forecast types live under `org.ta4j.core.indicators.forecast`. The root package holds primary indicators, while `forecast.state`, `forecast.projection`, and `forecast.adapters` hold composition contracts and the explicitly analytic bridge. The 0.23.1 surface includes Num-only summaries, support provenance, exact terminal-price simulation, minimal state, return-moment composition, representation-bound feature schemas, rough-volatility diagnostics, state-conditioned analog projection, and rolling conformal calibration. For tutorial and migration guidance, see [Forecast Indicators](Forecast-Indicators.md).
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
@@ -548,6 +548,8 @@ Forecast types live under `org.ta4j.core.indicators.forecast`. The root package 
 | `org.ta4j.core.indicators.forecast.state` | **ReturnForecastStateIndicator&lt;S&gt;** | Typed indicator interface for hidden state derived from a `ReturnIndicator`, including source and return representation. |
 | `org.ta4j.core.indicators.forecast` | **EwmaReturnForecastStateIndicator** | Builds return forecast state from a log-return `ReturnIndicator` using EWMA mean and variance. |
 | `org.ta4j.core.indicators.forecast.state` | **ReturnForecastState** | Default state record composing one validated `ReturnMoments` value. |
+| `org.ta4j.core.indicators.forecast` | **RoughVolatilityForecastStateIndicator** | Enriches shared EWMA log-return moments with bounded roughness, log-volatility vol-of-vol, and cumulative fractional horizon variances. |
+| `org.ta4j.core.indicators.forecast.state` | **RoughVolatilityForecastState** | Immutable rich return state containing canonical moments and typed rough-volatility diagnostics. |
 | `org.ta4j.core.indicators.forecast.projection` | **ReturnForecastProjectionIndicator** | Interface for return projections that declare their return representation. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloPriceForecastIndicator** | Exact terminal-path price simulation with inferred or explicit price source and advanced builder. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloReturnProjectionIndicator** | Monte Carlo cumulative log-return projection indicator with standard constructors and a builder for advanced configuration. |
@@ -559,7 +561,7 @@ Forecast types live under `org.ta4j.core.indicators.forecast`. The root package 
 
 **Short usage**
 - **What it is:** A forecasting layer that estimates future return or price distributions from historical returns and rolling volatility state.
-- **Theory:** Pipelines convert prices to semantic returns, estimate canonical state, then choose exact simulation, state-conditioned analogs, or explicit analytic projection; rolling conformal calibration can widen an existing model's tails from matured errors.
+- **Theory:** Pipelines convert prices to semantic returns, estimate canonical or rough-volatility state, then choose exact simulation, state-conditioned analogs, or explicit analytic projection; rolling conformal calibration can widen an existing model's tails from matured errors.
 - **When to use:** Probabilistic research labels, forecast-aware filters, risk bounds, tail checks, and point projections exposed as regular ta4j indicators.
 - **When not to use:** As a guaranteed target, without warm-up checks, or as a replacement for realistic execution and out-of-sample validation.
 - See also: [Forecast Indicators](Forecast-Indicators.md) and [Forecast Projection Models](Forecast-Projection-Models.md).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **Forecast foundation targeting 0.23.1**: Num-only summaries now declare empirical or analytic support, return estimators compose canonical `ReturnMoments`, and feature vectors publish representation-bound schemas.
 - **Exact and explicit price models**: `MonteCarloPriceForecastIndicator` summarizes transformed terminal-price paths exactly; `LognormalApproximationPriceForecastIndicator` is the clearly named analytic alternative when paths are unavailable.
 - **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
+- **Composable rough-volatility state**: `RoughVolatilityForecastStateIndicator` keeps canonical return moments while adding bounded roughness, vol-of-vol, cumulative horizon variance, and an explicit analog feature schema.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here
@@ -47,7 +48,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Num](Num.md)** - Precision-aware numeric types such as `DoubleNum` and `DecimalNum`
 - **[Technical Indicators](Technical-indicators.md)** - Indicator composition and caching
 - **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, point projections, and strategy filters
-- **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical return moments, representation-bound schemas, and provenance-aware summaries
+- **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical and rough-volatility moments, representation-bound schemas, and provenance-aware summaries
 - **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -105,12 +105,14 @@ ta4j's forecast package adds prediction-valued indicators for forward-looking re
 - `ReturnIndicator` marks indicators that semantically produce returns in a declared representation.
 - `EWMAIndicator` provides reusable explicit-decay smoothing for forecast and non-forecast workflows.
 - `EwmaReturnForecastStateIndicator` estimates canonical `ReturnMoments` from a log-return `ReturnIndicator`.
+- `RoughVolatilityForecastStateIndicator` composes those moments with bounded log-variogram roughness, log-volatility vol-of-vol, and cumulative horizon variance diagnostics.
 - `MonteCarloPriceForecastIndicator` transforms every simulated terminal return path before calculating exact empirical price summaries.
 - `MonteCarloReturnProjectionIndicator` simulates cumulative log-return distributions for return-space workflows or advanced tuning.
 - `LognormalApproximationPriceForecastIndicator` explicitly fits a coherent analytic lognormal distribution when terminal samples are unavailable.
 - `ForecastProjectionIndicator` declares `getHorizon()` and exposes point projections for normal ta4j rule composition.
 - `ForecastSupport` distinguishes unavailable, empirical-count, and named analytic output.
 - `ForecastFeatureSchema` binds primitive feature names, units, version, order, and return representation.
+- `ForecastFeatureExtractors.roughVolatility()` publishes the fixed `[mean, volatility, roughness_hurst, vol_of_vol]` shape for intentional rich-state model composition.
 
 Forecast indicators do not read future bars while producing `getValue(i)`. Use the configured horizon only when evaluating the forecast against later realized outcomes. See [Forecast Indicators](Forecast-Indicators.md) for setup, tuning, warm-up behavior, and strategy examples.
 


### PR DESCRIPTION
Documents ta4j/ta4j#1569.

- Add constructor-first and advanced rough-volatility state guides.
- Document field semantics, feature order and units, tuning, warm-up, recovery, and failure behavior.
- Extend the forecast quick start, projection composition guide, inventory, technical overview, Home, and synchronized README.