### PR TITLE
Document online change-point forecast state

### DIFF
--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -190,9 +190,9 @@ OnlineChangePointForecastStateIndicator changePoints =
 OnlineChangePointForecastState state = changePoints.getValue(index);
 ```
 
-The default filter expects a 100-observation regime, retains run lengths through 252, reports five typed posterior summaries, and becomes stable after 20 consecutive valid returns. `recentChangeProbability()` aggregates complete-posterior mass over run lengths zero through five. It is intentionally different from `P(runLength = 0)`, which equals the constant hazard before tail truncation and can increase slightly after truncation and renormalization, but cannot respond usefully to a shift.
+The default filter expects a 100-observation regime, retains run lengths through 252, reports five typed posterior summaries, and becomes stable after 20 consecutive valid returns. `recentChangeProbability()` aggregates complete-posterior mass over run lengths zero through five, and `recentChangeWindow()` carries that boundary with the state. It is intentionally different from `P(runLength = 0)`, which equals the constant hazard before tail truncation and can increase slightly after truncation and renormalization, but cannot respond usefully to a shift. Under canonical indexing, run length zero retains prior sufficient statistics and the current observation updates growth components.
 
-Use `ForecastFeatureExtractors.changePoint()` to publish `[mean, volatility, recent_change_probability, most_likely_run_length]` only when regime uncertainty and age are intentional analog dimensions. See [Forecast State Estimation](Forecast-State-Estimation.md#online-change-point-state) for prior tuning, posterior semantics, reset behavior, and failure guidance.
+Use `ForecastFeatureExtractors.changePoint()` for the default five-bar window or `changePoint(window)` for a window-qualified schema. Both publish `[mean, volatility, recent_change_probability, most_likely_run_length]` only when regime uncertainty and age are intentional analog dimensions. See [Forecast State Estimation](Forecast-State-Estimation.md#online-change-point-state) for prior tuning, posterior semantics, reset behavior, and failure guidance.
 
 ## Warm-Up, Recovery, and Numeric Failures
 

--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -180,6 +180,20 @@ RoughVolatilityForecastState state = rough.getValue(index);
 
 It reuses canonical EWMA moments and adds bounded log-variogram Hurst, population dispersion of the logarithmic volatility proxy, and five cumulative horizon variances by default. The representation-bound `ForecastFeatureExtractors.roughVolatility()` schema exposes `[mean, volatility, roughness_hurst, vol_of_vol]` for models that intentionally use those diagnostics. See [Forecast State Estimation](Forecast-State-Estimation.md#rough-volatility-state) for advanced tuning, exact field semantics, warm-up, recovery, and when to prefer the smaller EWMA state.
 
+## Online Change-Point State
+
+`OnlineChangePointForecastStateIndicator` is the constructor-first regime-uncertainty path:
+
+```java
+OnlineChangePointForecastStateIndicator changePoints =
+        new OnlineChangePointForecastStateIndicator(returns);
+OnlineChangePointForecastState state = changePoints.getValue(index);
+```
+
+The default filter expects a 100-observation regime, retains run lengths through 252, reports five typed posterior summaries, and becomes stable after 20 consecutive valid returns. `recentChangeProbability()` aggregates complete-posterior mass over run lengths zero through five. It is intentionally different from `P(runLength = 0)`, which equals the constant hazard before tail truncation and can increase slightly after truncation and renormalization, but cannot respond usefully to a shift.
+
+Use `ForecastFeatureExtractors.changePoint()` to publish `[mean, volatility, recent_change_probability, most_likely_run_length]` only when regime uncertainty and age are intentional analog dimensions. See [Forecast State Estimation](Forecast-State-Estimation.md#online-change-point-state) for prior tuning, posterior semantics, reset behavior, and failure guidance.
+
 ## Warm-Up, Recovery, and Numeric Failures
 
 A built-in projection returns `ForecastSupport.Unavailable` with `NaN.NaN` summary values until all prerequisites are valid. It can recover at a later index after invalid inputs leave the required window.
@@ -188,6 +202,7 @@ Common unavailable causes:
 
 - EWMA initialization or historical shock lookback is incomplete.
 - Rough-volatility EWMA, roughness, or vol-of-vol windows are incomplete or contain a non-finite return.
+- Online change-point valid-run warm-up is incomplete after construction, invalid input, or retained-history removal.
 - State index, return representation, stability, or `ReturnMoments` metadata does not match the query.
 - The price and return indicators do not share the same `BarSeries`.
 - A required return, state value, or decision price is non-finite; price is non-positive.
@@ -210,6 +225,7 @@ Always check `isStable()` when inspecting a raw summary. Point adapters are safe
 | Exact simulated price distribution | `MonteCarloPriceForecastIndicator` | Transforming summary moments after simulation. |
 | Cumulative log-return distribution | `MonteCarloReturnProjectionIndicator` | Treating returns as prices. |
 | State-conditioned empirical log returns | `AnalogReturnProjectionIndicator` | Letting current features influence training standardization. |
+| Abrupt regime and run-length diagnostics | `OnlineChangePointForecastStateIndicator` | Treating recent-change probability as a standalone trade signal. |
 | Rolling tail calibration | `RollingConformalForecastProjectionIndicator` | Counting calibration rows as forecast support. |
 | Price approximation from moments only | `LognormalApproximationPriceForecastIndicator` | Calling it empirical support. |
 | Point value in a rule | `projection.median()`, `.mean()`, or `.quantile(p)` | Reimplementing unstable checks. |
@@ -221,6 +237,8 @@ Always check `isStable()` when inspecting a raw summary. Point adapters are safe
 | Type | Package | Purpose |
 | --- | --- | --- |
 | `EwmaReturnForecastStateIndicator` | `forecast` | Default return-moment state estimator. |
+| `RoughVolatilityForecastStateIndicator` | `forecast` | EWMA moments enriched with roughness, vol-of-vol, and cumulative horizon variance. |
+| `OnlineChangePointForecastStateIndicator` | `forecast` | Bayesian run-length state with recent-change posterior mass. |
 | `MonteCarloReturnProjectionIndicator` | `forecast` | Exact empirical cumulative log-return projection. |
 | `AnalogReturnProjectionIndicator` | `forecast` | State-conditioned weighted empirical log-return projection. |
 | `RollingConformalForecastProjectionIndicator` | `forecast` | Matured-error tail calibration that preserves base support. |
@@ -230,6 +248,7 @@ Always check `isStable()` when inspecting a raw summary. Point adapters are safe
 | `ReturnForecastProjectionIndicator` | `forecast.projection` | Forecast projection with return semantics. |
 | `LognormalApproximationPriceForecastIndicator` | `forecast.adapters` | Explicit analytic lognormal price approximation. |
 | `ForecastState` / `ReturnMomentState` / `ReturnMoments` | `forecast.state` | Lifecycle and validated return-state composition. |
+| `OnlineChangePointForecastState` / `RunLengthPosterior` | `forecast.state` | Immutable regime state and typed complete-posterior component summaries. |
 | `ForecastFeatureSchema` / `ForecastFeatureExtractor` | `forecast.state` | Representation-bound model feature contract. |
 
 ## Related Guides

--- a/Forecast-Projection-Models.md
+++ b/Forecast-Projection-Models.md
@@ -61,6 +61,19 @@ AnalogReturnProjectionIndicator<RoughVolatilityForecastState> roughAnalog =
 
 The ordered raw features are `[mean, volatility, roughness_hurst, vol_of_vol]`. Candidate-only standardization remains owned by the analog model. Prefer the default `[mean, volatility]` schema unless roughness and vol-of-vol are intentional, tested similarity dimensions.
 
+Online change-point state composes through the same return-specific builder without repeating the return source:
+
+```java
+OnlineChangePointForecastStateIndicator changePointStates =
+        new OnlineChangePointForecastStateIndicator(returns);
+AnalogReturnProjectionIndicator<OnlineChangePointForecastState> regimeAnalog =
+        AnalogReturnProjectionIndicator.builder(changePointStates)
+                .featureExtractor(ForecastFeatureExtractors.changePoint())
+                .build();
+```
+
+Its raw schema is `[mean, volatility, recent_change_probability, most_likely_run_length]`. Candidate-only standardization is especially important because probability, observations, and log returns have different units. Prefer the smaller default schema unless walk-forward evidence supports treating regime uncertainty and age as similarity dimensions. Unstable post-reset states are excluded rather than converted into artificial neighbors.
+
 | Setting | Default | Operator intent |
 | --- | --- | --- |
 | `horizon(...)` | `1` | Match the forward-return label to the holding period. |

--- a/Forecast-Projection-Models.md
+++ b/Forecast-Projection-Models.md
@@ -68,11 +68,12 @@ OnlineChangePointForecastStateIndicator changePointStates =
         new OnlineChangePointForecastStateIndicator(returns);
 AnalogReturnProjectionIndicator<OnlineChangePointForecastState> regimeAnalog =
         AnalogReturnProjectionIndicator.builder(changePointStates)
-                .featureExtractor(ForecastFeatureExtractors.changePoint())
+                .featureExtractor(ForecastFeatureExtractors.changePoint(
+                        changePointStates.getRecentChangeWindow()))
                 .build();
 ```
 
