### PR TITLE
Document trade sampling and borrowing cost applicability

### DIFF
--- a/Analysis-Criteria-and-Risk-Metrics.md
+++ b/Analysis-Criteria-and-Risk-Metrics.md
@@ -6,7 +6,7 @@ Use analysis criteria after a strategy run to compare returns, risk, duration, f
 
 | Need | Primary classes | Notes |
 | --- | --- | --- |
-| Risk-adjusted return | `SharpeRatioCriterion`, `SortinoRatioCriterion` | Support `SamplingFrequency`, `Annualization`, risk-free rates, grouping zones, cash-return policy, equity-curve mode, and open-position handling. |
+| Risk-adjusted return | `SharpeRatioCriterion`, `SortinoRatioCriterion` | Support `SamplingFrequency`, including trade-level sampling, `Annualization`, risk-free rates, grouping zones, cash-return policy, equity-curve mode, and open-position handling. |
 | Drawdown-adjusted return | `CalmarRatioCriterion`, `ReturnOverMaxDrawdownCriterion` | `CalmarRatioCriterion` annualizes return and divides by maximum drawdown. |
 | Distribution-aware return | `OmegaRatioCriterion` | Compares upside excess returns against downside shortfalls around a configurable threshold. |
 | Trade duration | `PositionDurationCriterion` | Summarizes closed-position durations with `Statistics` such as mean/min/max. |
@@ -18,10 +18,11 @@ Use analysis criteria after a strategy run to compare returns, risk, duration, f
 
 `SharpeRatioCriterion` and `SortinoRatioCriterion` build a return sample from the equity curve. Choose these settings deliberately:
 
-- `SamplingFrequency.BAR`, `SECOND`, `MINUTE`, `HOUR`, `DAY`, `WEEK`, or `MONTH` controls the return intervals.
+- `SamplingFrequency.BAR`, `SECOND`, `MINUTE`, `HOUR`, `DAY`, `WEEK`, or `MONTH` controls time-based return intervals.
+- `SamplingFrequency.TRADE` creates one return per included position interval. Use it when each trade, not each bar or calendar bucket, should contribute one observation.
 - `Annualization.PERIOD` returns the per-sample ratio; `Annualization.ANNUALIZED` scales by observed periods per year.
 - `EquityCurveMode.MARK_TO_MARKET` includes unrealized movement on each bar; `EquityCurveMode.REALIZED` updates the curve only when positions close.
-- `OpenPositionHandling.MARK_TO_MARKET` includes the current open position; `IGNORE` evaluates only closed positions.
+- `OpenPositionHandling.MARK_TO_MARKET` includes the current open position; `IGNORE` evaluates only closed positions. Realized Sharpe calculations always ignore open positions.
 
 ```java
 AnalysisCriterion sharpe = new SharpeRatioCriterion(
@@ -32,6 +33,26 @@ AnalysisCriterion sharpe = new SharpeRatioCriterion(
 
 Num score = sharpe.calculate(series, tradingRecord);
 ```
+
+For a trade-level distribution, switch only the sampling frequency:
+
+```java
+AnalysisCriterion tradeSharpe = new SharpeRatioCriterion(
+        0.05,
+        SamplingFrequency.TRADE,
+        Annualization.PERIOD,
+        ZoneOffset.UTC);
+AnalysisCriterion tradeSortino = new SortinoRatioCriterion(
+        0.05,
+        SamplingFrequency.TRADE,
+        Annualization.PERIOD,
+        ZoneOffset.UTC);
+
+Num perTradeSharpe = tradeSharpe.calculate(series, tradingRecord);
+Num perTradeSortino = tradeSortino.calculate(series, tradingRecord);
+```
+
+`TRADE` is for criteria that receive a `TradingRecord`, such as Sharpe and Sortino. It is intentionally not supported by `SamplingFrequencyIndexes`, because that helper can only group bar indices and cannot inspect positions.
 
 ## Windowed Criterion Evaluation
 

--- a/Backtesting.md
+++ b/Backtesting.md
@@ -47,6 +47,27 @@ BarSeriesManager manager = new BarSeriesManager(
         new TradeOnNextOpenModel());
 ```
 
+`LinearBorrowingCostModel` defaults to short-only borrowing costs, the same behavior as `Applicability.SHORT_ONLY`. When your venue charges funding or borrow-like costs on long exposure too, make that side selection explicit:
+
+```java
+CostModel shortBorrow = new LinearBorrowingCostModel(0.0001);
+CostModel explicitShortBorrow = new LinearBorrowingCostModel(
+        0.0001,
+        LinearBorrowingCostModel.Applicability.SHORT_ONLY);
+CostModel longBorrow = new LinearBorrowingCostModel(
+        0.0001,
+        LinearBorrowingCostModel.Applicability.LONG_ONLY);
+CostModel bothSidesBorrow = new LinearBorrowingCostModel(
+        0.0001,
+        LinearBorrowingCostModel.Applicability.BOTH);
+
+BarSeriesManager manager = new BarSeriesManager(
+        series,
+        new LinearTransactionCostModel(0.001),
+        bothSidesBorrow,
+        new TradeOnNextOpenModel());
+```
+
 Current execution-model choices are:
 
 - `TradeOnNextOpenModel` - default; signal at bar `t`, fill at the next bar open when one exists.


### PR DESCRIPTION
Companion docs for ta4j/ta4j#1571.

Summary:
- Show SamplingFrequency.TRADE usage for Sharpe and Sortino trade-level risk ratios.
- Show LinearBorrowingCostModel.Applicability for SHORT_ONLY, LONG_ONLY, and BOTH borrowing-cost side selection.
- Clarify that TRADE sampling belongs on TradingRecord-aware criteria, not index-only sampling helpers.

Checks:
- git diff --check
