### PR TITLE
Document recent high and low detection

### DIFF
--- a/Elliott-Wave-Indicators.md
+++ b/Elliott-Wave-Indicators.md
@@ -373,7 +373,7 @@ Next steps:
 - Use `ElliottScenarioIndicator` for multiple interpretations per bar.
 - Use `ElliottProjectionIndicator` for targets and `ElliottInvalidationLevelIndicator` for invalidation prices.
 - Customize confidence scoring with `ConfidenceProfiles` and `ScenarioTypeConfidenceModel`.
-- Explore detectors under `org.ta4j.core.indicators.elliott.swing` for fractal, ZigZag, or adaptive ZigZag swing detection.
+- Explore detectors under `org.ta4j.core.analysis.elliott.swing` for fractal, ZigZag, or adaptive ZigZag swing detection.
 
 ### Example Classes
 
@@ -672,9 +672,9 @@ import org.ta4j.core.indicators.elliott.ElliottAnalysisResult;
 import org.ta4j.core.indicators.elliott.ElliottDegree;
 import org.ta4j.core.indicators.elliott.ElliottLogicProfile;
 import org.ta4j.core.indicators.elliott.ElliottScenario;
-import org.ta4j.core.indicators.elliott.swing.AdaptiveZigZagConfig;
-import org.ta4j.core.indicators.elliott.swing.SwingDetector;
-import org.ta4j.core.indicators.elliott.swing.SwingDetectors;
+import org.ta4j.core.analysis.elliott.swing.AdaptiveZigZagConfig;
+import org.ta4j.core.analysis.elliott.swing.SwingDetector;
+import org.ta4j.core.analysis.elliott.swing.SwingDetectors;
 import org.ta4j.core.indicators.elliott.ElliottWaveAnalysisResult;
 import org.ta4j.core.indicators.elliott.ElliottWaveAnalysisRunner;
 