-Its raw schema is `[mean, volatility, recent_change_probability, most_likely_run_length]`. Candidate-only standardization is especially important because probability, observations, and log returns have different units. Prefer the smaller default schema unless walk-forward evidence supports treating regime uncertainty and age as similarity dimensions. Unstable post-reset states are excluded rather than converted into artificial neighbors.
+Its raw schema is `[mean, volatility, recent_change_probability, most_likely_run_length]`. The default five-bar window uses `change-point/default`; custom windows use `change-point/recent-change/<window>`, and extraction rejects a state/window mismatch. Candidate-only standardization is especially important because probability, observations, and log returns have different units. Prefer the smaller default schema unless walk-forward evidence supports treating regime uncertainty and age as similarity dimensions. Unstable post-reset states are excluded rather than converted into artificial neighbors.
 
 | Setting | Default | Operator intent |
 | --- | --- | --- |

--- a/Forecast-State-Estimation.md
+++ b/Forecast-State-Estimation.md
@@ -114,6 +114,65 @@ The state remains unstable until EWMA initialization, the roughness window, and 
 
 Use rough-volatility state when changing volatility persistence or multi-horizon risk shape is part of the model. Prefer `EwmaReturnForecastStateIndicator` when current mean and variance are sufficient, the available history is short, or the extra dimensions have not earned their place in out-of-sample testing.
 
