### PR TITLE
Document serialization named shorthand

### DIFF
--- a/Analysis-Criteria-and-Risk-Metrics.md
+++ b/Analysis-Criteria-and-Risk-Metrics.md
@@ -33,7 +33,7 @@ AnalysisCriterion sharpe = new SharpeRatioCriterion(
 Num score = sharpe.calculate(series, tradingRecord);
 ```
 
-Criteria can be serialized with canonical JSON and, since 0.23.1, default criteria can be referenced by compact aliases:
+Criteria can be serialized with canonical JSON. The companion ta4j PR #1507, targeting 0.23.1, also lets default criteria be referenced by compact aliases:
 
 ```java
 AnalysisCriterion criterion = AnalysisCriterion.fromExpression("SharpeRatio");
@@ -41,7 +41,7 @@ String json = criterion.toJson();
 AnalysisCriterion restored = AnalysisCriterion.fromJson(json);
 ```
 
-See [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md) for the supported aliases and custom registry extension points.
+See [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md) for the supported aliases and custom registry extension points in that PR.
 
 ## Windowed Criterion Evaluation
 

--- a/Analysis-Criteria-and-Risk-Metrics.md
+++ b/Analysis-Criteria-and-Risk-Metrics.md
@@ -33,6 +33,16 @@ AnalysisCriterion sharpe = new SharpeRatioCriterion(
 Num score = sharpe.calculate(series, tradingRecord);
 ```
 
+Criteria can be serialized with canonical JSON and, since 0.23.1, default criteria can be referenced by compact aliases:
+
+```java
+AnalysisCriterion criterion = AnalysisCriterion.fromExpression("SharpeRatio");
+String json = criterion.toJson();
+AnalysisCriterion restored = AnalysisCriterion.fromJson(json);
+```
+
+See [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md) for the supported aliases and custom registry extension points.
+
 ## Windowed Criterion Evaluation
 
 Since the window-aware criterion API, any `AnalysisCriterion` can be evaluated over a bounded slice without hand-copying a `TradingRecord`.

--- a/Home.md
+++ b/Home.md
@@ -28,6 +28,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
 - **Composable rough-volatility state**: `RoughVolatilityForecastStateIndicator` keeps canonical return moments while adding bounded roughness, vol-of-vol, cumulative horizon variance, and an explicit analog feature schema.
 - **Bayesian regime state**: `OnlineChangePointForecastStateIndicator` adds canonical constant-hazard run-length inference, window-qualified recent-change posterior mass, typed component summaries, and direct analog composition.
+- **Serialization named shorthand**: Strategy JSON v2 and `NamedAssetRegistry` add compact expressions such as `SMA(7,21)`, `SmaCrossUp(7,21)`, `RSI(14)`, and `SharpeRatio` while keeping canonical descriptor JSON as the durable storage format.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here
@@ -38,6 +39,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Backtesting](Backtesting.md)** - `BarSeriesManager`, `BacktestExecutor`, supplied records, and manual simulation loops
 - **[Live Trading](Live-trading.md)** - Event-driven live or paper flows with `BaseTradingRecord`
 - **[Usage Examples](Usage-examples.md)** - Runnable examples, including parity and bot loops
+- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Persist and reload indicators, rules, strategies, and analysis criteria
 - **[Execution Decision Matrix](Execution-Decision-Matrix.md)** - Choose execution and simulation path by workload
 - **[Migration and Version Compatibility](Migration-and-Version-Compatibility.md)** - Preferred APIs and incremental migration guidance
 - **[Release Notes](https://github.com/ta4j/ta4j/blob/master/CHANGELOG.md)** - Version-by-version changelog and migration notes
@@ -52,6 +54,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical, rough-volatility, and Bayesian regime moments, representation-bound schemas, and provenance-aware summaries
 - **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
+- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Canonical JSON, compact strategy JSON v2, and named asset expressions
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts
 
 ## Pick The Right Execution Path

--- a/Home.md
+++ b/Home.md
@@ -28,7 +28,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
 - **Composable rough-volatility state**: `RoughVolatilityForecastStateIndicator` keeps canonical return moments while adding bounded roughness, vol-of-vol, cumulative horizon variance, and an explicit analog feature schema.
 - **Bayesian regime state**: `OnlineChangePointForecastStateIndicator` adds canonical constant-hazard run-length inference, window-qualified recent-change posterior mass, typed component summaries, and direct analog composition.
-- **Serialization named shorthand**: Strategy JSON v2 and `NamedAssetRegistry` add compact expressions such as `SMA(7,21)`, `SmaCrossUp(7,21)`, `RSI(14)`, and `SharpeRatio` while keeping canonical descriptor JSON as the durable storage format.
+- **Serialization named shorthand preview**: The companion ta4j PR #1507 targets 0.23.1 with compact expressions such as `SMA(7,21)`, `SmaCrossUp(7,21)`, `RSI(14)`, and `SharpeRatio` while keeping canonical descriptor JSON as the durable storage format.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here
@@ -39,7 +39,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Backtesting](Backtesting.md)** - `BarSeriesManager`, `BacktestExecutor`, supplied records, and manual simulation loops
 - **[Live Trading](Live-trading.md)** - Event-driven live or paper flows with `BaseTradingRecord`
 - **[Usage Examples](Usage-examples.md)** - Runnable examples, including parity and bot loops
-- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Persist and reload indicators, rules, strategies, and analysis criteria
+- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Preview guide for ta4j PR #1507 strategy, rule, indicator, and criterion serialization
 - **[Execution Decision Matrix](Execution-Decision-Matrix.md)** - Choose execution and simulation path by workload
 - **[Migration and Version Compatibility](Migration-and-Version-Compatibility.md)** - Preferred APIs and incremental migration guidance
 - **[Release Notes](https://github.com/ta4j/ta4j/blob/master/CHANGELOG.md)** - Version-by-version changelog and migration notes
@@ -54,7 +54,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical, rough-volatility, and Bayesian regime moments, representation-bound schemas, and provenance-aware summaries
 - **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
-- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Canonical JSON, compact strategy JSON v2, and named asset expressions
+- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Preview guide for canonical JSON, compact strategy JSON v2, and named asset expressions
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts
 
 ## Pick The Right Execution Path

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
 - **Composable rough-volatility state**: `RoughVolatilityForecastStateIndicator` keeps canonical return moments while adding bounded roughness, vol-of-vol, cumulative horizon variance, and an explicit analog feature schema.
 - **Bayesian regime state**: `OnlineChangePointForecastStateIndicator` adds canonical constant-hazard run-length inference, window-qualified recent-change posterior mass, typed component summaries, and direct analog composition.
+- **Serialization named shorthand**: Strategy JSON v2 and `NamedAssetRegistry` add compact expressions such as `SMA(7,21)`, `SmaCrossUp(7,21)`, `RSI(14)`, and `SharpeRatio` while keeping canonical descriptor JSON as the durable storage format.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here
@@ -38,6 +39,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Backtesting](Backtesting.md)** - `BarSeriesManager`, `BacktestExecutor`, supplied records, and manual simulation loops
 - **[Live Trading](Live-trading.md)** - Event-driven live or paper flows with `BaseTradingRecord`
 - **[Usage Examples](Usage-examples.md)** - Runnable examples, including parity and bot loops
+- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Persist and reload indicators, rules, strategies, and analysis criteria
 - **[Execution Decision Matrix](Execution-Decision-Matrix.md)** - Choose execution and simulation path by workload
 - **[Migration and Version Compatibility](Migration-and-Version-Compatibility.md)** - Preferred APIs and incremental migration guidance
 - **[Release Notes](https://github.com/ta4j/ta4j/blob/master/CHANGELOG.md)** - Version-by-version changelog and migration notes
@@ -52,6 +54,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical, rough-volatility, and Bayesian regime moments, representation-bound schemas, and provenance-aware summaries
 - **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
+- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Canonical JSON, compact strategy JSON v2, and named asset expressions
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts
 
 ## Pick The Right Execution Path

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **State-conditioned projections and calibrated tails**: `AnalogReturnProjectionIndicator` builds deterministic empirical neighbor forecasts, and `RollingConformalForecastProjectionIndicator` widens tails from matured residuals without changing base provenance.
 - **Composable rough-volatility state**: `RoughVolatilityForecastStateIndicator` keeps canonical return moments while adding bounded roughness, vol-of-vol, cumulative horizon variance, and an explicit analog feature schema.
 - **Bayesian regime state**: `OnlineChangePointForecastStateIndicator` adds canonical constant-hazard run-length inference, window-qualified recent-change posterior mass, typed component summaries, and direct analog composition.
-- **Serialization named shorthand**: Strategy JSON v2 and `NamedAssetRegistry` add compact expressions such as `SMA(7,21)`, `SmaCrossUp(7,21)`, `RSI(14)`, and `SharpeRatio` while keeping canonical descriptor JSON as the durable storage format.
+- **Serialization named shorthand preview**: The companion ta4j PR #1507 targets 0.23.1 with compact expressions such as `SMA(7,21)`, `SmaCrossUp(7,21)`, `RSI(14)`, and `SharpeRatio` while keeping canonical descriptor JSON as the durable storage format.
 - **Forecast migration required**: The 0.23.1 correction intentionally replaces the forecast API introduced in 0.23.0. See [Migration and Version Compatibility](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231).
 
 ## Start Here
@@ -39,7 +39,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Backtesting](Backtesting.md)** - `BarSeriesManager`, `BacktestExecutor`, supplied records, and manual simulation loops
 - **[Live Trading](Live-trading.md)** - Event-driven live or paper flows with `BaseTradingRecord`
 - **[Usage Examples](Usage-examples.md)** - Runnable examples, including parity and bot loops
-- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Persist and reload indicators, rules, strategies, and analysis criteria
+- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Preview guide for ta4j PR #1507 strategy, rule, indicator, and criterion serialization
 - **[Execution Decision Matrix](Execution-Decision-Matrix.md)** - Choose execution and simulation path by workload
 - **[Migration and Version Compatibility](Migration-and-Version-Compatibility.md)** - Preferred APIs and incremental migration guidance
 - **[Release Notes](https://github.com/ta4j/ta4j/blob/master/CHANGELOG.md)** - Version-by-version changelog and migration notes
@@ -54,7 +54,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical, rough-volatility, and Bayesian regime moments, representation-bound schemas, and provenance-aware summaries
 - **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior
 - **[Trading Strategies](Trading-strategies.md)** - Rules, strategies, unstable bars, and serialization
-- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Canonical JSON, compact strategy JSON v2, and named asset expressions
+- **[Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)** - Preview guide for canonical JSON, compact strategy JSON v2, and named asset expressions
 - **[Charting](Charting.md)** - Visual overlays, trading-record rendering, and analysis charts
 
 ## Pick The Right Execution Path

--- a/Serialization-and-Named-Shorthand.md
+++ b/Serialization-and-Named-Shorthand.md
@@ -1,6 +1,10 @@
 # Serialization and Named Shorthand
 
-ta4j can persist and rebuild indicators, rules, strategies, and analysis criteria. The default JSON form is a canonical descriptor tree: it is explicit, stable, and intended for durable storage. Since 0.23.1, ta4j also supports compact named shorthand for authoring configuration, presenting strategy choices in UIs, and round-tripping common graphs without hand-writing full descriptor JSON.
+ta4j can persist and rebuild indicators, rules, strategies, and analysis criteria. The default JSON form is a canonical descriptor tree: it is explicit, stable, and intended for durable storage.
+
+> **Preview status:** This page documents the companion serialization shorthand feature in [ta4j PR #1507](https://github.com/ta4j/ta4j/pull/1507), targeting ta4j 0.23.1. The named shorthand APIs are not available from the latest released ta4j artifacts or from ta4j `master` until that implementation PR is merged and released.
+
+The PR #1507 implementation adds compact named shorthand for authoring configuration, presenting strategy choices in UIs, and round-tripping common graphs without hand-writing full descriptor JSON.
 
 Use this guide when you want to store a strategy, pass a rule or indicator through a service boundary, load strategy presets from configuration, or let users choose named assets such as `SMA(7,21)` or `SharpeRatio`.
 

--- a/Serialization-and-Named-Shorthand.md
+++ b/Serialization-and-Named-Shorthand.md
@@ -81,12 +81,12 @@ Strategy v2 accepts these metadata fields:
 | Field | Meaning |
 | --- | --- |
 | `version` | Required for v2, must be `2`. |
-| `strategy` | Optional top-level strategy macro such as `SMA(7,21)`. If present, entry and exit rules come from the macro unless overridden by metadata. |
+| `strategy` | Optional top-level strategy macro such as `SMA(7,21)`. If present, entry and exit rules come from the macro; do not also provide `entryRule` or `exitRule`. |
 | `name` | Optional strategy name. Use `null` to intentionally preserve an unnamed strategy when compacting a macro-shaped strategy. |
-| `type` | Optional strategy type. Omit it for `BaseStrategy`. |
+| `type` | Optional, but only `BaseStrategy` or `org.ta4j.core.BaseStrategy` is accepted by v2. Use canonical JSON or a registered macro for other strategy implementations. |
 | `unstableBars` | Optional non-negative integer override. |
 | `startingType` | Optional `BUY` or `SELL`. |
-| `entryRule`, `exitRule` | Required unless `strategy` supplies both rules. Values may be expression strings or rule objects. |
+| `entryRule`, `exitRule` | Required when `strategy` is absent. Values may be expression strings or rule objects. |
 
 ## Indicators
 

--- a/Serialization-and-Named-Shorthand.md
+++ b/Serialization-and-Named-Shorthand.md
@@ -1,0 +1,266 @@
+# Serialization and Named Shorthand
+
+ta4j can persist and rebuild indicators, rules, strategies, and analysis criteria. The default JSON form is a canonical descriptor tree: it is explicit, stable, and intended for durable storage. Since 0.23.1, ta4j also supports compact named shorthand for authoring configuration, presenting strategy choices in UIs, and round-tripping common graphs without hand-writing full descriptor JSON.
+
+Use this guide when you want to store a strategy, pass a rule or indicator through a service boundary, load strategy presets from configuration, or let users choose named assets such as `SMA(7,21)` or `SharpeRatio`.
+
+## Choose the Right Form
+
+| Form | Best for | API |
+| --- | --- | --- |
+| Canonical descriptor JSON | Long-term storage, audit logs, exact graph persistence, and maximum compatibility | `toJson()`, `fromJson(...)`, `describe(...)` |
+| Strategy JSON v2 | Human-authored strategy configuration with named rule and indicator shorthand | `Strategy.fromJson(series, json)` |
+| Named expressions | UI pickers, CLI arguments, compact config values, and registry extension points | `toExpression(...)`, `fromExpression(...)` |
+| Compact strategy JSON | Exporting a recognized strategy graph as a v2 config | `strategy.toCompactJson()` |
+
+Canonical JSON remains the baseline. `strategy.toJson()` always emits the canonical descriptor form. Compact output is explicit: call `strategy.toCompactJson()` only when you want the opt-in v2 envelope.
+
+## Strategy Quickstart
+
+The shortest built-in strategy macro is an SMA crossover:
+
+```java
+String json = """
+        {
+          "version": 2,
+          "strategy": "SMA(7,21)",
+          "name": "Daily_SMA_Crossover"
+        }
+        """;
+
+Strategy strategy = Strategy.fromJson(series, json);
+String canonicalJson = strategy.toJson();
+String compactJson = strategy.toCompactJson();
+```
+
+`SMA(7,21)` builds a `BaseStrategy` whose entry rule is `CrossedUpIndicatorRule(SMA(7), SMA(21))` and whose exit rule is `CrossedDownIndicatorRule(SMA(7), SMA(21))`. The strategy's unstable bar count is set to the slow SMA period.
+
+If you need full control over entry and exit logic, write a v2 strategy with rule shorthand:
+
+```java
+String json = """
+        {
+          "version": 2,
+          "name": "Momentum_With_Risk_Stops",
+          "unstableBars": 26,
+          "startingType": "BUY",
+          "entryRule": "And(SmaCrossUp(12,26),Under(RSI(14),70))",
+          "exitRule": "Or(SmaCrossDown(12,26),StopLoss(2.5%))"
+        }
+        """;
+
+Strategy strategy = Strategy.fromJson(series, json);
+```
+
+The same fields can be expressed as objects when that is easier for generated JSON:
+
+```json
+{
+  "version": 2,
+  "name": "Momentum_With_Risk_Stops",
+  "entryRule": {
+    "type": "CrossedUpIndicatorRule",
+    "args": ["SMA(12)", "SMA(26)"]
+  },
+  "exitRule": {
+    "type": "OrRule",
+    "rules": [
+      { "type": "SmaCrossDown", "args": [12, 26] },
+      { "type": "StopLossRule", "args": ["2.5%"] }
+    ]
+  }
+}
+```
+
+Strategy v2 accepts these metadata fields:
+
+| Field | Meaning |
+| --- | --- |
+| `version` | Required for v2, must be `2`. |
+| `strategy` | Optional top-level strategy macro such as `SMA(7,21)`. If present, entry and exit rules come from the macro unless overridden by metadata. |
+| `name` | Optional strategy name. Use `null` to intentionally preserve an unnamed strategy when compacting a macro-shaped strategy. |
+| `type` | Optional strategy type. Omit it for `BaseStrategy`. |
+| `unstableBars` | Optional non-negative integer override. |
+| `startingType` | Optional `BUY` or `SELL`. |
+| `entryRule`, `exitRule` | Required unless `strategy` supplies both rules. Values may be expression strings or rule objects. |
+
+## Indicators
+
+Indicators can round-trip through canonical JSON:
+
+```java
+ClosePriceIndicator close = new ClosePriceIndicator(series);
+RSIIndicator rsi = new RSIIndicator(close, 14);
+
+String json = rsi.toJson();
+Indicator<?> restored = Indicator.fromJson(series, json);
+```
+
+For compact authoring, use expressions:
+
+```java
+Indicator<?> close = Indicator.fromExpression(series, "ClosePrice");
+Indicator<?> sma = Indicator.fromExpression(series, "SMA(21)");
+Indicator<?> rsiOfSma = Indicator.fromExpression(series, "RSI(SMA(14),9)");
+
+String expression = sma.toExpression(); // "SMA(21)"
+```
+
+Built-in indicator shorthand:
+
+| Expression | Descriptor meaning |
+| --- | --- |
+| `ClosePrice` | `ClosePriceIndicator` |
+| `ClosePriceIndicator` | `ClosePriceIndicator`, accepted for input but not preferred for compact output |
+| `SMA(barCount)` | `SMAIndicator(ClosePriceIndicator, barCount)` |
+| `SMA(indicator,barCount)` | `SMAIndicator(indicator, barCount)` |
+| `EMA(barCount)` | `EMAIndicator(ClosePriceIndicator, barCount)` |
+| `EMA(indicator,barCount)` | `EMAIndicator(indicator, barCount)` |
+| `RSI(barCount)` | `RSIIndicator(ClosePriceIndicator, barCount)` |
+| `RSI(indicator,barCount)` | `RSIIndicator(indicator, barCount)` |
+
+Indicator expression export succeeds only when the registry recognizes the descriptor. If a graph includes an unsupported indicator, keep using canonical `indicator.toJson()` until you add a registry binding and formatter for that indicator.
+
+## Rules
+
+Rules can also round-trip through canonical JSON:
+
+```java
+Rule entry = new CrossedUpIndicatorRule(new SMAIndicator(close, 12), new SMAIndicator(close, 26));
+
+String json = entry.toJson();
+Rule restored = Rule.fromJson(series, json);
+```
+
+Expression form keeps common trading logic readable:
+
+```java
+Rule entry = Rule.fromExpression(series,
+        "And(SmaCrossUp(12,26),Under(RSI(14),70))");
+
+Rule exit = Rule.fromExpression(series,
+        "Or(SmaCrossDown(12,26),StopLoss(2.5%))");
+```
+
+Built-in rule shorthand:
+
+| Expression | Descriptor meaning |
+| --- | --- |
+| `SmaCrossUp(fast,slow)` | `CrossedUpIndicatorRule(SMA(fast), SMA(slow))` |
+| `SmaCrossDown(fast,slow)` | `CrossedDownIndicatorRule(SMA(fast), SMA(slow))` |
+| `CrossedUp(indicator,indicatorOrNumber)` | `CrossedUpIndicatorRule` |
+| `CrossedDown(indicator,indicatorOrNumber)` | `CrossedDownIndicatorRule` |
+| `Over(indicator,indicatorOrNumber)` | `OverIndicatorRule` |
+| `Under(indicator,indicatorOrNumber)` | `UnderIndicatorRule` |
+| `And(left,right)` | `AndRule` |
+| `Or(left,right)` | `OrRule` |
+| `StopLoss(lossPercentage)` | `StopLossRule(ClosePriceIndicator, lossPercentage)` |
+| `StopGain(gainPercentage)` | `StopGainRule(ClosePriceIndicator, gainPercentage)` |
+
+Class-style aliases such as `AndRule`, `OrRule`, `OverIndicatorRule`, `UnderIndicatorRule`, `CrossedUpIndicatorRule`, `CrossedDownIndicatorRule`, `StopLossRule`, and `StopGainRule` are accepted as input where the v2 object syntax is more natural. Compact output prefers the shorter names above when a formatter recognizes the descriptor.
+
+## Analysis Criteria
+
+Analysis criteria serialize through canonical descriptor JSON and can also use default named aliases:
+
+```java
+AnalysisCriterion criterion = AnalysisCriterion.fromExpression("SharpeRatio");
+String json = criterion.toJson();
+AnalysisCriterion restored = AnalysisCriterion.fromJson(json);
+String expression = restored.toExpression(); // "SharpeRatio"
+```
+
+Built-in analysis criterion aliases map to their default constructors:
+
+| Expression | Criterion |
+| --- | --- |
+| `NetProfit` | `NetProfitCriterion` |
+| `GrossReturn` | `GrossReturnCriterion` |
+| `NetReturn` | `NetReturnCriterion` |
+| `MaximumDrawdown` | `MaximumDrawdownCriterion` |
+| `ReturnOverMaxDrawdown` | `ReturnOverMaxDrawdownCriterion` |
+| `SharpeRatio` | `SharpeRatioCriterion` |
+| `SortinoRatio` | `SortinoRatioCriterion` |
+| `TotalFees` | `TotalFeesCriterion` |
+| `NumberOfPositions` | `NumberOfPositionsCriterion` |
+
+Parameterized criteria should use canonical JSON unless you register a custom formatter that can represent every constructor argument without losing information.
+
+## Custom Shorthand
+
+Use `NamedAssetRegistry` when your application has its own aliases. Registries are immutable after build, and aliases are scoped by `NamedAssetKind`, so `SMA(7)` can mean an indicator while `SMA(7,21)` can mean a strategy macro.
+
+```java
+NamedAssetRegistry registry = NamedAssetRegistry.builder()
+        .withDefaults()
+        .registerIndicator("FastCloseSma", List.of("barCount"), args -> {
+            args.requireCount(1);
+            return ComponentDescriptor.builder()
+                    .withType("SMAIndicator")
+                    .withParameters(Map.of("barCount", args.positiveInt(0)))
+                    .addComponent(ComponentDescriptor.typeOnly("ClosePriceIndicator"))
+                    .build();
+        })
+        .build();
+
+Indicator<?> indicator = Indicator.fromExpression(series, "FastCloseSma(5)", registry);
+```
+
+Factories receive typed `NamedAssetRegistry.Arguments` helpers:
+
+| Helper | Use |
+| --- | --- |
+| `requireCount(expected)` | Fail fast when an alias receives the wrong arity. |
+| `positiveInt(index)` | Read a positive bar count or lookback. |
+| `intValue(index)` | Read an integer that may be zero or negative. |
+| `finiteNumberText(index)` | Read a finite JSON-style number, accepting an optional trailing `%`. |
+| `stringValue(index)` | Read a quoted string or bare token. |
+| `indicatorDescriptor(index)` | Expand an argument as an indicator descriptor. |
+| `ruleDescriptor(index)` | Expand an argument as a rule descriptor. |
+
+Add a formatter when you also want `toExpression(...)` or `toCompactJson(...)` to emit your alias. Without a formatter, the alias is still valid for input.
+
+To make application defaults automatic, implement `NamedAssetProvider` and register it with Java `ServiceLoader`:
+
+```text
+META-INF/services/org.ta4j.core.named.NamedAssetProvider
+```
+
+The file should contain the fully qualified provider class name. `NamedAssetRegistry.defaultRegistry()` loads ta4j defaults first, then provider bindings.
+
+## Grammar and Validation
+
+The expression grammar is intentionally strict:
+
+- Alias names must be identifiers.
+- Arguments may be nested expressions, quoted strings, bare string or enum-like tokens, finite numbers, or percentages used by stop rules.
+- Whitespace around aliases and commas is ignored.
+- Empty arguments, unknown aliases, unbalanced parentheses, and trailing input fail immediately.
+- Built-in bar-count arguments require positive integers.
+- Strategy `unstableBars` must be non-negative.
+- Strategy `startingType` must be `BUY` or `SELL`.
+
+When processing lists of expressions from a CLI or configuration file, do not split on commas manually. Use `NamedAssetRegistry#splitTopLevel(...)` so nested expressions and quoted strings stay intact:
+
+```java
+List<String> entries = NamedAssetRegistry.defaultRegistry()
+        .splitTopLevel("SMA(7),Custom(\"a,b\",SMA(21)),RSI(14)");
+```
+
+## Round-Trip Checklist
+
+- Use canonical JSON for audit trails and long-lived storage.
+- Use v2 strategy JSON for human-authored strategy configs.
+- Use expressions for compact UI, CLI, and config values.
+- Keep `toJson()` output canonical; use `toCompactJson()` only when compact v2 output is desired.
+- Expect `toExpression(...)` to fail when no registered formatter can represent the descriptor.
+- Preserve all constructor inputs in serializable fields when adding new indicator, rule, strategy, or criterion support.
+- Add regression tests that compare canonical descriptors, not just object class names.
+- Prefer custom registry aliases over string parsing in application code.
+
+## Related Pages
+
+- [Trading Strategies](Trading-strategies.md)
+- [Technical Indicators](Technical-indicators.md)
+- [Analysis Criteria and Risk Metrics](Analysis-Criteria-and-Risk-Metrics.md)
+- [Usage Examples](Usage-examples.md)

--- a/Serialization-and-Named-Shorthand.md
+++ b/Serialization-and-Named-Shorthand.md
@@ -72,7 +72,7 @@ The same fields can be expressed as objects when that is easier for generated JS
   "exitRule": {
     "type": "OrRule",
     "rules": [
-      { "type": "SmaCrossDown", "args": [12, 26] },
+      { "type": "CrossedDownIndicatorRule", "args": ["SMA(12)", "SMA(26)"] },
       { "type": "StopLossRule", "args": ["2.5%"] }
     ]
   }

--- a/Serialization-and-Named-Shorthand.md
+++ b/Serialization-and-Named-Shorthand.md
@@ -35,6 +35,9 @@ String json = """
 Strategy strategy = Strategy.fromJson(series, json);
 String canonicalJson = strategy.toJson();
 String compactJson = strategy.toCompactJson();
+
+Strategy macroStrategy = Strategy.fromExpression(series, "SMA(7,21)");
+String expression = macroStrategy.toExpression(); // "SMA(7,21)"
 ```
 
 `SMA(7,21)` builds a `BaseStrategy` whose entry rule is `CrossedUpIndicatorRule(SMA(7), SMA(21))` and whose exit rule is `CrossedDownIndicatorRule(SMA(7), SMA(21))`. The strategy's unstable bar count is set to the slow SMA period.
@@ -87,6 +90,10 @@ Strategy v2 accepts these metadata fields:
 | `unstableBars` | Optional non-negative integer override. |
 | `startingType` | Optional `BUY` or `SELL`. |
 | `entryRule`, `exitRule` | Required when `strategy` is absent. Values may be expression strings or rule objects. |
+
+Use `Strategy.fromExpression(series, "SMA(7,21)")` when the whole strategy is a
+single registered macro. Use `Strategy.fromJson(series, json)` when you need
+metadata overrides, explicit entry/exit rules, or a stored v2 envelope.
 
 ## Indicators
 
@@ -224,6 +231,12 @@ Factories receive typed `NamedAssetRegistry.Arguments` helpers:
 
 Add a formatter when you also want `toExpression(...)` or `toCompactJson(...)` to emit your alias. Without a formatter, the alias is still valid for input.
 
+If an indicator alias may be used inside numeric comparison rules such as
+`Over(...)`, `Under(...)`, `CrossedUp(...)`, or `CrossedDown(...)`, it must
+rebuild an indicator whose runtime values are `Num`. Boolean indicators belong
+behind boolean-aware rules such as `BooleanIndicatorRule`; v2 strategy parsing
+rejects non-numeric indicator aliases at the rule argument that used them.
+
 To make application defaults automatic, implement `NamedAssetProvider` and register it with Java `ServiceLoader`:
 
 ```text
@@ -243,6 +256,11 @@ The expression grammar is intentionally strict:
 - Built-in bar-count arguments require positive integers.
 - Strategy `unstableBars` must be non-negative.
 - Strategy `startingType` must be `BUY` or `SELL`.
+- Malformed JSON-looking descriptor payloads fail as syntax errors. Plain labels
+  remain accepted only for non-JSON text.
+- Canonical descriptor numeric constructor arguments follow the same finite
+  JSON-number rule as shorthand; integer constructor parameters must be exact
+  integers and cannot silently truncate decimals.
 
 When processing lists of expressions from a CLI or configuration file, do not split on commas manually. Use `NamedAssetRegistry#splitTopLevel(...)` so nested expressions and quoted strings stay intact:
 
@@ -256,6 +274,9 @@ List<String> entries = NamedAssetRegistry.defaultRegistry()
 - Use canonical JSON for audit trails and long-lived storage.
 - Use v2 strategy JSON for human-authored strategy configs.
 - Use expressions for compact UI, CLI, and config values.
+- Use `Strategy.fromExpression(...)` / `Strategy#toExpression()` for whole
+  strategy macros and `Strategy#fromJson(...)` / `Strategy#toCompactJson()` for
+  v2 envelopes.
 - Keep `toJson()` output canonical; use `toCompactJson()` only when compact v2 output is desired.
 - Expect `toExpression(...)` to fail when no registered formatter can represent the descriptor.
 - Preserve all constructor inputs in serializable fields when adding new indicator, rule, strategy, or criterion support.

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -56,14 +56,14 @@ String json = rsi.toJson();
 Indicator<?> restored = Indicator.fromJson(series, json);
 ```
 
-Since 0.23.1, common indicators can also be authored through named expressions:
+The companion ta4j PR #1507, targeting 0.23.1, also lets common indicators be authored through named expressions:
 
 ```java
 Indicator<?> sma = Indicator.fromExpression(series, "SMA(21)");
 Indicator<?> rsiOfSma = Indicator.fromExpression(series, "RSI(SMA(14),9)");
 ```
 
-See [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md) for the full strategy, rule, indicator, and analysis-criterion guide.
+See [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md) for the full preview guide to strategy, rule, indicator, and analysis-criterion serialization in that PR.
 
 ## Market structure workflow (VWAP + S/R + Wyckoff)
 

--- a/Technical-indicators.md
+++ b/Technical-indicators.md
@@ -47,6 +47,24 @@ Indicator<Num> blendedMomentum = BinaryOperationIndicator.add(macdv.getMacd(), n
 - `BinaryOperationIndicator` / `UnaryOperationIndicator` are the preferred numeric composition APIs for new code; `CombineIndicator` remains available in `org.ta4j.core.indicators.helpers`.
 - Output indicators can feed directly into rules (`new OverIndicatorRule(trendBias, numOf(1.0))`) or become inputs to other indicators.
 
+## Serialization and shorthand
+
+Indicators can be persisted with canonical JSON:
+
+```java
+String json = rsi.toJson();
+Indicator<?> restored = Indicator.fromJson(series, json);
+```
+
+Since 0.23.1, common indicators can also be authored through named expressions:
+
+```java
+Indicator<?> sma = Indicator.fromExpression(series, "SMA(21)");
+Indicator<?> rsiOfSma = Indicator.fromExpression(series, "RSI(SMA(14),9)");
+```
+
+See [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md) for the full strategy, rule, indicator, and analysis-criterion guide.
+
 ## Market structure workflow (VWAP + S/R + Wyckoff)
 
 ta4j now includes a complete workflow for value, location, and phase analysis:

--- a/Trading-strategies.md
+++ b/Trading-strategies.md
@@ -205,7 +205,7 @@ Strategy restored = Strategy.fromJson(series, json);
 
 That JSON payload captures the full rule graph, making it safe to persist strategies between runs, transmit them over an API, or archive the configuration used for a specific backtest run. Use `rule.toJson()` and `Rule.fromJson(series, json)` when you only need to persist one rule subtree.
 
-Since 0.23.1, strategy JSON also has an opt-in compact v2 form:
+The companion ta4j PR #1507, targeting 0.23.1, adds an opt-in compact v2 strategy JSON form:
 
 ```java
 Strategy crossover = Strategy.fromJson(series, """
@@ -220,7 +220,7 @@ String compactJson = crossover.toCompactJson();
 ```
 
 `NamedStrategy` variants generate compact IDs (`ToggleNamedStrategy_true_false_u3`) that you can store alongside backtest results or in configuration files.
-For the complete guide to strategy, rule, indicator, and analysis-criterion serialization, see [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md).
+For the complete preview guide to strategy, rule, indicator, and analysis-criterion serialization in that PR, see [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md).
 
 ## Execution context tips
 

--- a/Trading-strategies.md
+++ b/Trading-strategies.md
@@ -205,7 +205,22 @@ Strategy restored = Strategy.fromJson(series, json);
 
 That JSON payload captures the full rule graph, making it safe to persist strategies between runs, transmit them over an API, or archive the configuration used for a specific backtest run. Use `rule.toJson()` and `Rule.fromJson(series, json)` when you only need to persist one rule subtree.
 
+Since 0.23.1, strategy JSON also has an opt-in compact v2 form:
+
+```java
+Strategy crossover = Strategy.fromJson(series, """
+        {
+          "version": 2,
+          "strategy": "SMA(7,21)",
+          "name": "Daily_SMA_Crossover"
+        }
+        """);
+
+String compactJson = crossover.toCompactJson();
+```
+
 `NamedStrategy` variants generate compact IDs (`ToggleNamedStrategy_true_false_u3`) that you can store alongside backtest results or in configuration files.
+For the complete guide to strategy, rule, indicator, and analysis-criterion serialization, see [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md).
 
 ## Execution context tips
 

--- a/Usage-examples.md
+++ b/Usage-examples.md
@@ -8,6 +8,7 @@ If you are deciding where to start, use this map:
 
 - First successful run: [Start quickly](#start-quickly)
 - Build and compare strategy logic: [Strategy patterns](#strategy-patterns)
+- Persist and reload configuration: [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)
 - Validate execution assumptions and metrics: [Backtesting & analytics](#backtesting--analytics)
 - Integrate bot loops and fill-driven recording: [Bots & live trading](#bots--live-trading)
 - Debug indicators and visual behavior: [Indicators & visualization](#indicators--visualization)

--- a/Usage-examples.md
+++ b/Usage-examples.md
@@ -8,7 +8,7 @@ If you are deciding where to start, use this map:
 
 - First successful run: [Start quickly](#start-quickly)
 - Build and compare strategy logic: [Strategy patterns](#strategy-patterns)
-- Persist and reload configuration: [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)
+- Preview compact serialization configuration: [Serialization and Named Shorthand](Serialization-and-Named-Shorthand.md)
 - Validate execution assumptions and metrics: [Backtesting & analytics](#backtesting--analytics)
 - Integrate bot loops and fill-driven recording: [Bots & live trading](#bots--live-trading)
 - Debug indicators and visual behavior: [Indicators & visualization](#indicators--visualization)

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -10,7 +10,7 @@
 - [Canonical User Journey](Canonical-User-Journey.md)
 - [Execution Decision Matrix](Execution-Decision-Matrix.md)
 - [Migration and Version Compatibility](Migration-and-Version-Compatibility.md)
-- [Serialization & Named Shorthand](Serialization-and-Named-Shorthand.md)
+- [Serialization Shorthand Preview](Serialization-and-Named-Shorthand.md)
 - [Examples Expected Outputs](Examples-Expected-Outputs.md)
 - [Performance Characterization](Performance-Characterization.md)
 - [FAQ](FAQ.md)
@@ -34,7 +34,7 @@
 
 ## Build Strategies
 - [Trading Strategies](Trading-strategies.md)
-- [Serialization & Named Shorthand](Serialization-and-Named-Shorthand.md)
+- [Serialization Shorthand Preview](Serialization-and-Named-Shorthand.md)
 - [Stop Loss & Stop Gain Rules](Stop-Loss-and-Stop-Gain-Rules.md)
 - [Backtesting Realism Checklist](Backtesting-Realism-Checklist.md)
 - [Analysis Criteria & Risk Metrics](Analysis-Criteria-and-Risk-Metrics.md)

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -10,6 +10,7 @@
 - [Canonical User Journey](Canonical-User-Journey.md)
 - [Execution Decision Matrix](Execution-Decision-Matrix.md)
 - [Migration and Version Compatibility](Migration-and-Version-Compatibility.md)
+- [Serialization & Named Shorthand](Serialization-and-Named-Shorthand.md)
 - [Examples Expected Outputs](Examples-Expected-Outputs.md)
 - [Performance Characterization](Performance-Characterization.md)
 - [FAQ](FAQ.md)
@@ -33,6 +34,7 @@
 
 ## Build Strategies
 - [Trading Strategies](Trading-strategies.md)
+- [Serialization & Named Shorthand](Serialization-and-Named-Shorthand.md)
 - [Stop Loss & Stop Gain Rules](Stop-Loss-and-Stop-Gain-Rules.md)
 - [Backtesting Realism Checklist](Backtesting-Realism-Checklist.md)
 - [Analysis Criteria & Risk Metrics](Analysis-Criteria-and-Risk-Metrics.md)


### PR DESCRIPTION
## Summary
- add a comprehensive serialization and named shorthand guide for strategies, indicators, rules, and analysis criteria
- link the guide from the wiki home/sidebar and related concept pages
- document compact strategy JSON v2, built-in aliases, registry extension points, and round-trip guidance

## Verification
- scripts/sync-readme-from-home.sh
- confirmed Home.md and README.md are identical
- docs-only change