@@ -840,7 +840,7 @@ Use trend bias for entry filters (e.g. only enter long when bias is bullish and 
 
 ## Pluggable Swing Detection
 
-Elliott Wave analysis can use different swing detection backends via the **SwingDetector** interface (package `org.ta4j.core.indicators.elliott.swing`). The runner accepts any `SwingDetector` and optional `SwingFilter` and `ElliottSwingCompressor`.
+Elliott Wave analysis can use different swing detection backends via the **SwingDetector** interface (package `org.ta4j.core.analysis.elliott.swing`). The runner accepts any `SwingDetector` and optional `SwingFilter` and `ElliottSwingCompressor`.
 
 ### Built-in detectors
 
@@ -899,7 +899,7 @@ ElliottWaveAnalysisRunner runner = ElliottWaveAnalysisRunner.builder()
 - **AdaptiveZigZagConfig**: ATR period, multiplier, min/max threshold, smoothing for adaptive ZigZag.
 - **SlopeChangeConfig**: regression window, persistence count, ATR period, minimum slope change, and minimum ATR reversal. `defaults(window)` returns the balanced profile used by `SwingDetectors.slopeChange(window)`.
 
-See [Indicators Inventory](Indicators-Inventory.md#102-elliott-confidence-orgta4jcoreindicatorselliottconfidence) for the full list of swing and confidence types.
+See [Indicators Inventory](Indicators-Inventory.md#103-elliott-swing-detection-orgta4jcoreanalysiselliottswing) for the full list of swing detector support types.
 
 ---
 

--- a/Highs-and-Lows.md
+++ b/Highs-and-Lows.md
@@ -77,7 +77,7 @@ RecentSwingIndicators.Pair swings =
         RecentSwingIndicators.fromDetector(series, detector);
 ```
 
-`SwingDetector.detectPivots(series, index)` provides the confirmed pivot view without requiring Elliott degree metadata. `RecentSwingIndicators.Pair.method()` records the factory provenance; arbitrary detector adapters report `CUSTOM`.
+`SwingDetector.detectPivots(series, index)` provides the confirmed pivot view without requiring Elliott degree metadata. Detector-backed recent indicators preserve `SwingPivot.price()` for pivots detected through the current series end, so a custom detector can report a pivot level that differs from the bar's high or low source. The custom high/low price-source overload still defines the shared bar series and acts as the fallback for bars that are not known detector pivots. `RecentSwingIndicators.Pair.method()` records the factory provenance; arbitrary detector adapters report `CUSTOM`.
 
 ## ETH/USD reference behavior
 
@@ -110,7 +110,7 @@ These differences are interpretation, not errors: ZigZag reacts to reversal magn
 Run the comparison from a ta4j source checkout:
 
 ```bash
-mvn -pl ta4j-examples \
+./mvnw -pl ta4j-examples -am \
   -Dexec.mainClass=ta4jexamples.analysis.TrendLineAndSwingPointAnalysis \
   -Dexec.args="--no-display --no-save" \
   exec:java

--- a/Highs-and-Lows.md
+++ b/Highs-and-Lows.md
@@ -2,6 +2,8 @@
 
 Ta4j provides paired recent-swing indicators for local fractals, reversal-distance ZigZag, adaptive ZigZag, rounded slope changes, bounded price prominence, and multi-detector consensus. All confirmed indicators are causal: a query at index `i` only uses bars through `i`, even when the reported pivot belongs to an earlier bar.
 
+First-class ta4j indicators are named `*Indicator`. Swing configuration records such as `AdaptiveZigZagConfig`, `SlopeChangeConfig`, and `ProminenceSwingConfig`, plus detector helpers such as `SwingDetector` and `SwingDetectors`, live with the Elliott swing detector API and are not indicators themselves.
+
 ## Start with the default
 
 Use `RecentSwingIndicators.defaultFor(series)` unless the strategy has a reason to prefer another definition:

--- a/Highs-and-Lows.md
+++ b/Highs-and-Lows.md
@@ -2,7 +2,7 @@
 
 Ta4j provides paired recent-swing indicators for local fractals, reversal-distance ZigZag, adaptive ZigZag, rounded slope changes, bounded price prominence, and multi-detector consensus. All confirmed indicators are causal: a query at index `i` only uses bars through `i`, even when the reported pivot belongs to an earlier bar.
 
-First-class ta4j indicators are named `*Indicator`. Swing configuration records such as `AdaptiveZigZagConfig`, `SlopeChangeConfig`, and `ProminenceSwingConfig`, plus detector helpers such as `SwingDetector` and `SwingDetectors`, live with the Elliott swing detector API and are not indicators themselves.
+First-class ta4j indicators are named `*Indicator`. Swing configuration records such as `AdaptiveZigZagConfig`, `SlopeChangeConfig`, and `ProminenceSwingConfig`, plus detector helpers such as `SwingDetector` and `SwingDetectors`, live under `org.ta4j.core.analysis.elliott.swing` and are not indicators themselves.
 
 ## Start with the default
 

--- a/Highs-and-Lows.md
+++ b/Highs-and-Lows.md
@@ -1,0 +1,133 @@
+# Highs and Lows
+
+Ta4j provides paired recent-swing indicators for local fractals, reversal-distance ZigZag, adaptive ZigZag, rounded slope changes, bounded price prominence, and multi-detector consensus. All confirmed indicators are causal: a query at index `i` only uses bars through `i`, even when the reported pivot belongs to an earlier bar.
+
+## Start with the default
+
+Use `RecentSwingIndicators.defaultFor(series)` unless the strategy has a reason to prefer another definition:
+
+```java
+RecentSwingIndicators.Pair swings = RecentSwingIndicators.defaultFor(series);
+RecentSwingIndicator highs = swings.highs();
+RecentSwingIndicator lows = swings.lows();
+
+int endIndex = series.getEndIndex();
+Num recentHigh = highs.getValue(endIndex);
+int highBar = highs.getLatestSwingIndex(endIndex);
+int confirmedAt = highs.getLatestSwingConfirmationIndex(endIndex);
+```
+
+The canonical default is an OHLC-aware ATR(14) ZigZag:
+
+- Intrabar highs and lows locate the extremes.
+- Close prices confirm movement away from an extreme.
+- The reversal distance scales with volatility through ATR.
+- High and low indicators share one `ZigZagStateIndicator`.
+
+This is the best general balance of causal operation, noise filtering, scale independence, and variable confirmation time. Named constructors and methodology-specific behavior remain unchanged; choosing the canonical default does not silently convert Bill Williams, Wyckoff, or explicitly fractal workflows to ZigZag.
+
+## Method guide
+
+| Method | Factory | Confirmation | Prefer it when |
+| --- | --- | --- | --- |
+| ATR ZigZag | `defaultFor(series)` or `zigZag(series)` | Price reverses from an OHLC extreme by ATR(14) using close confirmation | You need one robust default across instruments and bar durations |
+| Fractal | `fractal(series)` | Three lower/higher bars on each side by default | Fixed latency and visually local extrema matter |
+| Adaptive ZigZag | `adaptiveZigZag(series)` or `adaptiveZigZag(series, config)` | Smoothed ATR threshold is crossed | Volatility regimes change enough to justify smoothing and clamps |
+| Slope change | `slopeChange(series)` | Rolling regression slope reverses and persists | Turns are rounded rather than sharp |
+| Prominence | `prominence(series)` | A local extreme stands at least one ATR beyond bounded surrounding baselines, with three right-side bars | You want fewer, structurally salient extrema without requiring a full ZigZag reversal |
+| Consensus | `consensus(series)` | Two of fractal, adaptive ZigZag, and slope change agree within two bars | False positives cost more than latency or computation |
+
+`ProminenceSwingConfig.defaults()` uses a 20-bar bounded baseline search, three confirmation bars, ATR(14), and one ATR of minimum prominence. Prominence is distinct from local-window dominance: a bar can be a fractal but still be rejected as insignificant relative to its surrounding baselines. This follows the standard topographic idea of [peak prominence](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.peak_prominences.html), implemented here with bounded causal evidence.
+
+The default consensus is deliberately not the global default. It is sparser, more expensive, and can hide a weak component when the remaining voters agree. Use it when agreement itself is part of the strategy thesis.
+
+## Confirmed and forming points
+
+`RecentSwingIndicator` remains confirmed-only and non-repainting. The paired API separately exposes the developing terminal extreme:
+
+```java
+RecentSwingIndicators.Pair swings = RecentSwingIndicators.defaultFor(series);
+
+RecentSwingIndicators.SwingPoint latestHigh =
+        swings.latestHigh(series.getEndIndex()).orElseThrow();
+
+if (latestHigh.confirmation() == RecentSwingIndicators.Confirmation.PROVISIONAL) {
+    // Useful for display, monitoring, or forming-structure diagnostics.
+    // It can move or disappear before confirmation.
+}
+```
+
+`formingPoint(index)` starts after the latest confirmed high or low, follows the next alternating leg, and returns its most extreme high or low with `confirmationIndex == -1`. If the last bar sets that extreme, it is visible immediately. Once the selected methodology confirms it, `latestHigh(...)` or `latestLow(...)` returns the same pivot as `CONFIRMED` with the exact confirmation index.
+
+Do not treat a provisional point as a confirmed entry or exit signal without accepting repaint risk. Keeping this status separate avoids a constructor flag that would silently change the meaning of `getValue`, `getLatestSwingIndex`, and `getSwingPointIndexesUpTo`.
+
+## Custom detectors and composites
+
+The detector family can be adapted to regular recent high/low indicators:
+
+```java
+SwingDetector detector = SwingDetectors.consensus(
+        2,
+        2,
+        SwingDetectors.prominence(),
+        SwingDetectors.slopeChange(7),
+        SwingDetectors.adaptiveZigZag(AdaptiveZigZagConfig.defaults()));
+
+RecentSwingIndicators.Pair swings =
+        RecentSwingIndicators.fromDetector(series, detector);
+```
+
+`SwingDetector.detectPivots(series, index)` provides the confirmed pivot view without requiring Elliott degree metadata. `RecentSwingIndicators.Pair.method()` records the factory provenance; arbitrary detector adapters report `CUSTOM`.
+
+## ETH/USD reference behavior
+
+The analysis harness uses ossified Coinbase ETH/USD fixtures at `PT5M`, `PT15M`, `PT1H`, `PT4H`, and `PT1D`. On the hourly fixture, the candle beginning `2026-07-22T16:00:00Z` (12 PM EDT) has close `1949.30` and high `1955.87`.
+
+Every method reports that candle as the latest confirmed swing high before the fixture ends:
+
+| Method | Confirmation delay from the hourly high |
+| --- | ---: |
+| ATR ZigZag | 1 bar |
+| Adaptive ZigZag | 1 bar |
+| Fractal | 3 bars |
+| Slope change | 3 bars |
+| Prominence | 3 bars |
+| Consensus | 3 bars |
+
+The methods should not produce identical histories. On the hourly fixture, high/low counts were:
+
+| Method | Highs | Lows |
+| --- | ---: | ---: |
+| ATR ZigZag | 17 | 18 |
+| Fractal | 11 | 13 |
+| Adaptive ZigZag | 13 | 13 |
+| Slope change | 7 | 7 |
+| Prominence | 7 | 5 |
+| Consensus | 7 | 7 |
+
+These differences are interpretation, not errors: ZigZag reacts to reversal magnitude, fractals to fixed neighborhoods, slope change to direction persistence, prominence to structural relief, and consensus to agreement. The regression suite additionally verifies that each method produces highs and lows on all five tested durations.
+
+Run the comparison from a ta4j source checkout:
+
+```bash
+mvn -pl ta4j-examples \
+  -Dexec.mainClass=ta4jexamples.analysis.TrendLineAndSwingPointAnalysis \
+  -Dexec.args="--no-display --no-save" \
+  exec:java
+```
+
+## Causal and live-series guarantees
+
+- Historical queries are filtered by confirmation index. Discovering a pivot at a later bar cannot leak it into an earlier query.
+- Replacing or revising the live terminal bar rewinds affected swing tracking instead of leaving a stale confirmation.
+- Dynamic ZigZag thresholds formed during indicator warm-up adopt the first finite positive threshold and pin it to that candidate; an early ATR `NaN` cannot freeze the state indefinitely.
+- Confirmed pivot indexes can be earlier than their confirmation indexes. Store both when auditing signal timing.
+- Use high/low price sources when identifying price extremes. A close-based series answers a different question and would report `1949.30`, not the hourly wick high `1955.87`, for the ETH example.
+
+## What is not a separate method
+
+- Directional-change detection is already expressible by ZigZag with a fixed, percentage-derived, ATR, or custom reversal threshold.
+- Donchian channels and rolling highest/lowest indicators expose levels but do not confirm turning points.
+- Session pivot points derive reference levels from prior-session OHLC; they are not recent empirical swing extrema.
+
+This keeps the toolkit small: add a methodology only when it supplies meaning that cannot already be composed from the existing reversal, neighborhood, slope, prominence, and consensus building blocks.

--- a/Highs-and-Lows.md
+++ b/Highs-and-Lows.md
@@ -112,7 +112,8 @@ These differences are interpretation, not errors: ZigZag reacts to reversal magn
 Run the comparison from a ta4j source checkout:
 
 ```bash
-./mvnw -pl ta4j-examples -am \
+./mvnw -pl ta4j-examples -am install
+./mvnw -pl ta4j-examples \
   -Dexec.mainClass=ta4jexamples.analysis.TrendLineAndSwingPointAnalysis \
   -Dexec.args="--no-display --no-save" \
   exec:java

--- a/Home.md
+++ b/Home.md
@@ -50,6 +50,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Data Sources](Data-Sources.md)** - Loading bars or trades from files and HTTP providers
 - **[Num](Num.md)** - Precision-aware numeric types such as `DoubleNum` and `DecimalNum`
 - **[Technical Indicators](Technical-indicators.md)** - Indicator composition and caching
+- **[Highs and Lows](Highs-and-Lows.md)** - Recent swing methods, canonical defaults, confirmation timing, and forming extremes
 - **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, point projections, and strategy filters
 - **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical, rough-volatility, and Bayesian regime moments, representation-bound schemas, and provenance-aware summaries
 - **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -351,22 +351,28 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 ## 9. Swing & zigzag
 
+### 9.1. First-class swing indicators
+
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators` | **RecentSwingIndicator** | Generic recent swing (e.g. value at last swing). |
-| `org.ta4j.core.indicators` | **RecentSwingIndicators** | Canonical factory and paired confirmed/provisional view for all swing methodologies. |
 | `org.ta4j.core.indicators` | **FractalHighIndicator** | Bill Williams fractal high confirmation indicator (no look-ahead). |
 | `org.ta4j.core.indicators` | **FractalLowIndicator** | Bill Williams fractal low confirmation indicator (no look-ahead). |
 | `org.ta4j.core.indicators` | **RecentFractalSwingHighIndicator** | Most recent fractal swing high (Bill Williams style). |
 | `org.ta4j.core.indicators` | **RecentFractalSwingLowIndicator** | Most recent fractal swing low. |
 | `org.ta4j.core.indicators` | **RecentProminenceSwingHighIndicator** | Most recent ATR-qualified bounded-prominence swing high. |
 | `org.ta4j.core.indicators` | **RecentProminenceSwingLowIndicator** | Most recent ATR-qualified bounded-prominence swing low. |
-| `org.ta4j.core.indicators` | **ProminenceSwingConfig** | Bounded baseline, confirmation, plateau, and ATR prominence configuration. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagPivotHighIndicator** | True at ZigZag pivot high bars. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagPivotLowIndicator** | True at ZigZag pivot low bars. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagStateIndicator** | ZigZag state (e.g. current segment direction and levels). |
 | `org.ta4j.core.indicators.zigzag` | **RecentZigZagSwingHighIndicator** | Most recent ZigZag swing high price. |
 | `org.ta4j.core.indicators.zigzag` | **RecentZigZagSwingLowIndicator** | Most recent ZigZag swing low price. |
+
+### 9.2. Swing indicator factory
+
+| FQN | Class | Description (from codebase) |
+|-----|-------|-----------------------------|
+| `org.ta4j.core.indicators` | **RecentSwingIndicators** | Canonical factory and paired confirmed/provisional view for all swing methodologies; not itself an indicator. |
 
 **Short usage**  
 - **What it is:** Swing high/low and ZigZag pivots; “recent” variants expose the last confirmed swing level.  
@@ -398,24 +404,38 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 ### 10.1. Elliott swing detection (org.ta4j.core.indicators.elliott.swing)
 
+These are detector, configuration, pivot, and filter support types. They are not first-class `Indicator` implementations; first-class indicators use the `*Indicator` naming convention and are listed in the indicator tables above.
+
+#### Detector API and factories
+
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.elliott.swing` | **SwingDetector** | Interface: detects swing pivots and constructs swing sequences for a bar index. |
-| `org.ta4j.core.indicators.elliott.swing` | **SwingDetectorResult** | Record: detected pivots and derived swings for a given index. |
 | `org.ta4j.core.indicators.elliott.swing` | **SwingDetectors** | Factory helpers for fractal, adaptive ZigZag, slope-change, prominence, composite, and tolerant multi-scale swing detectors. |
 | `org.ta4j.core.indicators.elliott.swing` | **FractalSwingDetector** | Swing detector backed by fractal swing high/low (fixed lookback/lookforward window). |
 | `org.ta4j.core.indicators.elliott.swing` | **ZigZagSwingDetector** | Swing detector backed by ZigZag state (reversal threshold or ATR-based). |
 | `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagSwingDetector** | ZigZag swing detector that adapts reversal threshold to volatility (ATR-based). |
-| `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagConfig** | Record: ATR period, multiplier, min/max threshold, smoothing for adaptive ZigZag. |
 | `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeSwingDetector** | Detects rounded turns from sustained causal changes in rolling regression slope; supports balanced window-only construction. |
-| `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeConfig** | Record: slope window, confirmation persistence, ATR period, and magnitude filters. |
 | `org.ta4j.core.indicators.elliott.swing` | **ProminenceSwingDetector** | Detects bounded topographic price prominence with ATR-scaled qualification. |
 | `org.ta4j.core.indicators.elliott.swing` | **CompositeSwingDetector** | Combines detectors with exact AND/OR agreement or tolerant clustered quorum voting. |
+
+#### Configuration records
+
+| FQN | Class | Description (from codebase) |
+|-----|-------|-----------------------------|
+| `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagConfig** | Record: ATR period, multiplier, min/max threshold, smoothing for adaptive ZigZag. |
+| `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeConfig** | Record: slope window, confirmation persistence, ATR period, and magnitude filters. |
+| `org.ta4j.core.indicators.elliott.swing` | **ProminenceSwingConfig** | Record: bounded baseline, confirmation, plateau, and ATR prominence configuration. |
+
+#### Pivot/filter support
+
+| FQN | Class | Description (from codebase) |
+|-----|-------|-----------------------------|
+| `org.ta4j.core.indicators.elliott.swing` | **SwingDetectorResult** | Record: detected pivots and derived swings for a given index. |
 | `org.ta4j.core.indicators.elliott.swing` | **MinMagnitudeSwingFilter** | SwingFilter that drops swings below a relative magnitude of the largest swing. |
 | `org.ta4j.core.indicators.elliott.swing` | **SwingFilter** | Interface: post-processes swing lists (e.g. remove noise, apply constraints). |
 | `org.ta4j.core.indicators.elliott.swing` | **SwingPivot** | Record: confirmed swing pivot (index, price, type high/low). |
 | `org.ta4j.core.indicators.elliott.swing` | **SwingPivotType** | Enum: pivot classification (high/low). |
-| `org.ta4j.core.indicators.elliott.swing` | **SwingDetectorSupport** | Helper for building ElliottSwing lists from detector results. |
 
 ### 10.2. Elliott confidence (org.ta4j.core.indicators.elliott.confidence)
 

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -385,6 +385,8 @@ For an overview of indicator categories and composition patterns, see [Technical
 
 ## 10. Elliott Wave
 
+### 10.1. First-class Elliott indicators
+
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.elliott` | **ElliottSwingIndicator** | List of Elliott swings (structure) at each index. |
@@ -398,46 +400,54 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.elliott` | **ElliottScenarioIndicator** | Set of possible Elliott scenarios at index. |
 | `org.ta4j.core.indicators.elliott` | **ElliottConfluenceIndicator** | Confluence score (e.g. agreement across scenarios). |
 | `org.ta4j.core.indicators.elliott` | **ElliottTrendBiasIndicator** | Aggregate directional bias across Elliott wave scenarios (bullish/bearish/neutral). |
+
+### 10.2. Elliott support types
+
+These types support Elliott analysis but are not first-class indicators. Some
+remain in `org.ta4j.core.indicators.elliott` for existing API continuity.
+
+| FQN | Class | Description (from codebase) |
+|-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.elliott` | **ElliottWaveAnalysisRunner** | One-shot Elliott analysis entry point; can analyze supporting degrees and returns `ElliottWaveAnalysisResult`. |
 | `org.ta4j.core.indicators.elliott` | **ElliottScenarioSet** | Immutable container of ranked alternative Elliott scenarios (base case + alternatives). |
 | `org.ta4j.core.indicators.elliott` | **PatternSet** | Configures which Elliott scenario pattern types are enabled (impulse, corrective zigzag, etc.). |
 
-### 10.1. Elliott swing detection (org.ta4j.core.indicators.elliott.swing)
+### 10.3. Elliott swing detection (org.ta4j.core.analysis.elliott.swing)
 
-These are detector, configuration, pivot, and filter support types. They are not first-class `Indicator` implementations; first-class indicators use the `*Indicator` naming convention and are listed in the indicator tables above.
+These are analysis support types for detector, configuration, pivot, and filter workflows. They are not first-class `Indicator` implementations; first-class indicators use the `*Indicator` naming convention and are listed in the indicator tables above.
 
 #### Detector API and factories
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
-| `org.ta4j.core.indicators.elliott.swing` | **SwingDetector** | Interface: detects swing pivots and constructs swing sequences for a bar index. |
-| `org.ta4j.core.indicators.elliott.swing` | **SwingDetectors** | Factory helpers for fractal, adaptive ZigZag, slope-change, prominence, composite, and tolerant multi-scale swing detectors. |
-| `org.ta4j.core.indicators.elliott.swing` | **FractalSwingDetector** | Swing detector backed by fractal swing high/low (fixed lookback/lookforward window). |
-| `org.ta4j.core.indicators.elliott.swing` | **ZigZagSwingDetector** | Swing detector backed by ZigZag state (reversal threshold or ATR-based). |
-| `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagSwingDetector** | ZigZag swing detector that adapts reversal threshold to volatility (ATR-based). |
-| `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeSwingDetector** | Detects rounded turns from sustained causal changes in rolling regression slope; supports balanced window-only construction. |
-| `org.ta4j.core.indicators.elliott.swing` | **ProminenceSwingDetector** | Detects bounded topographic price prominence with ATR-scaled qualification. |
-| `org.ta4j.core.indicators.elliott.swing` | **CompositeSwingDetector** | Combines detectors with exact AND/OR agreement or tolerant clustered quorum voting. |
+| `org.ta4j.core.analysis.elliott.swing` | **SwingDetector** | Interface: detects swing pivots and constructs swing sequences for a bar index. |
+| `org.ta4j.core.analysis.elliott.swing` | **SwingDetectors** | Factory helpers for fractal, adaptive ZigZag, slope-change, prominence, composite, and tolerant multi-scale swing detectors. |
+| `org.ta4j.core.analysis.elliott.swing` | **FractalSwingDetector** | Swing detector backed by fractal swing high/low (fixed lookback/lookforward window). |
+| `org.ta4j.core.analysis.elliott.swing` | **ZigZagSwingDetector** | Swing detector backed by ZigZag state (reversal threshold or ATR-based). |
+| `org.ta4j.core.analysis.elliott.swing` | **AdaptiveZigZagSwingDetector** | ZigZag swing detector that adapts reversal threshold to volatility (ATR-based). |
+| `org.ta4j.core.analysis.elliott.swing` | **SlopeChangeSwingDetector** | Detects rounded turns from sustained causal changes in rolling regression slope; supports balanced window-only construction. |
+| `org.ta4j.core.analysis.elliott.swing` | **ProminenceSwingDetector** | Detects bounded topographic price prominence with ATR-scaled qualification. |
+| `org.ta4j.core.analysis.elliott.swing` | **CompositeSwingDetector** | Combines detectors with exact AND/OR agreement or tolerant clustered quorum voting. |
 
 #### Configuration records
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
-| `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagConfig** | Record: ATR period, multiplier, min/max threshold, smoothing for adaptive ZigZag. |
-| `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeConfig** | Record: slope window, confirmation persistence, ATR period, and magnitude filters. |
-| `org.ta4j.core.indicators.elliott.swing` | **ProminenceSwingConfig** | Record: bounded baseline, confirmation, plateau, and ATR prominence configuration. |
+| `org.ta4j.core.analysis.elliott.swing` | **AdaptiveZigZagConfig** | Record: ATR period, multiplier, min/max threshold, smoothing for adaptive ZigZag. |
+| `org.ta4j.core.analysis.elliott.swing` | **SlopeChangeConfig** | Record: slope window, confirmation persistence, ATR period, and magnitude filters. |
+| `org.ta4j.core.analysis.elliott.swing` | **ProminenceSwingConfig** | Record: bounded baseline, confirmation, plateau, and ATR prominence configuration. |
 
 #### Pivot/filter support
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
-| `org.ta4j.core.indicators.elliott.swing` | **SwingDetectorResult** | Record: detected pivots and derived swings for a given index. |
-| `org.ta4j.core.indicators.elliott.swing` | **MinMagnitudeSwingFilter** | SwingFilter that drops swings below a relative magnitude of the largest swing. |
-| `org.ta4j.core.indicators.elliott.swing` | **SwingFilter** | Interface: post-processes swing lists (e.g. remove noise, apply constraints). |
-| `org.ta4j.core.indicators.elliott.swing` | **SwingPivot** | Record: confirmed swing pivot (index, price, type high/low). |
-| `org.ta4j.core.indicators.elliott.swing` | **SwingPivotType** | Enum: pivot classification (high/low). |
+| `org.ta4j.core.analysis.elliott.swing` | **SwingDetectorResult** | Record: detected pivots and derived swings for a given index. |
+| `org.ta4j.core.analysis.elliott.swing` | **MinMagnitudeSwingFilter** | SwingFilter that drops swings below a relative magnitude of the largest swing. |
+| `org.ta4j.core.analysis.elliott.swing` | **SwingFilter** | Interface: post-processes swing lists (e.g. remove noise, apply constraints). |
+| `org.ta4j.core.analysis.elliott.swing` | **SwingPivot** | Record: confirmed swing pivot (index, price, type high/low). |
+| `org.ta4j.core.analysis.elliott.swing` | **SwingPivotType** | Enum: pivot classification (high/low). |
 
-### 10.2. Elliott confidence (org.ta4j.core.indicators.elliott.confidence)
+### 10.4. Elliott confidence (org.ta4j.core.indicators.elliott.confidence)
 
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -354,10 +354,14 @@ For an overview of indicator categories and composition patterns, see [Technical
 | FQN | Class | Description (from codebase) |
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators` | **RecentSwingIndicator** | Generic recent swing (e.g. value at last swing). |
+| `org.ta4j.core.indicators` | **RecentSwingIndicators** | Canonical factory and paired confirmed/provisional view for all swing methodologies. |
 | `org.ta4j.core.indicators` | **FractalHighIndicator** | Bill Williams fractal high confirmation indicator (no look-ahead). |
 | `org.ta4j.core.indicators` | **FractalLowIndicator** | Bill Williams fractal low confirmation indicator (no look-ahead). |
 | `org.ta4j.core.indicators` | **RecentFractalSwingHighIndicator** | Most recent fractal swing high (Bill Williams style). |
 | `org.ta4j.core.indicators` | **RecentFractalSwingLowIndicator** | Most recent fractal swing low. |
+| `org.ta4j.core.indicators` | **RecentProminenceSwingHighIndicator** | Most recent ATR-qualified bounded-prominence swing high. |
+| `org.ta4j.core.indicators` | **RecentProminenceSwingLowIndicator** | Most recent ATR-qualified bounded-prominence swing low. |
+| `org.ta4j.core.indicators` | **ProminenceSwingConfig** | Bounded baseline, confirmation, plateau, and ATR prominence configuration. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagPivotHighIndicator** | True at ZigZag pivot high bars. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagPivotLowIndicator** | True at ZigZag pivot low bars. |
 | `org.ta4j.core.indicators.zigzag` | **ZigZagStateIndicator** | ZigZag state (e.g. current segment direction and levels). |
@@ -369,7 +373,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 - **Theory:** Swing points define structure; ZigZag filters small moves and highlights significant reversals.  
 - **When to use:** Trend lines, invalidation levels, and structure for Elliott or other pattern logic.  
 - **When not to use:** When look-back or threshold is too small (noisy pivots).  
-- *Future: use cases, example code.*
+- See also: [Highs and Lows](Highs-and-Lows.md).
 
 ---
 
@@ -398,13 +402,14 @@ For an overview of indicator categories and composition patterns, see [Technical
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.elliott.swing` | **SwingDetector** | Interface: detects swing pivots and constructs swing sequences for a bar index. |
 | `org.ta4j.core.indicators.elliott.swing` | **SwingDetectorResult** | Record: detected pivots and derived swings for a given index. |
-| `org.ta4j.core.indicators.elliott.swing` | **SwingDetectors** | Factory helpers for fractal, adaptive ZigZag, slope-change, composite, and tolerant multi-scale swing detectors. |
+| `org.ta4j.core.indicators.elliott.swing` | **SwingDetectors** | Factory helpers for fractal, adaptive ZigZag, slope-change, prominence, composite, and tolerant multi-scale swing detectors. |
 | `org.ta4j.core.indicators.elliott.swing` | **FractalSwingDetector** | Swing detector backed by fractal swing high/low (fixed lookback/lookforward window). |
 | `org.ta4j.core.indicators.elliott.swing` | **ZigZagSwingDetector** | Swing detector backed by ZigZag state (reversal threshold or ATR-based). |
 | `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagSwingDetector** | ZigZag swing detector that adapts reversal threshold to volatility (ATR-based). |
 | `org.ta4j.core.indicators.elliott.swing` | **AdaptiveZigZagConfig** | Record: ATR period, multiplier, min/max threshold, smoothing for adaptive ZigZag. |
 | `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeSwingDetector** | Detects rounded turns from sustained causal changes in rolling regression slope; supports balanced window-only construction. |
 | `org.ta4j.core.indicators.elliott.swing` | **SlopeChangeConfig** | Record: slope window, confirmation persistence, ATR period, and magnitude filters. |
+| `org.ta4j.core.indicators.elliott.swing` | **ProminenceSwingDetector** | Detects bounded topographic price prominence with ATR-scaled qualification. |
 | `org.ta4j.core.indicators.elliott.swing` | **CompositeSwingDetector** | Combines detectors with exact AND/OR agreement or tolerant clustered quorum voting. |
 | `org.ta4j.core.indicators.elliott.swing` | **MinMagnitudeSwingFilter** | SwingFilter that drops swings below a relative magnitude of the largest swing. |
 | `org.ta4j.core.indicators.elliott.swing` | **SwingFilter** | Interface: post-processes swing lists (e.g. remove noise, apply constraints). |

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The current wiki reflects ta4j's newer unified trading stack:
 - **[Data Sources](Data-Sources.md)** - Loading bars or trades from files and HTTP providers
 - **[Num](Num.md)** - Precision-aware numeric types such as `DoubleNum` and `DecimalNum`
 - **[Technical Indicators](Technical-indicators.md)** - Indicator composition and caching
+- **[Highs and Lows](Highs-and-Lows.md)** - Recent swing methods, canonical defaults, confirmation timing, and forming extremes
 - **[Forecast Indicators](Forecast-Indicators.md)** - Forward-looking return and price distributions, point projections, and strategy filters
 - **[Forecast State Estimation](Forecast-State-Estimation.md)** - Minimal lifecycle state, canonical, rough-volatility, and Bayesian regime moments, representation-bound schemas, and provenance-aware summaries
 - **[Forecast Projection Models](Forecast-Projection-Models.md)** - Analog neighbors, rolling conformal calibration, maturity guards, tuning, and failure behavior

--- a/Trendlines-and-Swing-Points.md
+++ b/Trendlines-and-Swing-Points.md
@@ -2,6 +2,10 @@
 
 Trendlines and swing points are the core building blocks behind support/resistance analysis, breakout systems, and Elliott-style structure detection. Ta4j ships a full toolkit for detecting swings, turning them into markers, and projecting data-driven support and resistance lines that behave the way traders draw them by hand.
 
+For the complete detector comparison, canonical default, confirmation timing,
+forming-point API, and ETH/USD reference behavior, see
+[Highs and Lows](Highs-and-Lows.md).
+
 ## What you get
 - **Fractal swing detectors**: window-based swing highs/lows with configurable symmetry and tolerance for flat tops/bottoms.
 - **ZigZag swing detectors**: OHLC-aware ATR/price-threshold reversals for adaptive swing confirmation without fixed lookahead windows.
@@ -55,7 +59,7 @@ Use fractals when you want visually obvious turning points and don’t mind wait
 ```java
 // 7-bar symmetric window that tolerates one additional equal bar in the plateau
 RecentFractalSwingHighIndicator majorHighs = new RecentFractalSwingHighIndicator(high, 7, 7, 1);
-int latestHighIndex = majorHighs.getLatestSwingHighIndex(series.getEndIndex());
+int latestHighIndex = majorHighs.getLatestSwingIndex(series.getEndIndex());
 ```
 
 ### ZigZag swings (reversal-threshold based)
@@ -95,7 +99,12 @@ No single formula is best for every turn shape:
 | Fractal | Distinct local extrema and fixed timing requirements | Waits for the configured right-side window. |
 | ZigZag | Sharp reversals whose importance is defined by price distance or volatility | Confirms after the reversal threshold is crossed. |
 
-These two sources implement `RecentSwingIndicator` and plug directly into trendline and marker indicators. Elliott analysis also supports slope-change and tolerant consensus backends through its separate `SwingDetector` contract; see [Pluggable Swing Detection](Elliott-Wave-Indicators.md#pluggable-swing-detection) for those runner-specific APIs.
+All detector families can now be exposed as paired `RecentSwingIndicator`
+instances through `RecentSwingIndicators`, including slope-change, prominence,
+adaptive ZigZag, and tolerant consensus. See
+[Highs and Lows](Highs-and-Lows.md#method-guide) for selection guidance and
+[Pluggable Swing Detection](Elliott-Wave-Indicators.md#pluggable-swing-detection)
+for Elliott-specific composition.
 
 Both trendline swing sources are causal at the requested evaluation index: they use only bars available at that index, while the reported pivot can refer to the earlier bar where the confirmed extreme occurred.
 
@@ -193,7 +202,11 @@ TrendLineResistanceIndicator tightResistance = new TrendLineResistanceIndicator(
 - **Descriptor/JSON**: `support.toJson()` serializes parameters and the swing subtree for persistence.
 
 ### Runnable analysis harness
-`ta4jexamples.analysis.TrendLineAndSwingPointAnalysis` is the companion example for this page. It performs regression-style headroom checks across bundled datasets for fractal and ZigZag swing sources, then renders a chart with support/resistance lines and swing markers.
+`ta4jexamples.analysis.TrendLineAndSwingPointAnalysis` is the companion example
+for this page. It performs regression-style headroom checks, compares all recent
+swing methods across ossified ETH/USD `PT5M` through `PT1D` fixtures, verifies
+the July 22 hourly reference high, then renders a chart with support/resistance
+lines and swing markers.
 
 Run it from the ta4j source checkout:
 

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -28,6 +28,7 @@
 - [Forecast 0.23.1 Migration](Migration-and-Version-Compatibility.md#forecast-api-correction-in-0231)
 - [Moving Average Indicators](Moving-Average-Indicators.md)
 - [Bill Williams Indicators](Bill-Williams-Indicators.md)
+- [Highs and Lows](Highs-and-Lows.md)
 - [Trendlines & Swing Points](Trendlines-and-Swing-Points.md)
 - [Elliott Wave Quickstart](Elliott-Wave-Quickstart.md)
 - [VWAP, S/R & Wyckoff Guide](VWAP-Support-Resistance-and-Wyckoff.md)


### PR DESCRIPTION
Paired documentation for ta4j/ta4j#1582.

Summary:
- Add a dedicated Highs and Lows guide covering default, fractal, ZigZag, adaptive ZigZag, slope-change, prominence, and consensus swing methods.
- Document confirmed versus forming swing points, detector-backed price behavior, ETH/USD reference behavior, and method-selection guidance.
- Link the guide from the wiki navigation and indicator inventory.

Validation:
- Documentation-only wiki update; reviewed local rendered Markdown source and command snippets.