+## Online Change-Point State
+
+`OnlineChangePointForecastStateIndicator` estimates uncertainty about the current log-return regime. It uses canonical constant-hazard Bayesian online change-point detection with Normal-Inverse-Gamma sufficient statistics, Student-t predictive densities, and log-space normalization.
+
+```java
+LogReturnIndicator returns = new LogReturnIndicator(series);
+OnlineChangePointForecastStateIndicator states =
+        new OnlineChangePointForecastStateIndicator(returns);
+
+OnlineChangePointForecastState state = states.getValue(series.getEndIndex());
+if (state.isStable()) {
+    Num recentChangeProbability = state.recentChangeProbability();
+    int regimeAge = state.mostLikelyRunLength();
+    List<RunLengthPosterior> alternatives = state.topRunLengths();
+}
+```
+
+Advanced construction keeps the same semantic return source and names every model assumption:
+
+```java
+OnlineChangePointForecastStateIndicator states =
+        OnlineChangePointForecastStateIndicator.builder(returns)
+                .expectedRunLength(150)
+                .maximumRunLength(500)
+                .topRunLengthCount(8)
+                .minimumObservationCount(30)
+                .recentChangeWindow(10)
+                .priorMean(0)
+                .priorMeanPrecision(1e-3)
+                .priorShape(3)
+                .priorScale(1e-3)
+                .build();
+```
+
+| Setting | Default | Operator intent |
+| --- | --- | --- |
+| `expectedRunLength(...)` | `100` | Controls the constant hazard `1 / expectedRunLength`; larger values favor longer regimes. |
+| `maximumRunLength(...)` | `252` | Bounds posterior cost and the oldest retained run-length hypothesis. |
+| `topRunLengthCount(...)` | `5` | Number of typed posterior summaries published without subset renormalization. |
+| `minimumObservationCount(...)` | `20` | Consecutive valid returns required after construction or reset. |
+| `recentChangeWindow(...)` | `5` | Inclusive run-length boundary used by the recent-change probability. |
+| `priorMean(...)` | `0` | Prior location for a newly reset component. |
+| `priorMeanPrecision(...)` | `1e-4` | Confidence in the prior mean; higher values shrink regimes toward it. |
+| `priorShape(...)` | `2` | Inverse-Gamma shape; must exceed one so expected observation variance exists. |
+| `priorScale(...)` | `1e-4` | Positive prior observation-variance scale. |
+
+| State field | Meaning |
+| --- | --- |
+| `moments()` | MAP component mean, drift, canonical expected observation variance, and consecutive valid observation count. Drift equals the component mean. |
+| `recentChangeProbability()` | Complete posterior mass for run lengths `0..recentChangeWindow`. |
+| `mostLikelyRunLength()` | Run length of the probability-leading component after deterministic tie-breaking. |
+| `topRunLengths()` | Immutable probability-descending summaries; equal probabilities use shorter run length first. |
+
+Each `RunLengthPosterior` contains run length, its probability in the complete posterior, posterior mean, and expected observation variance. The top list generally sums to less than one because omitted hypotheses retain their probability. In the untruncated constant-hazard filter, `P(runLength = 0)` equals the hazard. Configured tail truncation and renormalization can increase it slightly, but it still is not a responsive change signal; `recentChangeProbability()` intentionally aggregates short run lengths instead.
+
+The estimator remains unstable until 20 consecutive valid returns mature by default. A non-finite return or primitive conversion overflow/underflow resets the posterior and observation count. Removed history is not silently reused: a bounded series must warm up again from its first retained bar. Unstable state preserves its current valid-run count, uses `NaN.NaN` for recent-change probability, reports run length `-1`, and exposes an empty posterior list.
+
+Use change-point state when abrupt location/variance regimes and uncertainty about regime age are intentional model inputs. Prefer EWMA for smooth adaptation, rough-volatility state for volatility persistence and term structure, or a smaller schema when regime dimensions have not improved walk-forward results. This state is diagnostic, not a standalone entry signal.
+
 ## Feature Schemas
 
 Feature vectors are representation-bound and self-describing. Choose a schema by modeling intent:
@@ -132,6 +191,7 @@ double[] values = extractor.features(state.getValue(index));
 | `driftVolatility(rep)` | `return-moments/drift-volatility` | `[drift, volatility]` | return, return | The model intentionally uses forward drift. |
 | `meanDriftVariance(rep)` | `return-moments/mean-drift-variance` | `[mean, drift, variance]` | return, return, return squared | A model needs separate location assumptions and canonical variance. |
 | `roughVolatility()` | `rough-volatility/default` | `[mean, volatility, roughness_hurst, vol_of_vol]` | log-return, log-return, dimensionless, dimensionless | Similarity should include roughness and volatility variability. |
+| `changePoint()` | `change-point/default` | `[mean, volatility, recent_change_probability, most_likely_run_length]` | log-return, log-return, probability, observations | Similarity should include recent regime uncertainty and age. |
 
 Every schema has version `1`, its required return representation, a defensive ordered descriptor list, and `dimension()`. Unit names are `log-return`, `decimal-return`, `percentage-points`, or `multiplicative-return`; variance appends `^2`.
 
@@ -160,7 +220,7 @@ Use `Forecast.ofSamples(...)` for empirical output and `Forecast.builder(...)` f
 
 ## Warm-Up and Recovery
 
-EWMA state is unstable until its configured initialization window contains valid returns. Invalid inputs produce unstable moments rather than partially valid fields. Later indices recover once all required state and lookback inputs are valid again.
+EWMA state is unstable until its configured initialization window contains valid returns. Rough-volatility state also waits for its rolling proxy windows. Online change-point state requires a complete consecutive-valid warm-up after any reset. Invalid inputs produce unstable moments rather than partially valid fields, and later indices recover only after the relevant estimator contract is satisfied again.
 
 Model consumers should treat these as unusable:
 

--- a/Forecast-State-Estimation.md
+++ b/Forecast-State-Estimation.md
@@ -163,13 +163,16 @@ OnlineChangePointForecastStateIndicator states =
 | State field | Meaning |
 | --- | --- |
 | `moments()` | MAP component mean, drift, canonical expected observation variance, and consecutive valid observation count. Drift equals the component mean. |
+| `recentChangeWindow()` | Inclusive run-length boundary carried with the state so the probability remains interpretable when detached. |
 | `recentChangeProbability()` | Complete posterior mass for run lengths `0..recentChangeWindow`. |
 | `mostLikelyRunLength()` | Run length of the probability-leading component after deterministic tie-breaking. |
 | `topRunLengths()` | Immutable probability-descending summaries; equal probabilities use shorter run length first. |
 
