### PR TITLE
Document Hurst exponent and CHOP APIs

### DIFF
--- a/Forecast-Indicators.md
+++ b/Forecast-Indicators.md
@@ -178,7 +178,7 @@ RoughVolatilityForecastStateIndicator rough =
 RoughVolatilityForecastState state = rough.getValue(index);
 ```
 
-It reuses canonical EWMA moments and adds bounded log-variogram Hurst, population dispersion of the logarithmic volatility proxy, and five cumulative horizon variances by default. The representation-bound `ForecastFeatureExtractors.roughVolatility()` schema exposes `[mean, volatility, roughness_hurst, vol_of_vol]` for models that intentionally use those diagnostics. See [Forecast State Estimation](Forecast-State-Estimation.md#rough-volatility-state) for advanced tuning, exact field semantics, warm-up, recovery, and when to prefer the smaller EWMA state.
+It reuses canonical EWMA moments and composes `HurstExponentIndicator` over the logarithmic volatility proxy, then applies the rough model's `[0.01, 0.49]` bound. Population dispersion of that proxy and five cumulative horizon variances complete the default state. The representation-bound `ForecastFeatureExtractors.roughVolatility()` schema exposes `[mean, volatility, roughness_hurst, vol_of_vol]` for models that intentionally use those diagnostics. See [Forecast State Estimation](Forecast-State-Estimation.md#rough-volatility-state) for advanced tuning, exact field semantics, warm-up, recovery, and when to prefer the smaller EWMA state.
 
 ## Online Change-Point State
 

--- a/Forecast-State-Estimation.md
+++ b/Forecast-State-Estimation.md
@@ -110,6 +110,18 @@ RoughVolatilityForecastStateIndicator states =
 
 The first horizon variance is factory-coherent with the current canonical variance. The estimator uses lags one through ten, or all available lags for shorter configured windows, and floors each variogram at `1e-12` before taking its logarithm. These are deterministic state diagnostics, not a claim that returns follow a complete rough-volatility pricing model.
 
+The same rolling statistic is independently reusable:
+
+```java
+HurstExponentIndicator hurst =
+        new HurstExponentIndicator(new ClosePriceIndicator(series), 120);
+Num currentHurst = hurst.getValue(index);
+```
+
+`HurstExponentIndicator` accepts close prices or any `Indicator<Num>` and returns
+the general estimate bounded to `[0, 1]`. Rough-volatility state composes it over
+`log(abs(return) + 1e-8)` and owns the narrower `[0.01, 0.49]` policy.
+
 The state remains unstable until EWMA initialization, the roughness window, and the vol-of-vol window are all complete and finite. A non-finite return resets availability for every affected rolling window; later indices recover automatically. Unstable state preserves the known observation count, uses `NaN.NaN` for specialized scalars, and exposes an empty variance list.
 
 Use rough-volatility state when changing volatility persistence or multi-horizon risk shape is part of the model. Prefer `EwmaReturnForecastStateIndicator` when current mean and variance are sufficient, the available history is short, or the extra dimensions have not earned their place in out-of-sample testing.

--- a/Indicators-Inventory.md
+++ b/Indicators-Inventory.md
@@ -138,7 +138,7 @@ For an overview of indicator categories and composition patterns, see [Technical
 | `org.ta4j.core.indicators.donchian` | **DonchianChannelFacade** | Fluent builder that exposes cached numeric Donchian lower/upper/middle channels from one constructor call. |
 | `org.ta4j.core.indicators` | **ChandelierExitLongIndicator** | Chandelier Exit (long): highest high minus ATR-based offset. |
 | `org.ta4j.core.indicators` | **ChandelierExitShortIndicator** | Chandelier Exit (short): lowest low plus ATR-based offset. |
-| `org.ta4j.core.indicators` | **ChopIndicator** | Choppiness Index (0–100); measures trend vs range. |
+| `org.ta4j.core.indicators` | **ChopIndicator** | Choppiness Index; defaults to percentage output (0–100), supports decimal output (0–1), and retains deprecated arbitrary integer scaling. |
 | `org.ta4j.core.indicators` | **UlcerIndexIndicator** | Ulcer Index; depth and duration of drawdowns. |
 | `org.ta4j.core.indicators` | **SqueezeProIndicator** | Squeeze Pro; momentum in low volatility (e.g. Bollinger vs Keltner). |
 | `org.ta4j.core.indicators` | **CompressionIndicator** | Composite contraction score (0–100) from inverted ATR, Bollinger width, and Donchian width percentile ranks. |
@@ -479,6 +479,7 @@ These are analysis support types for detector, configuration, pivot, and filter 
 |-----|-------|-----------------------------|
 | `org.ta4j.core.indicators.statistics` | **StandardDeviationIndicator** | Standard deviation of source over period; supports sample/population modes. |
 | `org.ta4j.core.indicators.statistics` | **VarianceIndicator** | Variance of source over period; defaults to sample variance and supports explicit sample/population modes. |
+| `org.ta4j.core.indicators.statistics` | **HurstExponentIndicator** | Rolling bounded `[0, 1]` Hurst estimate from a configurable log-variogram regression over close prices or any numeric indicator. |
 | `org.ta4j.core.indicators.statistics` | **MeanDeviationIndicator** | Mean absolute deviation. |
 | `org.ta4j.core.indicators.statistics` | **CovarianceIndicator** | Covariance between two indicators. |
 | `org.ta4j.core.indicators.statistics` | **CorrelationCoefficientIndicator** | Correlation between two series; supports sample/population variance normalization; unstable bars follow variance/covariance warm-up. |


### PR DESCRIPTION
Document the reusable Hurst exponent API and the modernized CHOP representation/compatibility constructors.

Companion to ta4j/ta4j#1585.

Validation:
- README synchronization is clean.
- The generated Jekyll site and internal link validation pass.