-Each `RunLengthPosterior` contains run length, its probability in the complete posterior, posterior mean, and expected observation variance. The top list generally sums to less than one because omitted hypotheses retain their probability. In the untruncated constant-hazard filter, `P(runLength = 0)` equals the hazard. Configured tail truncation and renormalization can increase it slightly, but it still is not a responsive change signal; `recentChangeProbability()` intentionally aggregates short run lengths instead.
+Each `RunLengthPosterior` contains run length, its probability in the complete posterior, posterior mean, and expected observation variance. The top list generally sums to less than one because omitted hypotheses retain their probability. Mass validation uses the owning numeric factory's decimal quantization, so coherent low-precision summaries remain usable while differences larger than the representation can explain are rejected. In the untruncated constant-hazard filter, `P(runLength = 0)` equals the hazard. Configured tail truncation and renormalization can increase it slightly, but it still is not a responsive change signal; `recentChangeProbability()` intentionally aggregates short run lengths instead.
 
-The estimator remains unstable until 20 consecutive valid returns mature by default. A non-finite return or primitive conversion overflow/underflow resets the posterior and observation count. Removed history is not silently reused: a bounded series must warm up again from its first retained bar. Unstable state preserves its current valid-run count, uses `NaN.NaN` for recent-change probability, reports run length `-1`, and exposes an empty posterior list.
+The implementation follows Adams-MacKay run-length indexing: run length zero has prior sufficient statistics and an empty associated run. The current observation updates growth components only. This keeps each component's public moments aligned with the predictive probability used by the recurrence.
+
+The estimator remains unstable until 20 consecutive valid returns mature by default. A non-finite return or primitive conversion overflow/underflow resets the posterior and observation count. Prior settings that cannot produce a representable variance or predictive density fail at construction. Removed history is not silently reused: a bounded series must warm up again from its first retained bar. Unstable state preserves its current valid-run count and recent-change window, uses `NaN.NaN` for recent-change probability, reports run length `-1`, and exposes an empty posterior list.
 
 Use change-point state when abrupt location/variance regimes and uncertainty about regime age are intentional model inputs. Prefer EWMA for smooth adaptation, rough-volatility state for volatility persistence and term structure, or a smaller schema when regime dimensions have not improved walk-forward results. This state is diagnostic, not a standalone entry signal.
 
@@ -191,9 +194,10 @@ double[] values = extractor.features(state.getValue(index));
 | `driftVolatility(rep)` | `return-moments/drift-volatility` | `[drift, volatility]` | return, return | The model intentionally uses forward drift. |
 | `meanDriftVariance(rep)` | `return-moments/mean-drift-variance` | `[mean, drift, variance]` | return, return, return squared | A model needs separate location assumptions and canonical variance. |
 | `roughVolatility()` | `rough-volatility/default` | `[mean, volatility, roughness_hurst, vol_of_vol]` | log-return, log-return, dimensionless, dimensionless | Similarity should include roughness and volatility variability. |
-| `changePoint()` | `change-point/default` | `[mean, volatility, recent_change_probability, most_likely_run_length]` | log-return, log-return, probability, observations | Similarity should include recent regime uncertainty and age. |
+| `changePoint()` | `change-point/default` | `[mean, volatility, recent_change_probability, most_likely_run_length]` | log-return, log-return, probability, observations | Similarity should include default five-bar regime uncertainty and age. |
+| `changePoint(window)` | `change-point/recent-change/<window>` | `[mean, volatility, recent_change_probability, most_likely_run_length]` | log-return, log-return, probability, observations | A custom recent-change window is an intentional, persisted model input. |
 
-Every schema has version `1`, its required return representation, a defensive ordered descriptor list, and `dimension()`. Unit names are `log-return`, `decimal-return`, `percentage-points`, or `multiplicative-return`; variance appends `^2`.
+Every schema has version `1`, its required return representation, a defensive ordered descriptor list, and `dimension()`. Unit names are `log-return`, `decimal-return`, `percentage-points`, or `multiplicative-return`; variance appends `^2`. A window-bound change-point extractor rejects states carrying another window rather than mixing incompatible probability meanings.
 
 For allocation-sensitive model loops, reuse a target array:
 

--- a/Home.md
+++ b/Home.md
@@ -27,7 +27,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **Exact and explicit price models**: `MonteCarloPriceForecastIndicator` summarizes transformed terminal-price paths exactly; `LognormalApproximationPriceForecastIndicator` is the clearly named analytic alternative when paths are unavailable.
 - **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
 - **Composable rough-volatility state**: `RoughVolatilityForecastStateIndicator` keeps canonical return moments while adding bounded roughness, vol-of-vol, cumulative horizon variance, and an explicit analog feature schema.
-- **Bayesian regime state**: `OnlineChangePointForecastStateIndicator` adds canonical constant-hazard run-length inference, recent-change posterior mass, typed component summaries, and direct analog composition.
+- **Bayesian regime state**: `OnlineChangePointForecastStateIndicator` adds canonical constant-hazard run-length inference, window-qualified recent-change posterior mass, typed component summaries, and direct analog composition.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here

--- a/Home.md
+++ b/Home.md
@@ -27,6 +27,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **Exact and explicit price models**: `MonteCarloPriceForecastIndicator` summarizes transformed terminal-price paths exactly; `LognormalApproximationPriceForecastIndicator` is the clearly named analytic alternative when paths are unavailable.
 - **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
 - **Composable rough-volatility state**: `RoughVolatilityForecastStateIndicator` keeps canonical return moments while adding bounded roughness, vol-of-vol, cumulative horizon variance, and an explicit analog feature schema.
+- **Bayesian regime state**: `OnlineChangePointForecastStateIndicator` adds canonical constant-hazard run-length inference, recent-change posterior mass, typed component summaries, and direct analog composition.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here
@@ -48,7 +49,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Num](Num.md)** - Precision-aware numeric types such as `DoubleNum` and `DecimalNum`
 - **[Technical Indicators](Technical-indicators.md)** - Indicator composition and caching
 - **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, point projections, and strategy filters
-- **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical and rough-volatility moments, representation-bound schemas, and provenance-aware summaries
+- **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical, rough-volatility, and Bayesian regime moments, representation-bound schemas, and provenance-aware summaries
 - **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -551,7 +551,7 @@ Forecast types live under `org.ta4j.core.indicators.forecast`. The root package 
 | `org.ta4j.core.indicators.forecast` | **RoughVolatilityForecastStateIndicator** | Enriches shared EWMA log-return moments with bounded roughness, log-volatility vol-of-vol, and cumulative fractional horizon variances. |
 | `org.ta4j.core.indicators.forecast.state` | **RoughVolatilityForecastState** | Immutable rich return state containing canonical moments and typed rough-volatility diagnostics. |
 | `org.ta4j.core.indicators.forecast` | **OnlineChangePointForecastStateIndicator** | Constant-hazard Bayesian online run-length estimator with reset-aware warm-up and recent-change posterior mass. |
-| `org.ta4j.core.indicators.forecast.state` | **OnlineChangePointForecastState** | Immutable return state containing MAP moments, recent-change probability, and ordered posterior summaries. |
+| `org.ta4j.core.indicators.forecast.state` | **OnlineChangePointForecastState** | Immutable return state containing MAP moments, the probability's recent-change window, and ordered posterior summaries. |
 | `org.ta4j.core.indicators.forecast.state` | **RunLengthPosterior** | Typed run-length probability and posterior expected observation moments from the complete distribution. |
 | `org.ta4j.core.indicators.forecast.projection` | **ReturnForecastProjectionIndicator** | Interface for return projections that declare their return representation. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloPriceForecastIndicator** | Exact terminal-path price simulation with inferred or explicit price source and advanced builder. |

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -529,7 +529,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 ## 15. Forecasting
 
-Forecast types live under `org.ta4j.core.indicators.forecast`. The root package holds primary indicators, while `forecast.state`, `forecast.projection`, and `forecast.adapters` hold composition contracts and the explicitly analytic bridge. The 0.23.1 surface includes Num-only summaries, support provenance, exact terminal-price simulation, minimal state, return-moment composition, representation-bound feature schemas, rough-volatility diagnostics, state-conditioned analog projection, and rolling conformal calibration. For tutorial and migration guidance, see [Forecast Indicators](Forecast-Indicators.md).
+Forecast types live under `org.ta4j.core.indicators.forecast`. The root package holds primary indicators, while `forecast.state`, `forecast.projection`, and `forecast.adapters` hold composition contracts and the explicitly analytic bridge. The 0.23.1 surface includes Num-only summaries, support provenance, exact terminal-price simulation, minimal state, return-moment composition, representation-bound feature schemas, rough-volatility diagnostics, Bayesian run-length state, state-conditioned analog projection, and rolling conformal calibration. For tutorial and migration guidance, see [Forecast Indicators](Forecast-Indicators.md).
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
@@ -550,6 +550,9 @@ Forecast types live under `org.ta4j.core.indicators.forecast`. The root package 
 | `org.ta4j.core.indicators.forecast.state` | **ReturnForecastState** | Default state record composing one validated `ReturnMoments` value. |
 | `org.ta4j.core.indicators.forecast` | **RoughVolatilityForecastStateIndicator** | Enriches shared EWMA log-return moments with bounded roughness, log-volatility vol-of-vol, and cumulative fractional horizon variances. |
 | `org.ta4j.core.indicators.forecast.state` | **RoughVolatilityForecastState** | Immutable rich return state containing canonical moments and typed rough-volatility diagnostics. |
+| `org.ta4j.core.indicators.forecast` | **OnlineChangePointForecastStateIndicator** | Constant-hazard Bayesian online run-length estimator with reset-aware warm-up and recent-change posterior mass. |
+| `org.ta4j.core.indicators.forecast.state` | **OnlineChangePointForecastState** | Immutable return state containing MAP moments, recent-change probability, and ordered posterior summaries. |
+| `org.ta4j.core.indicators.forecast.state` | **RunLengthPosterior** | Typed run-length probability and posterior expected observation moments from the complete distribution. |
 | `org.ta4j.core.indicators.forecast.projection` | **ReturnForecastProjectionIndicator** | Interface for return projections that declare their return representation. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloPriceForecastIndicator** | Exact terminal-path price simulation with inferred or explicit price source and advanced builder. |
 | `org.ta4j.core.indicators.forecast` | **MonteCarloReturnProjectionIndicator** | Monte Carlo cumulative log-return projection indicator with standard constructors and a builder for advanced configuration. |
@@ -561,7 +564,7 @@ Forecast types live under `org.ta4j.core.indicators.forecast`. The root package 
 
 **Short usage**
 - **What it is:** A forecasting layer that estimates future return or price distributions from historical returns and rolling volatility state.
-- **Theory:** Pipelines convert prices to semantic returns, estimate canonical or rough-volatility state, then choose exact simulation, state-conditioned analogs, or explicit analytic projection; rolling conformal calibration can widen an existing model's tails from matured errors.
+- **Theory:** Pipelines convert prices to semantic returns, estimate canonical, rough-volatility, or Bayesian run-length state, then choose exact simulation, state-conditioned analogs, or explicit analytic projection; rolling conformal calibration can widen an existing model's tails from matured errors.
 - **When to use:** Probabilistic research labels, forecast-aware filters, risk bounds, tail checks, and point projections exposed as regular ta4j indicators.
 - **When not to use:** As a guaranteed target, without warm-up checks, or as a replacement for realistic execution and out-of-sample validation.
 - See also: [Forecast Indicators](Forecast-Indicators.md) and [Forecast Projection Models](Forecast-Projection-Models.md).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **Exact and explicit price models**: `MonteCarloPriceForecastIndicator` summarizes transformed terminal-price paths exactly; `LognormalApproximationPriceForecastIndicator` is the clearly named analytic alternative when paths are unavailable.
 - **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
 - **Composable rough-volatility state**: `RoughVolatilityForecastStateIndicator` keeps canonical return moments while adding bounded roughness, vol-of-vol, cumulative horizon variance, and an explicit analog feature schema.
-- **Bayesian regime state**: `OnlineChangePointForecastStateIndicator` adds canonical constant-hazard run-length inference, recent-change posterior mass, typed component summaries, and direct analog composition.
+- **Bayesian regime state**: `OnlineChangePointForecastStateIndicator` adds canonical constant-hazard run-length inference, window-qualified recent-change posterior mass, typed component summaries, and direct analog composition.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **Exact and explicit price models**: `MonteCarloPriceForecastIndicator` summarizes transformed terminal-price paths exactly; `LognormalApproximationPriceForecastIndicator` is the clearly named analytic alternative when paths are unavailable.
 - **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
 - **Composable rough-volatility state**: `RoughVolatilityForecastStateIndicator` keeps canonical return moments while adding bounded roughness, vol-of-vol, cumulative horizon variance, and an explicit analog feature schema.
+- **Bayesian regime state**: `OnlineChangePointForecastStateIndicator` adds canonical constant-hazard run-length inference, recent-change posterior mass, typed component summaries, and direct analog composition.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here
@@ -48,7 +49,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Num](Num.md)** - Precision-aware numeric types such as `DoubleNum` and `DecimalNum`
 - **[Technical Indicators](Technical-indicators.md)** - Indicator composition and caching
 - **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, point projections, and strategy filters
-- **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical and rough-volatility moments, representation-bound schemas, and provenance-aware summaries
+- **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical, rough-volatility, and Bayesian regime moments, representation-bound schemas, and provenance-aware summaries
 - **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -106,6 +106,7 @@ ta4j's forecast package adds prediction-valued indicators for forward-looking re
 - `EWMAIndicator` provides reusable explicit-decay smoothing for forecast and non-forecast workflows.
 - `EwmaReturnForecastStateIndicator` estimates canonical `ReturnMoments` from a log-return `ReturnIndicator`.
 - `RoughVolatilityForecastStateIndicator` composes those moments with bounded log-variogram roughness, log-volatility vol-of-vol, and cumulative horizon variance diagnostics.
+- `OnlineChangePointForecastStateIndicator` composes MAP regime moments with deterministic Bayesian run-length summaries and recent-change posterior mass.
 - `MonteCarloPriceForecastIndicator` transforms every simulated terminal return path before calculating exact empirical price summaries.
 - `MonteCarloReturnProjectionIndicator` simulates cumulative log-return distributions for return-space workflows or advanced tuning.
 - `LognormalApproximationPriceForecastIndicator` explicitly fits a coherent analytic lognormal distribution when terminal samples are unavailable.
@@ -113,6 +114,7 @@ ta4j's forecast package adds prediction-valued indicators for forward-looking re
 - `ForecastSupport` distinguishes unavailable, empirical-count, and named analytic output.
 - `ForecastFeatureSchema` binds primitive feature names, units, version, order, and return representation.
 - `ForecastFeatureExtractors.roughVolatility()` publishes the fixed `[mean, volatility, roughness_hurst, vol_of_vol]` shape for intentional rich-state model composition.
+- `ForecastFeatureExtractors.changePoint()` publishes `[mean, volatility, recent_change_probability, most_likely_run_length]` for intentional regime-aware composition.
 
 Forecast indicators do not read future bars while producing `getValue(i)`. Use the configured horizon only when evaluating the forecast against later realized outcomes. See [Forecast Indicators](Forecast-Indicators.md) for setup, tuning, warm-up behavior, and strategy examples.
 

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -114,7 +114,7 @@ ta4j's forecast package adds prediction-valued indicators for forward-looking re
 - `ForecastSupport` distinguishes unavailable, empirical-count, and named analytic output.
 - `ForecastFeatureSchema` binds primitive feature names, units, version, order, and return representation.
 - `ForecastFeatureExtractors.roughVolatility()` publishes the fixed `[mean, volatility, roughness_hurst, vol_of_vol]` shape for intentional rich-state model composition.
-- `ForecastFeatureExtractors.changePoint()` publishes `[mean, volatility, recent_change_probability, most_likely_run_length]` for intentional regime-aware composition.
+- `ForecastFeatureExtractors.changePoint()` publishes the default five-bar `[mean, volatility, recent_change_probability, most_likely_run_length]` shape; `changePoint(window)` binds custom aggregation windows into the schema identity.
 
 Forecast indicators do not read future bars while producing `getValue(i)`. Use the configured horizon only when evaluating the forecast against later realized outcomes. See [Forecast Indicators](Forecast-Indicators.md) for setup, tuning, warm-up behavior, and strategy examples.
 

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -22,7 +22,7 @@
 - [Technical Indicators](Technical-indicators.md)
 - [Indicators Inventory](Indicators-Inventory.md)
 - [Forecast Indicators](Forecast-Indicators.md)
-- [Forecast State Estimation](Forecast-State-Estimation.md)
+- [Forecast State & Regime Estimation](Forecast-State-Estimation.md)
 - [Forecast Projection Models](Forecast-Projection-Models.md)
 - [Forecast 0.23.1 Migration](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231)
 - [Moving Average Indicators](Moving-Average-Indicators.md)


### PR DESCRIPTION
Document the Phase 3B online change-point forecast state across the quick start, state-estimation and projection guides, inventory, technical overview, Home, and navigation.

The guides cover shortest and advanced construction, posterior field semantics, feature order and units, tuning, retained-history warm-up, numeric failure behavior, analog composition, and when to use or avoid the estimator.
